### PR TITLE
test: add coverage for agent_writer format_timestamp, lens classify, synapse metadata, forge JSON visitor

### DIFF
--- a/tests/test_agent_writer.py
+++ b/tests/test_agent_writer.py
@@ -135,3 +135,29 @@ def test_append_child_to_node_respects_four_space_tab_size(tmp_path: Path) -> No
 
     updated = page_path.read_text(encoding="utf-8")
     assert "    - Appended with four spaces" in updated
+
+
+# ── LogseqConfigReader / format_timestamp (issue #48) ──────────────────
+
+
+def test_format_timestamp_produces_logseq_journal_format(tmp_path: Path):
+    config = tmp_path / "config.edn"
+    config.write_text(':journal/page-title-format "yyyy_MM_dd"')
+    reader = LogseqConfigReader(str(config))
+    ts = reader.format_timestamp(datetime(2026, 5, 10))
+    assert ts == "2026_05_10"
+
+
+def test_format_timestamp_with_ordinal_day(tmp_path: Path):
+    config = tmp_path / "config.edn"
+    config.write_text(':journal/page-title-format "MMM do, yyyy"')
+    reader = LogseqConfigReader(str(config))
+    ts = reader.format_timestamp(datetime(2026, 5, 1))
+    assert "1st" in ts or "May" in ts
+
+
+def test_config_reader_loads_format(tmp_path: Path):
+    config = tmp_path / "config.edn"
+    config.write_text(':journal/page-title-format "yyyy-MM-dd"')
+    reader = LogseqConfigReader(str(config))
+    assert reader.load_journal_format() == "yyyy-MM-dd"

--- a/tests/test_extract_changelog.py
+++ b/tests/test_extract_changelog.py
@@ -23,6 +23,7 @@ _spec.loader.exec_module(_extract)
 normalize_version = _extract.normalize_version
 extract_changelog_section = _extract.extract_changelog_section
 iter_changelog_versions = _extract.iter_changelog_versions
+main = _extract.main
 
 
 # ── minimal changelog fixture ────────────────────────────────────────────
@@ -127,3 +128,45 @@ class TestIterChangelogVersions:
 
     def test_only_unreleased_returns_empty(self):
         assert iter_changelog_versions("## [Unreleased]\n") == []
