### PR TITLE
test(kinetic): assert per-command --help renders without error

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,62 @@
+"""Dedicated tests for the parser exception hierarchy (issue #21).
+
+Verifies that all domain exceptions inherit from LogseqParserError and
+that each class can be instantiated with a message string.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from logseq_matryca_parser.exceptions import (
+    BlockReferenceError,
+    LogseqIndentationError,
+    LogseqParserError,
+)
+
+
+class TestExceptionHierarchy:
+    """Structural assertions on the exception class hierarchy."""
+
+    def test_block_reference_error_is_subclass_of_logseq_parser_error(self):
+        """BlockReferenceError must inherit from the base parser exception."""
+        assert issubclass(BlockReferenceError, LogseqParserError)
+
+    def test_logseq_indentation_error_is_subclass_of_logseq_parser_error(self):
+        """LogseqIndentationError must inherit from LogseqParserError.
+
+        Note: LogseqIndentationError is reserved for a future strict
+        indentation mode and is not raised by the parser today.
+        """
+        assert issubclass(LogseqIndentationError, LogseqParserError)
+
+    def test_base_exception_is_standard_exception(self):
+        """LogseqParserError itself inherits from built-in Exception."""
+        assert issubclass(LogseqParserError, Exception)
+
+
+class TestExceptionInstantiation:
+    """Behavioural assertions — can instantiate and use as exceptions."""
+
+    def test_block_reference_error_can_be_raised_and_caught(self):
+        with pytest.raises(BlockReferenceError, match="test error"):
+            raise BlockReferenceError("test error")
+
+    def test_block_reference_error_is_caught_by_base_class(self):
+        """Catching LogseqParserError also catches BlockReferenceError."""
+        with pytest.raises(LogseqParserError):
+            raise BlockReferenceError("caught by base")
+
+    def test_logseq_indentation_error_can_be_raised_and_caught(self):
+        """LogseqIndentationError accepts a message like other exceptions."""
+        with pytest.raises(LogseqIndentationError, match="indent"):
+            raise LogseqIndentationError("broken indent")
+
+    def test_logseq_indentation_error_is_caught_by_base_class(self):
+        """Catching LogseqParserError also catches LogseqIndentationError."""
+        with pytest.raises(LogseqParserError):
+            raise LogseqIndentationError("caught by base")
+
+    def test_base_exception_stores_message(self):
+        exc = LogseqParserError("base message")
+        assert str(exc) == "base message"

--- a/tests/test_extract_changelog.py
+++ b/tests/test_extract_changelog.py
@@ -1,0 +1,129 @@
+"""Unit tests for the extract_changelog release helper (scripts/extract_changelog.py).
+
+Covers normalize_version, extract_changelog_section, iter_changelog_versions,
+and error paths per issue #23.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the script as a module (it lives outside the package in scripts/).
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "extract_changelog.py"
+_spec = importlib.util.spec_from_file_location("extract_changelog", _SCRIPT)
+assert _spec is not None
+assert _spec.loader is not None
+_extract = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _extract
+_spec.loader.exec_module(_extract)
+
+normalize_version = _extract.normalize_version
+extract_changelog_section = _extract.extract_changelog_section
+iter_changelog_versions = _extract.iter_changelog_versions
+
+
+# ── minimal changelog fixture ────────────────────────────────────────────
+
+MINIMAL_CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+- Upcoming feature
+
+## [1.0.0] - 2026-01-15
+
+### Added
+- Initial release
+
+## [0.9.0] - 2025-12-01
+
+### Added
+- Beta feature
+"""
+
+
+class TestNormalizeVersion:
+    """Tests for ``normalize_version()`` tag/version cleaning."""
+
+    @pytest.mark.parametrize(
+        ("input_val", "expected"),
+        [
+            ("v1.0.0", "1.0.0"),
+            ("V1.0.0", "1.0.0"),
+            ("v2.3.4-beta", "2.3.4-beta"),
+            ("1.0.0", "1.0.0"),
+            ("  v1.0.0  ", "1.0.0"),   # whitespace stripped
+            ("Unreleased", "Unreleased"),
+            ("unreleased", "Unreleased"),
+            ("UNRELEASED", "Unreleased"),
+        ],
+    )
+    def test_normalize_version(self, input_val, expected):
+        assert normalize_version(input_val) == expected
+
+    def test_v_without_digit_not_stripped(self):
+        """Leading 'v' without a following digit is kept as-is."""
+        assert normalize_version("vintage") == "vintage"
+        assert normalize_version("V-2") == "V-2"
+
+
+class TestExtractChangelogSection:
+    """Tests for ``extract_changelog_section()`` block extraction."""
+
+    def test_extract_existing_version(self):
+        section = extract_changelog_section(MINIMAL_CHANGELOG, "1.0.0")
+        assert "## [1.0.0]" in section
+        assert "- Initial release" in section
+        assert section.endswith("\n")
+
+    def test_extract_with_v_prefix(self):
+        section = extract_changelog_section(MINIMAL_CHANGELOG, "v1.0.0")
+        assert "## [1.0.0]" in section
+
+    def test_extract_first_version_section(self):
+        """The 0.9.0 section should be the last entry and contain beta feature."""
+        section = extract_changelog_section(MINIMAL_CHANGELOG, "0.9.0")
+        assert "## [0.9.0]" in section
+        assert "- Beta feature" in section
+
+    def test_missing_version_raises_lookuperror(self):
+        with pytest.raises(LookupError, match="9.9.9"):
+            extract_changelog_section(MINIMAL_CHANGELOG, "9.9.9")
+
+    def test_missing_version_includes_hint_with_known_versions(self):
+        with pytest.raises(LookupError, match="Known versions"):
+            extract_changelog_section("# Changelog\n\n## [1.0.0]\n", "2.0.0")
+
+    def test_unreleased_with_allow_unreleased_true(self):
+        section = extract_changelog_section(
+            MINIMAL_CHANGELOG, "Unreleased", allow_unreleased=True
+        )
+        assert "## [Unreleased]" in section
+        assert "- Upcoming feature" in section
+
+    def test_unreleased_without_allow_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Refusing to extract"):
+            extract_changelog_section(MINIMAL_CHANGELOG, "Unreleased")
+
+    def test_section_stops_at_next_version_heading(self):
+        """Extracted section must not include subsequent version blocks."""
+        section = extract_changelog_section(MINIMAL_CHANGELOG, "1.0.0")
+        assert "## [1.0.0]" in section
+        assert "## [0.9.0]" not in section
+
+
+class TestIterChangelogVersions:
+    """Tests for ``iter_changelog_versions()`` version listing."""
+
+    def test_returns_versions_excluding_unreleased(self):
+        versions = iter_changelog_versions(MINIMAL_CHANGELOG)
+        assert versions == ["1.0.0", "0.9.0"]
+
+    def test_empty_changelog_returns_empty_list(self):
+        assert iter_changelog_versions("# Changelog\n\n") == []
+
+    def test_only_unreleased_returns_empty(self):
+        assert iter_changelog_versions("## [Unreleased]\n") == []

--- a/tests/test_kinetic.py
+++ b/tests/test_kinetic.py
@@ -65,6 +65,17 @@ def test_cli_help_uses_rich_markup_mode() -> None:
     assert "KINETIC" in result.output or "Logseq" in result.output
 
 
+@pytest.mark.parametrize(
+    "command",
+    ["scan", "export", "visualize", "agent-read", "agent-write", "append", "demo"],
+)
+def test_per_command_help_renders_without_error(command: str) -> None:
+    """``--help`` on every subcommand must exit 0 (issue #27)."""
+    result = runner.invoke(app, [command, "--help"])
+    assert result.exit_code == 0
+    assert result.output.strip()
+
+
 def test_verbose_flag_enables_debug_logging(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     graph_root = _create_graph(tmp_path)
     caplog.set_level(logging.DEBUG, logger="logseq_matryca_parser")

--- a/tests/test_logos_parser.py
+++ b/tests/test_logos_parser.py
@@ -13,6 +13,7 @@ from logseq_matryca_parser.logos_parser import (
     LogosParser,
     StackMachineParser,
     is_system_block,
+    normalize_logseq_timestamp,
     resolve_journal_day,
 )
 
@@ -1492,3 +1493,117 @@ def test_resolve_asset_path_decodes_percent_encoding(tmp_path: Path) -> None:
     page = LogosParser().parse_page_file(page_path)
 
     assert page.resolve_asset_path("../assets/my%20document.pdf") == str(asset_path.resolve())
+
+
+# ── normalize_logseq_timestamp edge-input tests ───────────────────────────
+
+
+class TestNormalizeLogseqTimestamp:
+    """Edge-case coverage for ``normalize_logseq_timestamp()`` timestamp parser."""
+
+    # -- happy path (issue #32) --------------------------------------------
+
+    def test_none_returns_none(self):
+        assert normalize_logseq_timestamp(None) is None
+
+    def test_boolean_returns_none(self):
+        assert normalize_logseq_timestamp(True) is None
+        assert normalize_logseq_timestamp(False) is None
+
+    def test_empty_string_returns_none(self):
+        assert normalize_logseq_timestamp("") is None
+        assert normalize_logseq_timestamp("   ") is None
+
+    def test_invalid_format_returns_none(self):
+        assert normalize_logseq_timestamp("not a timestamp") is None
+        assert normalize_logseq_timestamp("garbage") is None
+        assert normalize_logseq_timestamp("123abc") is None
+
+    # -- integer / float ---------------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (0, 0),
+            (1, 1),
+            (1714065600, 1714065600),  # already seconds
+            (1714065600000, 1714065600),  # milliseconds → seconds
+            (9999999999999, 9999999999),  # big ms → seconds
+            (10000000000000, 10000000000),  # >= 10**12 → divide by 1000
+        ],
+    )
+    def test_int_input(self, value, expected):
+        assert normalize_logseq_timestamp(value) == expected
+
+    def test_float_input(self):
+        assert normalize_logseq_timestamp(1714065600.0) == 1714065600
+        assert normalize_logseq_timestamp(1714065600000.0) == 1714065600
+
+    # -- digit-only strings ------------------------------------------------
+
+    def test_digit_string_seconds(self):
+        assert normalize_logseq_timestamp("1714065600") == 1714065600
+
+    def test_digit_string_milliseconds(self):
+        assert normalize_logseq_timestamp("1714065600000") == 1714065600
+
+    # -- ISO-8601 strings --------------------------------------------------
+
+    def test_iso8601_with_z(self):
+        ts = normalize_logseq_timestamp("2026-04-25T17:00:00Z")
+        expected = int(datetime(2026, 4, 25, 17, 0, 0, tzinfo=UTC).timestamp())
+        assert ts == expected
+
+    def test_iso8601_with_offset(self):
+        ts = normalize_logseq_timestamp("2026-04-25T17:00:00+00:00")
+        expected = int(datetime(2026, 4, 25, 17, 0, 0, tzinfo=UTC).timestamp())
+        assert ts == expected
+
+    def test_iso8601_naive_assumes_utc(self):
+        ts = normalize_logseq_timestamp("2026-04-25T17:00:00")
+        expected = int(datetime(2026, 4, 25, 17, 0, 0, tzinfo=UTC).timestamp())
+        assert ts == expected
+
+    # -- Logseq datetime formats -------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("value", "expected_dt"),
+        [
+            ("2026-04-25 Sat 10:00", datetime(2026, 4, 25, 10, 0, 0, tzinfo=UTC)),
+            ("2026-04-25 Sat", datetime(2026, 4, 25, 0, 0, 0, tzinfo=UTC)),
+            ("2026-04-25 10:00", datetime(2026, 4, 25, 10, 0, 0, tzinfo=UTC)),
+            ("2026-04-25", datetime(2026, 4, 25, 0, 0, 0, tzinfo=UTC)),
+        ],
+    )
+    def test_logseq_date_formats(self, value, expected_dt):
+        ts = normalize_logseq_timestamp(value)
+        assert ts == int(expected_dt.timestamp())
+
+    # -- date-only formats -------------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("value", "expected_dt"),
+        [
+            ("2026/04/25", datetime(2026, 4, 25, 0, 0, 0, tzinfo=UTC)),
+            # "20260425" is all-digits → treated as a unix timestamp, not a date
+            ("2024_04_25", datetime(2024, 4, 25, 0, 0, 0, tzinfo=UTC)),
+            ("Apr 25, 2026", datetime(2026, 4, 25, 0, 0, 0, tzinfo=UTC)),
+        ],
+    )
+    def test_date_only_formats(self, value, expected_dt):
+        ts = normalize_logseq_timestamp(value)
+        assert ts == int(expected_dt.timestamp())
+
+    # -- edge cases --------------------------------------------------------
+
+    def test_list_input_returns_none(self):
+        assert normalize_logseq_timestamp([1, 2, 3]) is None
+
+    def test_dict_input_returns_none(self):
+        assert normalize_logseq_timestamp({"key": "val"}) is None
+
+    def test_ordinal_suffix_stripping(self):
+        """Ordinal suffixes (1st, 2nd, 3rd, 4th) are stripped before parsing."""
+        ts = normalize_logseq_timestamp("Apr 25th, 2026")
+        expected = int(datetime(2026, 4, 25, 0, 0, 0, tzinfo=UTC).timestamp())
+        assert ts == expected

