### PR TITLE
test: add extract_changelog main() CLI tests and backlink alias token tests

### DIFF
--- a/tests/test_extract_changelog.py
+++ b/tests/test_extract_changelog.py
@@ -23,6 +23,7 @@ _spec.loader.exec_module(_extract)
 normalize_version = _extract.normalize_version
 extract_changelog_section = _extract.extract_changelog_section
 iter_changelog_versions = _extract.iter_changelog_versions
+main = _extract.main
 
 
 # ── minimal changelog fixture ────────────────────────────────────────────
@@ -127,3 +128,45 @@ class TestIterChangelogVersions:
 
     def test_only_unreleased_returns_empty(self):
         assert iter_changelog_versions("## [Unreleased]\n") == []
+
+
+# ── main() CLI exit codes and stdout (issue #47) ────────────────────────
+
+
+class TestMainCLI:
+    """Tests for ``main()`` CLI entry-point exit codes and stdout."""
+
+    def test_missing_version_exits_1(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n\n## [1.0.0]\n- item\n")
+        assert main(["9.9.9", "--changelog", str(changelog)]) == 1
+
+    def test_version_found_exits_0(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n\n## [1.0.0] - 2026-01-01\n- item\n")
+        assert main(["1.0.0", "--changelog", str(changelog)]) == 0
+
+    def test_v_prefix_accepted(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("## [2.0.0]\n- feature\n")
+        assert main(["v2.0.0", "--changelog", str(changelog)]) == 0
+
+    def test_unreleased_without_flag_exits_2(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("## [Unreleased]\n- wip\n")
+        assert main(["Unreleased", "--changelog", str(changelog)]) == 2
+
+    def test_unreleased_with_flag_exits_0(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("## [Unreleased]\n- wip\n")
+        assert main(["Unreleased", "--changelog", str(changelog), "--allow-unreleased"]) == 0
+
+    def test_missing_file_exits_1(self):
+        assert main(["1.0.0", "--changelog", "/nonexistent/CHANGELOG.md"]) == 1
+
+    def test_stdout_contains_section(self, tmp_path: Path, capsys):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("## [3.0.0]\n- stdout test\n")
+        main(["3.0.0", "--changelog", str(changelog)])
+        captured = capsys.readouterr()
+        assert "- stdout test" in captured.out

--- a/tests/test_forge.py
+++ b/tests/test_forge.py
@@ -12,6 +12,7 @@ from logseq_matryca_parser.forge import (
     _build_local_embed_index,
     _page_properties_to_yaml_frontmatter,
 )
+from logseq_matryca_parser.logos_core import ASTVisitor
 from logseq_matryca_parser.logos_core import LogseqNode
 
 
@@ -248,3 +249,54 @@ class TestObsidianForgeVisitorDirect:
         node.accept(visitor)
         output = visitor.get_markdown()
         assert "id::" not in output
+
+
+# ── direct MarkdownForgeVisitor tests (issue #46) ────────────────────────
+
+
+class TestMarkdownForgeVisitorDirect:
+    """Unit tests for MarkdownForgeVisitor (property filtering, id stripping)."""
+
+    def test_basic_markdown_output(self):
+        node = LogseqNode(uuid="n1", content="Hello", clean_text="Hello", indent_level=0)
+        visitor = MarkdownForgeVisitor()
+        node.accept(visitor)
+        assert visitor.get_markdown() == "- Hello"
+
+    def test_filters_id_property(self):
+        node = LogseqNode(
+            uuid="n2", content="Block", clean_text="Block", indent_level=0,
+            properties={"id": "abc-123", "status": "WIP"},
+            properties_order=["id", "status"],
+        )
+        visitor = MarkdownForgeVisitor()
+        node.accept(visitor)
+        output = visitor.get_markdown()
+        assert "id" not in output
+        assert "[:status WIP]" in output
+
+    def test_nested_indentation(self, sample_ast):
+        visitor = MarkdownForgeVisitor()
+        for node in sample_ast:
+            node.accept(visitor)
+        output = visitor.get_markdown()
+        assert "- Radice" in output
+        assert "  - Figlio" in output
+
+    def test_only_id_property_produces_no_annotations(self):
+        node = LogseqNode(
+            uuid="n3", content="X", clean_text="X", indent_level=0,
+            properties={"id": "only-id"},
+            properties_order=["id"],
+        )
+        visitor = MarkdownForgeVisitor()
+        node.accept(visitor)
+        assert visitor.get_markdown() == "- X"
+
+    def test_multiline_clean_text_flattened(self):
+        node = LogseqNode(
+            uuid="n4", content="A\nB\nC", clean_text="A\nB\nC", indent_level=0,
+        )
+        visitor = MarkdownForgeVisitor()
+        node.accept(visitor)
+        assert "\n" not in visitor.get_markdown().split("- ", 1)[1]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from logseq_matryca_parser.exceptions import BlockReferenceError
-from logseq_matryca_parser.graph import GraphQuery, LogseqGraph
+from logseq_matryca_parser.graph import GraphQuery, LogseqGraph, _normalize_relative_link_target
 
 
 def test_load_directory_empty_graph(tmp_path: Path) -> None:
@@ -663,3 +663,39 @@ def test_load_directory_strict_refs_validates_cross_page(tmp_path: Path) -> None
     )
     with pytest.raises(BlockReferenceError):
         LogseqGraph.load_directory(graph_root, strict_refs=True)
+
+
+# ── _normalize_relative_link_target tests (issue #45) ────────────────────
+
+
+class TestNormalizeRelativeLinkTarget:
+    """Unit tests for ``_normalize_relative_link_target()`` path resolver."""
+
+    def test_no_relative_prefix_returns_unchanged(self):
+        assert _normalize_relative_link_target("A/B", "C") == "C"
+        assert _normalize_relative_link_target("A", "B/C") == "B/C"
+
+    def test_dot_slash_current_dir(self):
+        assert _normalize_relative_link_target("A/B/C", "./D") == "A/B/D"
+        assert _normalize_relative_link_target("A", "./B") == "B"
+
+    def test_dot_slash_only_returns_current(self):
+        assert _normalize_relative_link_target("A/B/C", "./") == "A/B/C"
+        assert _normalize_relative_link_target("Page", "./") == "Page"
+
+    def test_dot_dot_parent(self):
+        assert _normalize_relative_link_target("A/B/C", "../D") == "A/B/D"
+        assert _normalize_relative_link_target("A/B/C", "../../E") == "A/E"
+
+    def test_dot_dot_beyond_root(self):
+        assert _normalize_relative_link_target("A", "../../B") == "B"
+        assert _normalize_relative_link_target("Page", "../Other") == "Other"
+
+    def test_lone_dot_and_double_dot(self):
+        assert _normalize_relative_link_target("A/B", ".") == "A/B"
+        assert _normalize_relative_link_target("A/B/C", "..") == "A/B"
+
+    def test_mixed_segments(self):
+        # ./ strips from current and prepends; ../.. goes up two levels
+        assert _normalize_relative_link_target("X/Y/Z", "../a/./b") == "X/Y/a/b"
+        assert _normalize_relative_link_target("A/B/C", "../../D/E") == "A/D/E"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import pytest
 
 from logseq_matryca_parser.exceptions import BlockReferenceError
-from logseq_matryca_parser.graph import GraphQuery, LogseqGraph, _normalize_relative_link_target
+from logseq_matryca_parser.graph import (
+    GraphQuery,
+    LogseqGraph,
+    _normalize_backlink_key,
+    _normalize_page_aliases,
+    _normalize_relative_link_target,
+)
 
 
 def test_load_directory_empty_graph(tmp_path: Path) -> None:
@@ -699,3 +705,36 @@ class TestNormalizeRelativeLinkTarget:
         # ./ strips from current and prepends; ../.. goes up two levels
         assert _normalize_relative_link_target("X/Y/Z", "../a/./b") == "X/Y/a/b"
         assert _normalize_relative_link_target("A/B/C", "../../D/E") == "A/D/E"
+
+
+# ── backlink alias token helpers (issue #50) ────────────────────────────
+
+
+class TestBacklinkAliasHelpers:
+    """Unit tests for backlink registry token normalisation."""
+
+    def test_normalize_backlink_key_lowercases(self):
+        assert _normalize_backlink_key("MyPage") == "mypage"
+        assert _normalize_backlink_key("  Spaced  ") == "spaced"
+
+    def test_normalize_backlink_key_uuid_passthrough(self):
+        uid = "64c752b0-d33b-4448-a261-e4dc2bbe12d3"
+        assert _normalize_backlink_key(uid) == uid
+
+    def test_normalize_backlink_key_empty(self):
+        assert _normalize_backlink_key("") == ""
+        assert _normalize_backlink_key("   ") == ""
+
+    def test_normalize_page_aliases_string_comma_split(self):
+        result = _normalize_page_aliases("Alpha, Beta, Gamma")
+        assert result == ["Alpha", "Beta", "Gamma"]
+
+    def test_normalize_page_aliases_list_input(self):
+        result = _normalize_page_aliases(["[[Page One]]", "#Tag", "plain"])
+        assert "Page One" in result
+        assert "Tag" in result
+        assert "plain" in result
+
+    def test_normalize_page_aliases_empty(self):
+        assert _normalize_page_aliases(None) == []
+        assert _normalize_page_aliases(42) == []

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -9,7 +9,7 @@ import pytest
 
 from logseq_matryca_parser.graph import LogseqGraph
 from logseq_matryca_parser.logos_core import LogseqNode
-from logseq_matryca_parser.synapse import SynapseAdapter
+from logseq_matryca_parser.synapse import SynapseAdapter, _strip_markdown_for_embedding
 
 
 class FakeDocument:
@@ -345,3 +345,34 @@ def test_expand_missing_block_embed_completes_without_hang(tmp_path: Path) -> No
     expanded = _expand_macros_and_embeds(text, graph, set())
 
     assert "{{embed" not in expanded
+
+
+# ── _strip_markdown_for_embedding tests (issue #44) ─────────────────────
+
+
+class TestStripMarkdownForEmbedding:
+    """Table-driven tests for ``_strip_markdown_for_embedding()`` cleaner."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("plain text", "plain text"),
+            ("[[Simple Link]]", "Simple Link"),
+            ("[[Page|Alias]]", "Page"),
+            ("**bold text**", "bold text"),
+            ("*italic text*", "italic text"),
+            ("`code span`", "code span"),
+            ("text with #tag removed", "text with removed"),
+            ("**bold** and *italic* and `code`", "bold and italic and code"),
+            ("  extra spaces  ", "extra spaces"),
+            ("", ""),
+        ],
+    )
+    def test_strip_markdown(self, text, expected):
+        assert _strip_markdown_for_embedding(text) == expected
+
+    def test_combined_formatting(self):
+        result = _strip_markdown_for_embedding(
+            "See **[[Project Page]]** for `details` #todo"
+        )
+        assert result == "See Project Page for details"


### PR DESCRIPTION
Closes #47, Closes #50

### #47 - extract_changelog main() CLI (7 tests)
Exit codes and stdout for missing/found version, v-prefix, Unreleased, missing file

### #50 - backlink alias token helpers (6 tests)
_normalize_backlink_key, _normalize_page_aliases coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)