### PR TITLE
Fix duplicate block ids in Logseq export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ coverage.xml
 htmlcov/
 repomix-output.xml
 docs/index.html
+out/graph.json
+out/graph.md
 
 # =========================
 # IDEs & Tool Caches

--- a/src/logseq_matryca_parser/logos_core.py
+++ b/src/logseq_matryca_parser/logos_core.py
@@ -28,6 +28,8 @@ class LogseqNode(BaseModel):
     model_config = ConfigDict(strict=True, frozen=True)
 
     uuid: str
+    source_uuid: str | None = None
+    synthetic_id: bool = False
     content: str
     clean_text: str = ""
     indent_level: int
@@ -41,6 +43,10 @@ class LogseqNode(BaseModel):
     parent_id: str | None = None
     left_id: str | None = None
     path: list[str] = Field(default_factory=list)
+    source_path: str | None = None
+    line_start: int | None = None
+    line_end: int | None = None
+    outline_path: list[int] = Field(default_factory=list)
     properties_order: list[str] = Field(default_factory=list)
     created_at: int | None = None
     updated_at: int | None = None

--- a/src/logseq_matryca_parser/logos_parser.py
+++ b/src/logseq_matryca_parser/logos_parser.py
@@ -325,12 +325,12 @@ class StackMachineParser:
         in_code_block = False
         in_drawer = False
 
-        for raw_line in text.splitlines():
+        for line_number, raw_line in enumerate(text.splitlines(), start=1):
             stripped_line = raw_line.strip()
 
             if in_code_block and current_node is not None:
                 merged_content = f"{current_node.content}\n{raw_line}"
-                updated = self._refresh_node(current_node, merged_content)
+                updated = self._refresh_node(current_node, merged_content, line_end=line_number)
                 self._replace_stack_tail_node(stack, root_nodes, updated)
                 current_node = updated
                 if _is_code_fence_line(stripped_line):
@@ -372,6 +372,7 @@ class StackMachineParser:
                             current_node,
                             current_node.content,
                             properties_override=properties,
+                            line_end=line_number,
                         )
                         self._replace_stack_tail_node(stack, root_nodes, updated)
                         current_node = updated
@@ -381,7 +382,12 @@ class StackMachineParser:
                 in_drawer = True
                 properties = dict(current_node.properties)
                 properties.setdefault("logbook", [])
-                updated = self._refresh_node(current_node, current_node.content, properties_override=properties)
+                updated = self._refresh_node(
+                    current_node,
+                    current_node.content,
+                    properties_override=properties,
+                    line_end=line_number,
+                )
                 self._replace_stack_tail_node(stack, root_nodes, updated)
                 current_node = updated
                 continue
@@ -395,6 +401,7 @@ class StackMachineParser:
                     current_node,
                     current_node.content,
                     properties_override=properties,
+                    line_end=line_number,
                 )
                 self._replace_stack_tail_node(stack, root_nodes, updated)
                 current_node = updated
@@ -415,6 +422,7 @@ class StackMachineParser:
                     block_text=bullet_match.group(2),
                     indent_level=indent_level,
                     page_title=page_title,
+                    line_start=line_number,
                 )
                 raw_indent = bullet_match.group(1)
                 if (
@@ -455,6 +463,7 @@ class StackMachineParser:
                     block_text=heading_match.group(2),
                     indent_level=indent_level,
                     page_title=page_title,
+                    line_start=line_number,
                 )
                 raw_indent = heading_match.group(1)
 
@@ -500,9 +509,10 @@ class StackMachineParser:
                     current_node.content,
                     properties_override=properties,
                     properties_order_override=properties_order,
+                    line_end=line_number,
                 )
                 if key == "id":
-                    updated = updated.model_copy(update={"uuid": value})
+                    updated = updated.model_copy(update={"source_uuid": value})
                 self._replace_stack_tail_node(stack, root_nodes, updated)
                 current_node = updated
                 self.registry.register(updated)
@@ -519,7 +529,7 @@ class StackMachineParser:
                 continue
 
             merged_content = f"{current_node.content}\n{raw_line}"
-            updated = self._refresh_node(current_node, merged_content)
+            updated = self._refresh_node(current_node, merged_content, line_end=line_number)
             self._replace_stack_tail_node(stack, root_nodes, updated)
             current_node = updated
             frontmatter_active = False
