### PR TITLE
docs: fix relative paths and add notice to historical design docs index

### DIFF
--- a/docs/design-docs/README.md
+++ b/docs/design-docs/README.md
@@ -1,11 +1,13 @@
+> ⚠️ **Notice:** For the active documentation index, please refer to the main [README.md](../../README.md).
+
 # Historical design documents
 
-> **For contributors:** These files are **Document-Driven Development** blueprints from the initial Logos Protocol scaffolding. They explain design intent and mldoc parity research — they are **not** the live implementation contract.
+For contributors: These files are Document-Driven Development blueprints from the initial Logos Protocol scaffolding. They explain design intent and mldoc parity research — they are not the live implementation contract.
 
 For current architecture and APIs, use:
 
-- [`../ARCHITECTURE.md`](../ARCHITECTURE.md) — active system design
-- [`../logseq_ast_primer.md`](../logseq_ast_primer.md) — Spatial Markdown domain rules
-- [`../README.md`](../README.md) — documentation index
+* [ARCHITECTURE.md](../ARCHITECTURE.md) — active system design
+* [logseq_ast_primer.md](../logseq_ast_primer.md) — Logseq Spatial Markdown domain rules
+* [README.md](../../README.md) — documentation index
 
-Each file in this folder includes the same historical banner at the top. When implementing parser behavior, prefer tests in `tests/test_logos_parser.py` and [`OFFICIAL_MLDOC_SPECS.md`](OFFICIAL_MLDOC_SPECS.md) as **reference**, then confirm against the running code in `src/logseq_matryca_parser/`.
+Each file in this folder includes the same historical banner at the top. When implementing parser behavior, prefer tests in tests/test_logos_parser.py and OFFICIAL_MLDOC_SPECS.md as reference, then confirm against the running code in src/logseq_matryca_parser/.


### PR DESCRIPTION
## Description
Fixes relative path breaking for the main documentation index from within the historical design docs subdirectory, and adds a prominent redirection notice at the top of the historical index file.

## Type of change
- [x] Documentation update

## Sovereign Developer Checklist
- [x] I have read `CONTRIBUTING.md` (or picked a task from `docs/GOOD_FIRST_ISSUES.md`).
- [x] I have updated the relevant documentation (`