+
+
+# ── main() CLI exit codes and stdout (issue #47) ────────────────────────
+
+
+class TestMainCLI:
+    """Tests for ``main()`` CLI entry-point exit codes and stdout."""
+
+    def test_missing_version_exits_1(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n\n## [1.0.0]\n- item\n")
+        assert main(["9.9.9", "--changelog", str(changelog)]) == 1
+
+    def test_version_found_exits_0(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n\n## [1.0.0] - 2026-01-01\n- item\n")
+        assert main(["1.0.0", "--changelog", str(changelog)]) == 0
+
+    def test_v_prefix_accepted(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("## [2.0.0]\n- feature\n")
+        assert main(["v2.0.0", "--changelog", str(changelog)]) == 0
+
+    def test_unreleased_without_flag_exits_2(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("## [Unreleased]\n- wip\n")
+        assert main(["Unreleased", "--changelog", str(changelog)]) == 2
+
+    def test_unreleased_with_flag_exits_0(self, tmp_path: Path):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("## [Unreleased]\n- wip\n")
+        assert main(["Unreleased", "--changelog", str(changelog), "--allow-unreleased"]) == 0
+
+    def test_missing_file_exits_1(self):
+        assert main(["1.0.0", "--changelog", "/nonexistent/CHANGELOG.md"]) == 1
+
+    def test_stdout_contains_section(self, tmp_path: Path, capsys):
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("## [3.0.0]\n- stdout test\n")
+        main(["3.0.0", "--changelog", str(changelog)])
+        captured = capsys.readouterr()
+        assert "- stdout test" in captured.out

--- a/tests/test_forge.py
+++ b/tests/test_forge.py
@@ -12,6 +12,7 @@ from logseq_matryca_parser.forge import (
     _build_local_embed_index,
     _page_properties_to_yaml_frontmatter,
 )
+from logseq_matryca_parser.logos_core import ASTVisitor
 from logseq_matryca_parser.logos_core import LogseqNode
 
 
@@ -248,3 +249,54 @@ class TestObsidianForgeVisitorDirect:
         node.accept(visitor)
         output = visitor.get_markdown()
         assert "id::" not in output
+
+
+# ── direct MarkdownForgeVisitor tests (issue #46) ────────────────────────
+
+
+class TestMarkdownForgeVisitorDirect:
+    """Unit tests for MarkdownForgeVisitor (property filtering, id stripping)."""
+
+    def test_basic_markdown_output(self):
+        node = LogseqNode(uuid="n1", content="Hello", clean_text="Hello", indent_level=0)
+        visitor = MarkdownForgeVisitor()
+        node.accept(visitor)
+        assert visitor.get_markdown() == "- Hello"
+
+    def test_filters_id_property(self):
+        node = LogseqNode(
+            uuid="n2", content="Block", clean_text="Block", indent_level=0,
+            properties={"id": "abc-123", "status": "WIP"},
+            properties_order=["id", "status"],
+        )
+        visitor = MarkdownForgeVisitor()
+        node.accept(visitor)
+        output = visitor.get_markdown()
+        assert "id" not in output
+        assert "[:status WIP]" in output
+
+    def test_nested_indentation(self, sample_ast):
+        visitor = MarkdownForgeVisitor()
+        for node in sample_ast:
+            node.accept(visitor)
+        output = visitor.get_markdown()
+        assert "- Radice" in output
+        assert "  - Figlio" in output
+
+    def test_only_id_property_produces_no_annotations(self):
+        node = LogseqNode(
+            uuid="n3", content="X", clean_text="X", indent_level=0,
+            properties={"id": "only-id"},
+            properties_order=["id"],
+        )
+        visitor = MarkdownForgeVisitor()
+        node.accept(visitor)
+        assert visitor.get_markdown() == "- X"
+
+    def test_multiline_clean_text_flattened(self):
+        node = LogseqNode(
+            uuid="n4", content="A\nB\nC", clean_text="A\nB\nC", indent_level=0,
+        )
+        visitor = MarkdownForgeVisitor()
+        node.accept(visitor)
+        assert "\n" not in visitor.get_markdown().split("- ", 1)[1]

--- a/tests/test_forge.py
+++ b/tests/test_forge.py
@@ -300,3 +300,44 @@ class TestMarkdownForgeVisitorDirect:
         visitor = MarkdownForgeVisitor()
         node.accept(visitor)
         assert "\n" not in visitor.get_markdown().split("- ", 1)[1]
+
+
+# ── direct JSONForgeVisitor nested stack tests (issue #52) ──────────────
+
+
+class TestJSONForgeVisitorNestedStack:
+    """Tests for JSONForgeVisitor nested hierarchy preservation."""
+
+    def test_single_root_node(self):
+        root = LogseqNode(uuid="r", content="Root", indent_level=0)
+        visitor = JSONForgeVisitor()
+        root.accept(visitor)
+        data = visitor.get_data()
+        assert len(data) == 1
+        assert data[0]["uuid"] == "r"
+
+    def test_nested_children_stack(self):
+        child = LogseqNode(uuid="c", content="Child", indent_level=1, parent_id="p")
+        parent = LogseqNode(uuid="p", content="Parent", indent_level=0, children=[child])
+        visitor = JSONForgeVisitor()
+        parent.accept(visitor)
+        data = visitor.get_data()
+        assert len(data[0]["children"]) == 1
+        assert data[0]["children"][0]["uuid"] == "c"
+
+    def test_deeply_nested_stack(self):
+        leaf = LogseqNode(uuid="l", content="Leaf", indent_level=2, parent_id="m")
+        mid = LogseqNode(uuid="m", content="Mid", indent_level=1, parent_id="r", children=[leaf])
+        root = LogseqNode(uuid="r", content="Root", indent_level=0, children=[mid])
+        visitor = JSONForgeVisitor()
+        root.accept(visitor)
+        data = visitor.get_data()
+        assert data[0]["children"][0]["children"][0]["uuid"] == "l"
+
+    def test_excludes_children_key_from_payload(self):
+        node = LogseqNode(uuid="n", content="X", indent_level=0)
+        visitor = JSONForgeVisitor()
+        node.accept(visitor)
+        data = visitor.get_data()
+        assert "children" in data[0]
+        assert data[0]["children"] == []

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from logseq_matryca_parser.exceptions import BlockReferenceError
-from logseq_matryca_parser.graph import GraphQuery, LogseqGraph
+from logseq_matryca_parser.graph import GraphQuery, LogseqGraph, _normalize_relative_link_target
 
 
 def test_load_directory_empty_graph(tmp_path: Path) -> None:
@@ -663,3 +663,39 @@ def test_load_directory_strict_refs_validates_cross_page(tmp_path: Path) -> None
     )
     with pytest.raises(BlockReferenceError):
         LogseqGraph.load_directory(graph_root, strict_refs=True)
+
+
+# ── _normalize_relative_link_target tests (issue #45) ────────────────────
+
+
+class TestNormalizeRelativeLinkTarget:
+    """Unit tests for ``_normalize_relative_link_target()`` path resolver."""
+
+    def test_no_relative_prefix_returns_unchanged(self):
+        assert _normalize_relative_link_target("A/B", "C") == "C"
+        assert _normalize_relative_link_target("A", "B/C") == "B/C"
+
+    def test_dot_slash_current_dir(self):
+        assert _normalize_relative_link_target("A/B/C", "./D") == "A/B/D"
+        assert _normalize_relative_link_target("A", "./B") == "B"
+
+    def test_dot_slash_only_returns_current(self):
+        assert _normalize_relative_link_target("A/B/C", "./") == "A/B/C"
+        assert _normalize_relative_link_target("Page", "./") == "Page"
+
+    def test_dot_dot_parent(self):
+        assert _normalize_relative_link_target("A/B/C", "../D") == "A/B/D"
+        assert _normalize_relative_link_target("A/B/C", "../../E") == "A/E"
+
+    def test_dot_dot_beyond_root(self):
+        assert _normalize_relative_link_target("A", "../../B") == "B"
+        assert _normalize_relative_link_target("Page", "../Other") == "Other"
+
+    def test_lone_dot_and_double_dot(self):
+        assert _normalize_relative_link_target("A/B", ".") == "A/B"
+        assert _normalize_relative_link_target("A/B/C", "..") == "A/B"
+
+    def test_mixed_segments(self):
+        # ./ strips from current and prepends; ../.. goes up two levels
+        assert _normalize_relative_link_target("X/Y/Z", "../a/./b") == "X/Y/a/b"
+        assert _normalize_relative_link_target("A/B/C", "../../D/E") == "A/D/E"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import pytest
 
 from logseq_matryca_parser.exceptions import BlockReferenceError
-from logseq_matryca_parser.graph import GraphQuery, LogseqGraph, _normalize_relative_link_target
+from logseq_matryca_parser.graph import (
+    GraphQuery,
+    LogseqGraph,
+    _normalize_backlink_key,
+    _normalize_page_aliases,
+    _normalize_relative_link_target,
+)
 
 
 def test_load_directory_empty_graph(tmp_path: Path) -> None:
@@ -699,3 +705,36 @@ class TestNormalizeRelativeLinkTarget:
         # ./ strips from current and prepends; ../.. goes up two levels
         assert _normalize_relative_link_target("X/Y/Z", "../a/./b") == "X/Y/a/b"
         assert _normalize_relative_link_target("A/B/C", "../../D/E") == "A/D/E"
+
+
+# ── backlink alias token helpers (issue #50) ────────────────────────────
+
+
+class TestBacklinkAliasHelpers:
+    """Unit tests for backlink registry token normalisation."""
+
+    def test_normalize_backlink_key_lowercases(self):
+        assert _normalize_backlink_key("MyPage") == "mypage"
+        assert _normalize_backlink_key("  Spaced  ") == "spaced"
+
+    def test_normalize_backlink_key_uuid_passthrough(self):
+        uid = "64c752b0-d33b-4448-a261-e4dc2bbe12d3"
+        assert _normalize_backlink_key(uid) == uid
+
+    def test_normalize_backlink_key_empty(self):
+        assert _normalize_backlink_key("") == ""
+        assert _normalize_backlink_key("   ") == ""
+
+    def test_normalize_page_aliases_string_comma_split(self):
+        result = _normalize_page_aliases("Alpha, Beta, Gamma")
+        assert result == ["Alpha", "Beta", "Gamma"]
+
+    def test_normalize_page_aliases_list_input(self):
+        result = _normalize_page_aliases(["[[Page One]]", "#Tag", "plain"])
+        assert "Page One" in result
+        assert "Tag" in result
+        assert "plain" in result
+
+    def test_normalize_page_aliases_empty(self):
+        assert _normalize_page_aliases(None) == []
+        assert _normalize_page_aliases(42) == []

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -86,3 +86,33 @@ def test_export_html_calls_save_graph_with_mocked_pyvis(tmp_path: Path) -> None:
     save_graph_mock.assert_called_once_with(str(destination))
     body = destination.read_text(encoding="utf-8")
     assert 'style="display: none !important;"' in body
+
+
+# ── classify_node / journal detection (issue #49) ──────────────────────
+
+
+class TestClassifyNode:
+    """Tests for node classification and journal detection."""
+
+    def test_looks_like_journal_underscore_format(self):
+        assert GraphVisualizer._looks_like_journal("2026_05_23") is True
+
+    def test_looks_like_journal_hyphen_format(self):
+        assert GraphVisualizer._looks_like_journal("2026-05-23") is True
+
+    def test_looks_like_journal_bracketed_format(self):
+        assert GraphVisualizer._looks_like_journal("[[May 23rd, 2026]]") is True
+
+    def test_looks_like_journal_plain_text_false(self):
+        assert GraphVisualizer._looks_like_journal("MyPage") is False
+        assert GraphVisualizer._looks_like_journal("ProjectAlpha") is False
+
+    def test_classify_node_group_journal(self):
+        assert GraphVisualizer._classify_node_group("2026_05_23", None) == "journal"
+        assert GraphVisualizer._classify_node_group("2026-05-23", None) == "journal"
+
+    def test_classify_node_group_project(self):
+        assert GraphVisualizer._classify_node_group("Progetti___AI", None) == "project"
+
+    def test_classify_node_group_page(self):
+        assert GraphVisualizer._classify_node_group("NormalPage", None) == "page"

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -9,7 +9,7 @@ import pytest
 
 from logseq_matryca_parser.graph import LogseqGraph
 from logseq_matryca_parser.logos_core import LogseqNode
-from logseq_matryca_parser.synapse import SynapseAdapter
+from logseq_matryca_parser.synapse import SynapseAdapter, _strip_markdown_for_embedding
 
 
 class FakeDocument:
@@ -345,3 +345,34 @@ def test_expand_missing_block_embed_completes_without_hang(tmp_path: Path) -> No
     expanded = _expand_macros_and_embeds(text, graph, set())
 
     assert "{{embed" not in expanded
+
+
+# ── _strip_markdown_for_embedding tests (issue #44) ─────────────────────
+
+
+class TestStripMarkdownForEmbedding:
+    """Table-driven tests for ``_strip_markdown_for_embedding()`` cleaner."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("plain text", "plain text"),
+            ("[[Simple Link]]", "Simple Link"),
+            ("[[Page|Alias]]", "Page"),
+            ("**bold text**", "bold text"),
+            ("*italic text*", "italic text"),
+            ("`code span`", "code span"),
+            ("text with #tag removed", "text with removed"),
+            ("**bold** and *italic* and `code`", "bold and italic and code"),
+            ("  extra spaces  ", "extra spaces"),
+            ("", ""),
+        ],
+    )
+    def test_strip_markdown(self, text, expected):
+        assert _strip_markdown_for_embedding(text) == expected
+
+    def test_combined_formatting(self):
+        result = _strip_markdown_for_embedding(
+            "See **[[Project Page]]** for `details` #todo"
+        )
+        assert result == "See Project Page for details"

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -9,7 +9,7 @@ import pytest
 
 from logseq_matryca_parser.graph import LogseqGraph
 from logseq_matryca_parser.logos_core import LogseqNode
-from logseq_matryca_parser.synapse import SynapseAdapter, _strip_markdown_for_embedding
+from logseq_matryca_parser.synapse import SynapseAdapter, _strip_markdown_for_embedding, build_synapse_metadata
 
 
 class FakeDocument:
@@ -376,3 +376,35 @@ class TestStripMarkdownForEmbedding:
             "See **[[Project Page]]** for `details` #todo"
         )
         assert result == "See Project Page for details"
+
+
+# ── build_synapse_metadata schema (issue #51) ──────────────────────────
+
+
+class TestBuildSynapseMetadata:
+    """Direct schema tests for ``build_synapse_metadata()`` output."""
+
+    def test_includes_core_keys(self):
+        node = LogseqNode(uuid="abc", content="Test", indent_level=0)
+        meta = build_synapse_metadata(node, source="test")
+        for key in ("uuid", "indent_level", "source", "path", "refs",
+                     "task_status", "task_priority"):
+            assert key in meta
+
+    def test_property_serialization(self):
+        node = LogseqNode(uuid="x", content="T", indent_level=1,
+                          properties={"tags": "ai", "status": "done"})
+        meta = build_synapse_metadata(node, source="s")
+        assert meta["tags"] == "ai"
+        assert meta["status"] == "done"
+
+    def test_extra_kwarg_merged(self):
+        node = LogseqNode(uuid="y", content="T2", indent_level=0)
+        meta = build_synapse_metadata(node, source="s", extra={"custom": 42})
+        assert meta["custom"] == 42
+
+    def test_nullable_fields_are_none(self):
+        node = LogseqNode(uuid="n", content="X", indent_level=0)
+        meta = build_synapse_metadata(node, source="s")
+        assert meta["parent_id"] is None
+        assert meta["scheduled_at"] is None


### PR DESCRIPTION
Closes #48, Closes #49, Closes #51, Closes #52

### #48 - LogseqConfigReader / format_timestamp
### #49 - _looks_like_journal / _classify_node_group
### #51 - build_synapse_metadata schema
### #52 - JSONForgeVisitor nested stack

18 tests, all passing. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)