@@ -572,12 +582,14 @@ class StackMachineParser:
             created_at = int(os.path.getctime(path))
         if updated_at is None:
             updated_at = int(os.path.getmtime(path))
+        source_path = str(path.resolve())
         return page.model_copy(
             update={
-                "source_path": str(path.resolve()),
+                "source_path": source_path,
                 "graph_root": str(graph_root),
                 "created_at": created_at,
                 "updated_at": updated_at,
+                "root_nodes": self._apply_source_path(page.root_nodes, source_path),
             }
         )
 
@@ -602,6 +614,17 @@ class StackMachineParser:
                 return parent.parent.resolve()
         return resolved_path.parent.resolve()
 
+    def _apply_source_path(self, nodes: list[LogseqNode], source_path: str) -> list[LogseqNode]:
+        return [
+            node.model_copy(
+                update={
+                    "source_path": source_path,
+                    "children": self._apply_source_path(node.children, source_path),
+                }
+            )
+            for node in nodes
+        ]
+
     def _compute_indent_level(self, indentation: str) -> int:
         spaces = indentation.count(" ") + (indentation.count("\t") * self.tab_size)
         logger.debug(
@@ -612,7 +635,13 @@ class StackMachineParser:
         )
         return spaces // self.tab_size
 
-    def _build_node(self, block_text: str, indent_level: int, page_title: str) -> LogseqNode:
+    def _build_node(
+        self,
+        block_text: str,
+        indent_level: int,
+        page_title: str,
+        line_start: int,
+    ) -> LogseqNode:
         stripped_text = block_text.strip()
         properties: dict[str, Any] = {}
 
@@ -622,13 +651,12 @@ class StackMachineParser:
             inline_uuid = inline_uuid_match.group(1)
             properties["id"] = inline_uuid
             stripped_text = LOGSEQ_PATTERNS["inline_uuid_prop"].sub("", stripped_text).strip()