--- a/tests/test_logos_parser.py
+++ b/tests/test_logos_parser.py
@@ -12,6 +12,7 @@ from logseq_matryca_parser.exceptions import BlockReferenceError
 from logseq_matryca_parser.logos_parser import (
     LogosParser,
     StackMachineParser,
+    clean_node_content,
     is_system_block,
     normalize_logseq_timestamp,
     resolve_journal_day,
@@ -1607,3 +1608,116 @@ class TestNormalizeLogseqTimestamp:
         ts = normalize_logseq_timestamp("Apr 25th, 2026")
         expected = int(datetime(2026, 4, 25, 0, 0, 0, tzinfo=UTC).timestamp())
         assert ts == expected
+
+
+# ── clean_node_content table-driven tests ──────────────────────────────────
+
+
+class TestCleanNodeContent:
+    """Table-driven tests for ``clean_node_content()`` block text sanitizer."""
+
+    @pytest.mark.parametrize(
+        ("raw", "properties", "expected"),
+        [
+            # plain text passes through unchanged
+            ("just some text", {}, "just some text"),
+            ("hello world", {}, "hello world"),
+            # empty / whitespace
+            ("", {}, ""),
+            ("   ", {}, ""),
+            # task status extraction (first line only)
+            ("TODO Write parser", {}, "Write parser"),
+            ("DONE Finish docs", {}, "Finish docs"),
+            ("LATER revisit", {}, "revisit"),
+            ("NOW ship it", {}, "ship it"),
+            # task status with properties doesn't double-strip
+            ("TODO Write parser", {"id": "abc"}, "Write parser"),
+            # property key stripping (keys from properties dict — entire line dropped)
+            (
+                "id:: 67e3c1a0 content here",
+                {"id": "67e3c1a0"},
+                "",
+            ),
+            (
+                "title:: Hello World\nbody text",
+                {"title": "Hello World"},
+                "body text",
+            ),
+            # SCHEDULED/DEADLINE markers are removed by TIME_PATTERN
+            (
+                "TODO Plan launch SCHEDULED: <2026-04-30 Thu>\nDetails",
+                {},
+                "Plan launch\nDetails",
+            ),
+            (
+                "Finish draft DEADLINE: <2026-05-01 Fri>",
+                {},
+                "Finish draft",
+            ),
+            # inline id:: removal (double space collapsed to single)
+            (
+                "item one id:: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee item two",
+                {},
+                "item one item two",
+            ),
+            # aliased block ref (aliased → alias text, plain → empty)
+            (
+                "See [My Text](((aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee))) here",
+                {},
+                "See My Text here",
+            ),
+            (
+                "Ref ((aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)) gone",
+                {},
+                "Ref gone",
+            ),
+            # priority marker removal (first line)
+            (
+                "TODO [#A] Ship feature",
+                {},
+                "Ship feature",
+            ),
+            ("[#B] No status", {}, "No status"),
+            # code fence preservation
+            (
+                "text before\n```\nid:: abc\nSCHEDULED: <2026-01-01>\n```\ntext after",
+                {"id": "abc"},
+                "text before\n```\nid:: abc\nSCHEDULED: <2026-01-01>\n```\ntext after",
+            ),
+            # multiple property keys
+            (
+                "id:: abc\ntitle:: My Title\nreal content",
+                {"id": "abc", "title": "My Title"},
+                "real content",
+            ),
+            # bullet markers stripped
+            ("- bullet point", {}, "bullet point"),
+            ("  - indented bullet", {}, "indented bullet"),
+            # heading markers stripped
+            ("# Heading 1", {}, "Heading 1"),
+            ("## Heading 2", {}, "Heading 2"),
+            # bold marker stripping
+            ("**bold text **", {}, "bold text"),
+            # task markers with markdown checkboxes
+            ("[ ] Buy milk", {}, "Buy milk"),
+            ("[x] Done task", {}, "Done task"),
+            # space collapsing
+            ("double  space   here", {}, "double space here"),
+        ],
+    )
+    def test_clean_node_content(self, raw, properties, expected):
+        assert clean_node_content(raw, properties) == expected
+
+    def test_case_insensitive_property_keys(self):
+        """Property keys are matched case-insensitively."""
+        raw = "ID:: abc123\nTitle:: My Page\nvisible content"
+        props = {"id": "abc123", "title": "My Page"}
+        assert clean_node_content(raw, props) == "visible content"
+
+    def test_code_block_preserves_newlines(self):
+        raw = "before\n```python\nprint('hello')\nprint('world')\n```\nafter"
+        props = {}
+        result = clean_node_content(raw, props)
+        assert "```python" in result
+        assert "print('hello')" in result
+        assert "after" in result

--- a/tests/test_logseq_paths.py
+++ b/tests/test_logseq_paths.py
@@ -151,3 +151,50 @@ def test_discover_graph_files_skips_backup_and_recycle_dirs(tmp_path: Path) -> N
 
     assert len(discovered) == 1
     assert discovered[0].name == "Real.md"
+
+
+# ── edge-case coverage per issue #22 ─────────────────────────────────────
+
+
+def test_page_title_to_relative_path_empty_title_returns_untitled():
+    """Empty or whitespace-only title maps to untitled.md."""
+    assert page_title_to_relative_path("") == Path("untitled.md")
+    # Only truly empty (no segments after split) produces untitled;
+    # whitespace-only yields percent-encoded spaces (not untitled).
+    assert page_title_to_relative_path("/") == Path("untitled.md")
+
+
+def test_derive_graph_root_fallback_to_parent_when_no_pages_or_journals(tmp_path: Path):
+    """Files outside pages/ or journals/ resolve graph_root to path.parent."""
+    arbitrary = tmp_path / "some" / "nested" / "notes.md"
+    arbitrary.parent.mkdir(parents=True)
+    arbitrary.write_text("- note\n", encoding="utf-8")
+    root = derive_graph_root_from_source_path(arbitrary)
+    assert root == arbitrary.parent.resolve()
+
+
+def test_derive_page_title_outside_pages_uses_filename_to_page_title(tmp_path: Path):
+    """Files outside pages/ and journals/ use filename_to_page_title(stem)."""
+    file_path = tmp_path / "random" / "Notes___AI.md"
+    file_path.parent.mkdir(parents=True)
+    file_path.write_text("- content\n", encoding="utf-8")
+    title = derive_page_title_from_source_path(file_path)
+    assert title == "Notes/AI"
+
+
+def test_derive_page_title_outside_pages_simple_filename(tmp_path: Path):
+    """A simple file outside pages/journals uses its stem as title."""
+    file_path = tmp_path / "Simple.md"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("- content\n", encoding="utf-8")
+    title = derive_page_title_from_source_path(file_path)
+    assert title == "Simple"
+
+
+def test_derive_graph_root_fallback_with_deeply_nested_file(tmp_path: Path):
+    """Deeply nested files outside recognized markers resolve to parent dir."""
+    deep = tmp_path / "a" / "b" / "c" / "d" / "readme.md"
+    deep.parent.mkdir(parents=True)
+    deep.write_text("- deep\n", encoding="utf-8")
+    root = derive_graph_root_from_source_path(deep)
+    assert root == deep.parent.resolve()


### PR DESCRIPTION
## Issue
Closes #27

## Changes
Added parametrized test verifying all 7 subcommands accept --help without error:
- scan, export, visualize, agent-read, agent-write, append, demo

Follows existing CliRunner pattern in test_kinetic.py.

All tests pass. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)