-        node_uuid = (
+        source_uuid = (
             uuid_match.group(1)
             if uuid_match
             else (inline_uuid_match.group(1) if inline_uuid_match else None)
         )
-        if node_uuid is None:
-            node_uuid = self._deterministic_uuid(page_title, stripped_text)
+        node_uuid = self._deterministic_uuid(page_title, line_start, stripped_text)
         time_properties = _extract_time_properties(stripped_text)
         if time_properties:
             properties.update(time_properties)
@@ -645,6 +673,8 @@ class StackMachineParser:
 
         return LogseqNode(
             uuid=node_uuid,
+            source_uuid=source_uuid,
+            synthetic_id=True,
             content=stripped_text,
             clean_text=clean_node_content(stripped_text, properties),
             indent_level=indent_level,
@@ -657,13 +687,15 @@ class StackMachineParser:
             task_status=task_status,
             repeater=properties.get("repeater") if isinstance(properties.get("repeater"), str) else None,
             parent_id=None,
+            line_start=line_start,
+            line_end=line_start,
             created_at=_first_normalized_timestamp(properties, CREATED_AT_KEYS),
             updated_at=_first_normalized_timestamp(properties, UPDATED_AT_KEYS),
             children=[],
         )
 
-    def _deterministic_uuid(self, page_title: str, content: str) -> str:
-        payload = f"{page_title}:{content}".encode("utf-8")
+    def _deterministic_uuid(self, page_title: str, line_start: int, content: str) -> str:
+        payload = f"{page_title}:{line_start}:{content}".encode("utf-8")
         digest = hashlib.sha256(payload).hexdigest()
         return str(uuid.uuid5(uuid.NAMESPACE_DNS, digest))
 
@@ -729,9 +761,13 @@ class StackMachineParser:
         if stack:
             parent = stack[-1]
             path = [*parent.path, node.uuid]
+            outline_path = [*parent.outline_path, len(parent.children) + 1]
         else:
             path = [node.uuid]
-        return node.model_copy(update={"left_id": left_id, "path": path})
+            outline_path = [len(root_nodes) + 1]
+        return node.model_copy(
+            update={"left_id": left_id, "path": path, "outline_path": outline_path}
+        )
 
     def _resolve_left_sibling_id(
         self, stack: list[LogseqNode], root_nodes: list[LogseqNode]
@@ -765,6 +801,7 @@ class StackMachineParser:
         content: str,
         properties_override: dict[str, Any] | None = None,
         properties_order_override: list[str] | None = None,
+        line_end: int | None = None,
     ) -> LogseqNode:
         properties = dict(node.properties) if properties_override is None else dict(properties_override)
         properties_order = (
@@ -798,6 +835,7 @@ class StackMachineParser:
                 "tags": tags,
                 "refs": _merge_refs(wikilinks, tags),
                 "block_refs": [*_extract_block_refs(content), *property_block_refs],
+                "line_end": line_end if line_end is not None else node.line_end,
                 "created_at": _first_normalized_timestamp(properties, CREATED_AT_KEYS),
                 "updated_at": _first_normalized_timestamp(properties, UPDATED_AT_KEYS),
             }

--- a/tests/test_kinetic.py
+++ b/tests/test_kinetic.py
@@ -62,6 +62,31 @@ def test_export_command_json_writes_output_file(tmp_path: Path) -> None:
     assert payload[0]["ast"]
 
 
+def test_export_command_json_preserves_duplicate_block_identity(
+    tmp_path: Path,
+) -> None:
+    graph_root = tmp_path / "graph"
+    pages_dir = graph_root / "pages"
+    journals_dir = graph_root / "journals"
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    journals_dir.mkdir(parents=True, exist_ok=True)
+    (pages_dir / "identity.md").write_text("- repeated\n- repeated\n", encoding="utf-8")
+    output_dir = tmp_path / "out-json"
+
+    result = runner.invoke(app, ["export", str(graph_root), str(output_dir), "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads((output_dir / "graph.json").read_text(encoding="utf-8"))
+    ast = payload[0]["ast"]
+    first, second = ast
+    assert first["content"] == "repeated"
+    assert second["content"] == "repeated"
+    assert first["uuid"] != second["uuid"]
+    assert first["path"] == [first["uuid"]]
+    assert second["path"] == [second["uuid"]]
+    assert second["left_id"] == first["uuid"]
+
+
 def test_export_command_markdown_writes_output_file(tmp_path: Path) -> None:
     graph_root = _create_graph(tmp_path)
     output_dir = tmp_path / "out-markdown"

--- a/tests/test_kinetic.py
+++ b/tests/test_kinetic.py
@@ -87,6 +87,38 @@ def test_export_command_json_preserves_duplicate_block_identity(
     assert second["left_id"] == first["uuid"]
 
 
+def test_export_command_json_preserves_source_uuid_separately(
+    tmp_path: Path,
+) -> None:
+    graph_root = tmp_path / "graph"
+    pages_dir = graph_root / "pages"
+    journals_dir = graph_root / "journals"
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    journals_dir.mkdir(parents=True, exist_ok=True)
+    source_uuid = "11111111-1111-1111-1111-111111111111"
+    (pages_dir / "identity.md").write_text(
+        f"- Root\n  id:: {source_uuid}\n  - Child\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out-json"
+
+    result = runner.invoke(app, ["export", str(graph_root), str(output_dir), "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads((output_dir / "graph.json").read_text(encoding="utf-8"))
+    root = payload[0]["ast"][0]
+    child = root["children"][0]
+    assert root["uuid"] != source_uuid
+    assert root["source_uuid"] == source_uuid
+    assert root["synthetic_id"] is True
+    assert root["source_path"] == str((pages_dir / "identity.md").resolve())
+    assert root["line_start"] == 1
+    assert root["line_end"] == 2
+    assert root["outline_path"] == [1]
+    assert child["parent_id"] == root["uuid"]
+    assert child["path"] == [root["uuid"], child["uuid"]]
+
+
 def test_export_command_markdown_writes_output_file(tmp_path: Path) -> None:
     graph_root = _create_graph(tmp_path)
     output_dir = tmp_path / "out-markdown"

--- a/tests/test_logos_parser.py
+++ b/tests/test_logos_parser.py
@@ -86,7 +86,8 @@ def test_resolved_block_reference_does_not_raise(parser: StackMachineParser) -> 
 
     page = parser.parse(content, page_title="resolved-ref")
     assert len(page.root_nodes) == 1
-    assert page.root_nodes[0].uuid == existing_uuid
+    assert page.root_nodes[0].uuid != existing_uuid
+    assert page.root_nodes[0].source_uuid == existing_uuid
     assert page.root_nodes[0].children[0].block_refs == [existing_uuid]
 
 
@@ -426,10 +427,25 @@ def test_official_inline_uuid_property_binding(
     page = parser.parse(content, page_title="official-inline-id")
     root = page.root_nodes[0]
 
-    assert root.uuid == expected_uuid
+    assert root.uuid != expected_uuid
+    assert root.source_uuid == expected_uuid
+    assert root.synthetic_id is True
     assert root.properties["id"] == expected_uuid
     assert "id::" not in root.content
     assert "id::" not in root.clean_text
+
+
+def test_property_uuid_is_preserved_as_source_uuid(parser: StackMachineParser) -> None:
+    """Official id:: properties do not replace the parser identity."""
+    source_uuid = "11111111-1111-1111-1111-111111111111"
+    page = parser.parse(f"- Root\n  id:: {source_uuid}\n  - Child", page_title="property-id")
+    root = page.root_nodes[0]
+
+    assert root.uuid != source_uuid
+    assert root.source_uuid == source_uuid
+    assert root.properties["id"] == source_uuid
+    assert root.children[0].parent_id == root.uuid
+    assert root.children[0].path == [root.uuid, root.children[0].uuid]
 
 
 @pytest.mark.parametrize(
@@ -715,6 +731,10 @@ def test_duplicate_same_page_blocks_have_distinct_identities(
     assert first.content == "repeated"
     assert second.content == "repeated"
     assert first.uuid != second.uuid
+    assert first.line_start == 1
+    assert second.line_start == 2
+    assert first.outline_path == [1]
+    assert second.outline_path == [2]
     assert first.path == [first.uuid]
     assert second.path == [second.uuid]
     assert second.left_id == first.uuid
@@ -733,6 +753,8 @@ def test_duplicate_nested_blocks_have_position_distinct_identities(
     assert child_a.content == "repeated"
     assert child_b.content == "repeated"
     assert child_a.uuid != child_b.uuid
+    assert child_a.outline_path == [1, 1]
+    assert child_b.outline_path == [2, 1]
     assert child_a.parent_id == parent_a.uuid
     assert child_b.parent_id == parent_b.uuid
     assert child_a.path == [parent_a.uuid, child_a.uuid]

--- a/tests/test_logos_parser.py
+++ b/tests/test_logos_parser.py
@@ -704,6 +704,41 @@ def test_sibling_left_id_integrity(parser: StackMachineParser) -> None:
     assert child_c.left_id == child_b.uuid
 
 
+def test_duplicate_same_page_blocks_have_distinct_identities(
+    parser: StackMachineParser,
+) -> None:
+    """Repeated content on one page must not collapse to one parser identity."""
+    content = "- repeated\n- repeated"
+    page = parser.parse(content, page_title="identity-collision")
+    first, second = page.root_nodes
+
+    assert first.content == "repeated"
+    assert second.content == "repeated"
+    assert first.uuid != second.uuid
+    assert first.path == [first.uuid]
+    assert second.path == [second.uuid]
+    assert second.left_id == first.uuid
+
+
+def test_duplicate_nested_blocks_have_position_distinct_identities(
+    parser: StackMachineParser,
+) -> None:
+    """Identical children under different parents need independent identities."""
+    content = "- Parent A\n  - repeated\n- Parent B\n  - repeated"
+    page = parser.parse(content, page_title="nested-identity-collision")
+    parent_a, parent_b = page.root_nodes
+    child_a = parent_a.children[0]
+    child_b = parent_b.children[0]
+
+    assert child_a.content == "repeated"
+    assert child_b.content == "repeated"
+    assert child_a.uuid != child_b.uuid
+    assert child_a.parent_id == parent_a.uuid
+    assert child_b.parent_id == parent_b.uuid
+    assert child_a.path == [parent_a.uuid, child_a.uuid]
+    assert child_b.path == [parent_b.uuid, child_b.uuid]
+
+
 def test_leaf_path_resolution(parser: StackMachineParser) -> None:
     """Leaf path tracks UUID chain from root to current node."""
     content = "- Root\n  - Child\n    - Leaf"


### PR DESCRIPTION
Fixes the parser export identity issue where repeated blocks with the same text could get the same `uuid`.

Main changes:
- keep `uuid` as the parser/export block id
- preserve Logseq `id::` separately as `source_uuid`
- generate parser ids from source position instead of only page title + content
- add source/debug fields like `line_start`, `line_end`, `outline_path`, `source_path`
- add regression tests for duplicate same-content blocks and JSON export

Checked:
- `uv run pytest -v tests/`
- `uv run mypy src/ tests/ examples/`
- `uv run ruff check .`