### PR TITLE
chore(synapse): unify import error messages for missing AI dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **logseq-matryca-parser** (The Logos Protocol) are docume
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+### Changed
 
 ## [1.6.0] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **logseq-matryca-parser** (The Logos Protocol) are docume
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Changed
+## [Unreleased]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **logseq-matryca-parser** (The Logos Protocol) are docume
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+### Changed
 
 ### Fixed
 

--- a/claude-skill-logseq-read/examples/demo_logseq_journal.md
+++ b/claude-skill-logseq-read/examples/demo_logseq_journal.md
@@ -1,0 +1,13 @@
+- Public Funding Consulting Session - April 2026 #[[Work]] #[[FundedTraining]]
+  id:: 6628ec8c-5544-486a-8d77-62860c239851
+	- Met with [[Alpha Corp]] for the new #Fondimpresa regional call.
+		- Goal: Define the training plan for 50 employees in the #AI-Optimization sector.
+		- Next Steps:
+			- DONE Collect tax declarations (DURC) from the client.
+			- TODO Draft the budget for the #FSE+ technical assistance.
+	- Lunch with [[Marco Porcellato]] to discuss the integration of #Matryca in the consulting workflow.
+		- Key takeaway: The [[Logos Protocol]] will automate the extraction of learning gaps from Logseq graphs.
+	- Reviewed the compliance audit for the "Industry 5.0" grant.
+	  id:: 6628ed02-1234-4a5b-9c8d-72860c999abc
+		- Findings: The #SmartFactory module needs more evidence of energy saving.
+		- TODO Action: Contact the technical engineer at [[Omega Systems]].

--- a/claude-skill-logseq-read/examples/run_demo.py
+++ b/claude-skill-logseq-read/examples/run_demo.py
@@ -1,0 +1,62 @@
+"""
+Logos Protocol — live demo script.
+
+Parses ``examples/demo_logseq_journal.md`` and prints FORGE clean Markdown.
+
+Run from the repository root after syncing dependencies::
+
+    uv sync --all-extras
+    uv run python examples/run_demo.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+
+from logseq_matryca_parser.forge import ForgeExporter
+from logseq_matryca_parser.logos_parser import LogosParser
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+EXAMPLE_FILE = ROOT_DIR / "examples" / "demo_logseq_journal.md"
+
+
+def run_demo() -> None:
+    console = Console()
+    console.print(Panel("[bold gold1]🔱 Logos Protocol - Live Extraction Demo[/]", expand=False))
+    console.print(f"[cyan]Reading file:[/] {EXAMPLE_FILE.name}...")
+
+    parser = LogosParser()
+    try:
+        ast_nodes = parser.parse_file(EXAMPLE_FILE)
+    except ImportError as exc:
+        console.print(
+            "[bold red]Missing dependencies.[/] Run: [bold]uv sync --all-extras[/]"
+        )
+        raise SystemExit(1) from exc
+    except OSError as exc:
+        console.print(f"[bold red]Error reading file:[/] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(f"[green]✅ AST extracted:[/] {len(ast_nodes)} root nodes.\n")
+    console.print("[bold]Forge output (clean Markdown for AI):[/]")
+    console.print("=" * 40)
+    console.print(ForgeExporter.to_clean_markdown(ast_nodes))
+    console.print("=" * 40)
+    console.print(
+        "\n[bold green]Success:[/] Hierarchy preserved — ready for RAG ingestion."
+    )
+
+
+if __name__ == "__main__":
+    try:
+        run_demo()
+    except ImportError as exc:
+        print(
+            f"Error: install dependencies first (uv sync --all-extras). {exc}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc

--- a/src/logseq_matryca_parser/synapse.py
+++ b/src/logseq_matryca_parser/synapse.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 _PATH_JOIN = " > "
 _REFS_JOIN = ", "
 
+_MISSING_AI_EXPORT_DEPS_MSG = (
+    "Missing AI export dependencies. Please install them using: uv sync --extra ai"
+)
+
 
 class SynapseMetadata(TypedDict, total=False):
     """Vector-store-safe metadata schema for LangChain / LlamaIndex exports."""
@@ -292,9 +296,9 @@ class SynapseAdapter:
     def to_langchain_documents(nodes: list[LogseqNode], source_name: str) -> list[Any]:
         """Convert AST nodes to LangChain documents using `LangChainVisitor`."""
         if Document is None:
-            raise ImportError(
-                "Missing AI export dependencies. Install with: uv sync --extra ai"
-            )
+
+            raise ImportError(_MISSING_AI_EXPORT_DEPS_MSG)
+
         visitor = LangChainVisitor(
             source_name=source_name, document_cls=Document)
         for node in nodes:
@@ -310,9 +314,9 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Convert AST nodes to LlamaIndex nodes preserving topology links."""
         if TextNode is None or NodeRelationship is None or RelatedNodeInfo is None:
-            raise ImportError(
-                "Missing AI export dependencies. Install with: uv sync --extra ai"
-            )
+
+            raise ImportError(_MISSING_AI_EXPORT_DEPS_MSG)
+
         flat = _flatten_nodes_for_export(nodes)
         unique_paths = {node.source_path for node in flat if node.source_path}
         use_per_node_source = len(unique_paths) > 1
@@ -351,9 +355,7 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Flatten ``nodes`` and emit LangChain ``Document``s with breadcrumb-enriched ``page_content``."""
         if Document is None:
-            raise ImportError(
-                "Missing AI export dependencies. Install with: uv sync --extra ai"
-            )
+            raise ImportError(_MISSING_AI_EXPORT_DEPS_MSG)
         documents: list[Any] = []
         flat = _flatten_nodes_for_export(nodes)
         for node in flat:

--- a/src/logseq_matryca_parser/synapse.py
+++ b/src/logseq_matryca_parser/synapse.py
@@ -44,6 +44,7 @@ class SynapseMetadata(TypedDict, total=False):
     line_start: NotRequired[int | None]
     effective_properties: NotRequired[dict[str, Any]]
 
+
 Document: type[Any] | None
 NodeRelationship: Any
 RelatedNodeInfo: type[Any] | None
@@ -237,7 +238,8 @@ class LlamaIndexVisitor(ASTVisitor):
         text_node = self._text_node_cls(
             id_=node.uuid,
             text=node.clean_text,
-            metadata=build_synapse_metadata(node, source=node.source_path or ""),
+            metadata=build_synapse_metadata(
+                node, source=node.source_path or ""),
         )
         if not hasattr(text_node, "relationships") or text_node.relationships is None:
             text_node.relationships = {}
@@ -259,7 +261,8 @@ class LlamaIndexVisitor(ASTVisitor):
                 child_relationships = parent_node.relationships.get(
                     self._node_relationship.CHILD, []
                 )
-                child_relationships.append(self._related_node_info_cls(node_id=node.uuid))
+                child_relationships.append(
+                    self._related_node_info_cls(node_id=node.uuid))
                 parent_node.relationships[self._node_relationship.CHILD] = child_relationships
 
         if node.left_id:
@@ -289,8 +292,11 @@ class SynapseAdapter:
     def to_langchain_documents(nodes: list[LogseqNode], source_name: str) -> list[Any]:
         """Convert AST nodes to LangChain documents using `LangChainVisitor`."""
         if Document is None:
-            raise ImportError("LangChain non rilevato. Installa 'langchain-core' per usare Synapse.")
-        visitor = LangChainVisitor(source_name=source_name, document_cls=Document)
+            raise ImportError(
+                "Missing AI export dependencies. Install with: uv sync --extra ai"
+            )
+        visitor = LangChainVisitor(
+            source_name=source_name, document_cls=Document)
         for node in nodes:
             node.accept(visitor)
         return visitor.get_documents()
@@ -304,7 +310,9 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Convert AST nodes to LlamaIndex nodes preserving topology links."""
         if TextNode is None or NodeRelationship is None or RelatedNodeInfo is None:
-            raise ImportError("LlamaIndex non rilevato. Installa 'llama-index' per usare Synapse.")
+            raise ImportError(
+                "Missing AI export dependencies. Install with: uv sync --extra ai"
+            )
         flat = _flatten_nodes_for_export(nodes)
         unique_paths = {node.source_path for node in flat if node.source_path}
         use_per_node_source = len(unique_paths) > 1
@@ -313,8 +321,10 @@ class SynapseAdapter:
         def _source_id_for_node(node: LogseqNode) -> str:
             path_key = node.source_path or ""
             if path_key not in source_ids_by_path:
-                title_seed = page_title or (Path(path_key).stem if path_key else "untitled")
-                source_ids_by_path[path_key] = page_source_node_id(title_seed, path_key or None)
+                title_seed = page_title or (
+                    Path(path_key).stem if path_key else "untitled")
+                source_ids_by_path[path_key] = page_source_node_id(
+                    title_seed, path_key or None)
             return source_ids_by_path[path_key]
 
         resolved_source_id = page_source_id
@@ -341,7 +351,9 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Flatten ``nodes`` and emit LangChain ``Document``s with breadcrumb-enriched ``page_content``."""
         if Document is None:
-            raise ImportError("LangChain non rilevato. Installa 'langchain-core' per usare Synapse.")
+            raise ImportError(
+                "Missing AI export dependencies. Install with: uv sync --extra ai"
+            )
         documents: list[Any] = []
         flat = _flatten_nodes_for_export(nodes)
         for node in flat:
@@ -349,10 +361,12 @@ class SynapseAdapter:
                 logger.debug("context chunk skip orphan uuid=%s", node.uuid)
                 continue
             breadcrumbs, page = _build_breadcrumbs(graph, node)
-            source_name = Path(node.source_path).name if node.source_path else str(graph.graph_path.name)
+            source_name = Path(node.source_path).name if node.source_path else str(
+                graph.graph_path.name)
             host_page = graph.page_for_node(node)
             embed_chain = (
-                frozenset({host_page.title}) if host_page is not None else frozenset()
+                frozenset({host_page.title}
+                          ) if host_page is not None else frozenset()
             )
             expanded_content = _expand_macros_and_embeds(
                 node.content, graph, set(), embed_page_chain=embed_chain
@@ -376,7 +390,8 @@ class SynapseAdapter:
                     "effective_properties": effective_properties,
                 },
             )
-            documents.append(Document(page_content=page_content, metadata=metadata))
+            documents.append(
+                Document(page_content=page_content, metadata=metadata))
             logger.debug(
                 "context chunk uuid=%s breadcrumbs_len=%s effective_keys=%s",
                 node.uuid,

--- a/src/logseq_matryca_parser/synapse.py
+++ b/src/logseq_matryca_parser/synapse.py
@@ -44,6 +44,7 @@ class SynapseMetadata(TypedDict, total=False):
     line_start: NotRequired[int | None]
     effective_properties: NotRequired[dict[str, Any]]
 
+
 Document: type[Any] | None
 NodeRelationship: Any
 RelatedNodeInfo: type[Any] | None
@@ -237,7 +238,8 @@ class LlamaIndexVisitor(ASTVisitor):
         text_node = self._text_node_cls(
             id_=node.uuid,
             text=node.clean_text,
-            metadata=build_synapse_metadata(node, source=node.source_path or ""),
+            metadata=build_synapse_metadata(
+                node, source=node.source_path or ""),
         )
         if not hasattr(text_node, "relationships") or text_node.relationships is None:
             text_node.relationships = {}
@@ -259,7 +261,8 @@ class LlamaIndexVisitor(ASTVisitor):
                 child_relationships = parent_node.relationships.get(
                     self._node_relationship.CHILD, []
                 )
-                child_relationships.append(self._related_node_info_cls(node_id=node.uuid))
+                child_relationships.append(
+                    self._related_node_info_cls(node_id=node.uuid))
                 parent_node.relationships[self._node_relationship.CHILD] = child_relationships
 
         if node.left_id:
@@ -289,8 +292,16 @@ class SynapseAdapter:
     def to_langchain_documents(nodes: list[LogseqNode], source_name: str) -> list[Any]:
         """Convert AST nodes to LangChain documents using `LangChainVisitor`."""
         if Document is None:
+<<<<<<< HEAD
             raise ImportError("LangChain was not detected. Install 'langchain-core' to use Synapse.")
         visitor = LangChainVisitor(source_name=source_name, document_cls=Document)
+=======
+            raise ImportError(
+                "Missing AI export dependencies. Install with: uv sync --extra ai"
+            )
+        visitor = LangChainVisitor(
+            source_name=source_name, document_cls=Document)
+>>>>>>> efda638 (chore(synapse): replace dependency ImportErrors with unified AI export message)
         for node in nodes:
             node.accept(visitor)
         return visitor.get_documents()
@@ -304,7 +315,13 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Convert AST nodes to LlamaIndex nodes preserving topology links."""
         if TextNode is None or NodeRelationship is None or RelatedNodeInfo is None:
+<<<<<<< HEAD
             raise ImportError("LlamaIndex was not detected. Install 'llama-index' to use Synapse.")
+=======
+            raise ImportError(
+                "Missing AI export dependencies. Install with: uv sync --extra ai"
+            )
+>>>>>>> efda638 (chore(synapse): replace dependency ImportErrors with unified AI export message)
         flat = _flatten_nodes_for_export(nodes)
         unique_paths = {node.source_path for node in flat if node.source_path}
         use_per_node_source = len(unique_paths) > 1
@@ -313,8 +330,10 @@ class SynapseAdapter:
         def _source_id_for_node(node: LogseqNode) -> str:
             path_key = node.source_path or ""
             if path_key not in source_ids_by_path:
-                title_seed = page_title or (Path(path_key).stem if path_key else "untitled")
-                source_ids_by_path[path_key] = page_source_node_id(title_seed, path_key or None)
+                title_seed = page_title or (
+                    Path(path_key).stem if path_key else "untitled")
+                source_ids_by_path[path_key] = page_source_node_id(
+                    title_seed, path_key or None)
             return source_ids_by_path[path_key]
 
         resolved_source_id = page_source_id
@@ -341,7 +360,13 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Flatten ``nodes`` and emit LangChain ``Document``s with breadcrumb-enriched ``page_content``."""
         if Document is None:
+<<<<<<< HEAD
             raise ImportError("LangChain was not detected. Install 'langchain-core' to use Synapse.")
+=======
+            raise ImportError(
+                "Missing AI export dependencies. Install with: uv sync --extra ai"
+            )
+>>>>>>> efda638 (chore(synapse): replace dependency ImportErrors with unified AI export message)
         documents: list[Any] = []
         flat = _flatten_nodes_for_export(nodes)
         for node in flat:
@@ -349,10 +374,12 @@ class SynapseAdapter:
                 logger.debug("context chunk skip orphan uuid=%s", node.uuid)
                 continue
             breadcrumbs, page = _build_breadcrumbs(graph, node)
-            source_name = Path(node.source_path).name if node.source_path else str(graph.graph_path.name)
+            source_name = Path(node.source_path).name if node.source_path else str(
+                graph.graph_path.name)
             host_page = graph.page_for_node(node)
             embed_chain = (
-                frozenset({host_page.title}) if host_page is not None else frozenset()
+                frozenset({host_page.title}
+                          ) if host_page is not None else frozenset()
             )
             expanded_content = _expand_macros_and_embeds(
                 node.content, graph, set(), embed_page_chain=embed_chain
@@ -376,7 +403,8 @@ class SynapseAdapter:
                     "effective_properties": effective_properties,
                 },
             )
-            documents.append(Document(page_content=page_content, metadata=metadata))
+            documents.append(
+                Document(page_content=page_content, metadata=metadata))
             logger.debug(
                 "context chunk uuid=%s breadcrumbs_len=%s effective_keys=%s",
                 node.uuid,

--- a/src/logseq_matryca_parser/synapse.py
+++ b/src/logseq_matryca_parser/synapse.py
@@ -292,16 +292,10 @@ class SynapseAdapter:
     def to_langchain_documents(nodes: list[LogseqNode], source_name: str) -> list[Any]:
         """Convert AST nodes to LangChain documents using `LangChainVisitor`."""
         if Document is None:
-<<<<<<< HEAD
-            raise ImportError("LangChain was not detected. Install 'langchain-core' to use Synapse.")
-        visitor = LangChainVisitor(source_name=source_name, document_cls=Document)
-=======
             raise ImportError(
                 "Missing AI export dependencies. Install with: uv sync --extra ai"
             )
-        visitor = LangChainVisitor(
-            source_name=source_name, document_cls=Document)
->>>>>>> efda638 (chore(synapse): replace dependency ImportErrors with unified AI export message)
+        visitor = LangChainVisitor(source_name=source_name, document_cls=Document)
         for node in nodes:
             node.accept(visitor)
         return visitor.get_documents()
@@ -315,13 +309,9 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Convert AST nodes to LlamaIndex nodes preserving topology links."""
         if TextNode is None or NodeRelationship is None or RelatedNodeInfo is None:
-<<<<<<< HEAD
-            raise ImportError("LlamaIndex was not detected. Install 'llama-index' to use Synapse.")
-=======
             raise ImportError(
                 "Missing AI export dependencies. Install with: uv sync --extra ai"
             )
->>>>>>> efda638 (chore(synapse): replace dependency ImportErrors with unified AI export message)
         flat = _flatten_nodes_for_export(nodes)
         unique_paths = {node.source_path for node in flat if node.source_path}
         use_per_node_source = len(unique_paths) > 1
@@ -360,13 +350,9 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Flatten ``nodes`` and emit LangChain ``Document``s with breadcrumb-enriched ``page_content``."""
         if Document is None:
-<<<<<<< HEAD
-            raise ImportError("LangChain was not detected. Install 'langchain-core' to use Synapse.")
-=======
             raise ImportError(
                 "Missing AI export dependencies. Install with: uv sync --extra ai"
             )
->>>>>>> efda638 (chore(synapse): replace dependency ImportErrors with unified AI export message)
         documents: list[Any] = []
         flat = _flatten_nodes_for_export(nodes)
         for node in flat:

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -70,13 +70,15 @@ def build_ast() -> list[LogseqNode]:
 
 def test_to_langchain_documents_raises_when_dependency_missing() -> None:
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match="LangChain"):
-            SynapseAdapter.to_langchain_documents(build_ast(), source_name="test.md")
+        with pytest.raises(ImportError, match="Missing AI export dependencies"):
+            SynapseAdapter.to_langchain_documents(
+                build_ast(), source_name="test.md")
 
 
 def test_to_langchain_documents_uses_visitor_and_graph_metadata() -> None:
     with patch("logseq_matryca_parser.synapse.Document", FakeDocument):
-        docs = SynapseAdapter.to_langchain_documents(build_ast(), source_name="graph.md")
+        docs = SynapseAdapter.to_langchain_documents(
+            build_ast(), source_name="graph.md")
 
     assert len(docs) == 2
     root_doc = docs[0]
@@ -106,7 +108,7 @@ def test_to_llamaindex_nodes_raises_when_dependency_missing() -> None:
         patch("logseq_matryca_parser.synapse.NodeRelationship", None),
         patch("logseq_matryca_parser.synapse.RelatedNodeInfo", None),
     ):
-        with pytest.raises(ImportError, match="LlamaIndex"):
+        with pytest.raises(ImportError, match="Missing AI export dependencies"):
             SynapseAdapter.to_llamaindex_nodes(build_ast())
 
 
@@ -173,7 +175,8 @@ def test_to_llamaindex_nodes_assigns_distinct_source_per_page() -> None:
     ):
         nodes = SynapseAdapter.to_llamaindex_nodes([root_a, root_b])
 
-    source_ids = {nodes[0].relationships["SOURCE"].node_id, nodes[1].relationships["SOURCE"].node_id}
+    source_ids = {nodes[0].relationships["SOURCE"].node_id,
+                  nodes[1].relationships["SOURCE"].node_id}
     assert len(source_ids) == 2
 
 
@@ -212,7 +215,8 @@ def test_to_llamaindex_nodes_wires_sibling_next_and_previous() -> None:
         patch("logseq_matryca_parser.synapse.NodeRelationship", fake_relationship),
         patch("logseq_matryca_parser.synapse.RelatedNodeInfo", FakeRelatedNodeInfo),
     ):
-        nodes = SynapseAdapter.to_llamaindex_nodes([root], page_source_id="page-doc")
+        nodes = SynapseAdapter.to_llamaindex_nodes(
+            [root], page_source_id="page-doc")
 
     by_id = {node.id_: node for node in nodes}
     assert by_id["sibling-b"].relationships["PREVIOUS"].node_id == "sibling-a"
@@ -221,7 +225,7 @@ def test_to_llamaindex_nodes_wires_sibling_next_and_previous() -> None:
 
 def test_to_context_enriched_chunks_raises_when_dependency_missing(tmp_path: Path) -> None:
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match="LangChain"):
+        with pytest.raises(ImportError, match="Missing AI export dependencies"):
             graph = LogseqGraph(graph_path=tmp_path, pages={})
             SynapseAdapter.to_context_enriched_chunks([], graph)
 
@@ -243,7 +247,8 @@ def test_synapse_context_enriched_chunking(tmp_path: Path) -> None:
     demo = graph.pages["Demo"]
 
     with patch("logseq_matryca_parser.synapse.Document", FakeDocument):
-        chunks = SynapseAdapter.to_context_enriched_chunks(demo.root_nodes, graph)
+        chunks = SynapseAdapter.to_context_enriched_chunks(
+            demo.root_nodes, graph)
 
     assert len(chunks) == 2
     child_chunk = chunks[1]
@@ -277,8 +282,10 @@ def test_synapse_recursive_embed_expansion(tmp_path: Path) -> None:
         "- Before {{embed ((" + block_id + "))}} after\n",
         encoding="utf-8",
     )
-    (pages / "SnippetPage.md").write_text("- Line one from snippet\n- Line two from snippet\n", encoding="utf-8")
-    (pages / "PageEmbedHost.md").write_text("- Start {{embed [[SnippetPage]]}} end\n", encoding="utf-8")
+    (pages / "SnippetPage.md").write_text(
+        "- Line one from snippet\n- Line two from snippet\n", encoding="utf-8")
+    (pages / "PageEmbedHost.md").write_text(
+        "- Start {{embed [[SnippetPage]]}} end\n", encoding="utf-8")
 
     graph = LogseqGraph.load_directory(graph_root)
 
@@ -309,7 +316,8 @@ def test_expand_embed_missing_page_completes_without_hang(tmp_path: Path) -> Non
     graph_root = tmp_path / "vault"
     pages = graph_root / "pages"
     pages.mkdir(parents=True)
-    (pages / "P.md").write_text("- x {{embed [[NoSuchPage]]}}\n", encoding="utf-8")
+    (pages /
+     "P.md").write_text("- x {{embed [[NoSuchPage]]}}\n", encoding="utf-8")
     graph = LogseqGraph.load_directory(graph_root)
     text = graph.pages["P"].root_nodes[0].content
 
@@ -342,14 +350,16 @@ def test_expand_cyclic_page_embed_does_not_duplicate_parent_text(tmp_path: Path)
     graph_root = tmp_path / "vault"
     pages = graph_root / "pages"
     pages.mkdir(parents=True)
-    (pages / "A.md").write_text("- before {{embed [[B]]}} after\n", encoding="utf-8")
+    (pages /
+     "A.md").write_text("- before {{embed [[B]]}} after\n", encoding="utf-8")
     (pages / "B.md").write_text("- inner {{embed [[A]]}}\n", encoding="utf-8")
     graph = LogseqGraph.load_directory(graph_root)
     host_page = graph.pages["A"]
     text = host_page.root_nodes[0].content
     chain = frozenset({host_page.title})
 
-    expanded = _expand_macros_and_embeds(text, graph, set(), embed_page_chain=chain)
+    expanded = _expand_macros_and_embeds(
+        text, graph, set(), embed_page_chain=chain)
 
     assert expanded.strip() == "before inner after"
 
@@ -361,7 +371,8 @@ def test_expand_missing_block_embed_completes_without_hang(tmp_path: Path) -> No
     pages = graph_root / "pages"
     pages.mkdir(parents=True)
     missing = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-    (pages / "P.md").write_text(f"- {{{{embed (({missing}))}}}}\n", encoding="utf-8")
+    (pages /
+     "P.md").write_text(f"- {{{{embed (({missing}))}}}}\n", encoding="utf-8")
     graph = LogseqGraph.load_directory(graph_root)
     text = graph.pages["P"].root_nodes[0].content
 
@@ -411,7 +422,7 @@ class TestBuildSynapseMetadata:
         node = LogseqNode(uuid="abc", content="Test", indent_level=0)
         meta = build_synapse_metadata(node, source="test")
         for key in ("uuid", "indent_level", "source", "path", "refs",
-                     "task_status", "task_priority"):
+                    "task_status", "task_priority"):
             assert key in meta
 
     def test_property_serialization(self):

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+import re
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -71,7 +72,7 @@ def build_ast() -> list[LogseqNode]:
 
 def test_to_langchain_documents_raises_when_dependency_missing() -> None:
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match=_MISSING_AI_EXPORT_DEPS_MSG):
+        with pytest.raises(ImportError, match=re.escape(_MISSING_AI_EXPORT_DEPS_MSG)):
             SynapseAdapter.to_langchain_documents(
                 build_ast(), source_name="test.md")
 
@@ -109,7 +110,7 @@ def test_to_llamaindex_nodes_raises_when_dependency_missing() -> None:
         patch("logseq_matryca_parser.synapse.NodeRelationship", None),
         patch("logseq_matryca_parser.synapse.RelatedNodeInfo", None),
     ):
-        with pytest.raises(ImportError, match=_MISSING_AI_EXPORT_DEPS_MSG):
+        with pytest.raises(ImportError, match=re.escape(_MISSING_AI_EXPORT_DEPS_MSG)):
             SynapseAdapter.to_llamaindex_nodes(build_ast())
 
 
@@ -226,7 +227,7 @@ def test_to_llamaindex_nodes_wires_sibling_next_and_previous() -> None:
 
 def test_to_context_enriched_chunks_raises_when_dependency_missing(tmp_path: Path) -> None:
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match=_MISSING_AI_EXPORT_DEPS_MSG):
+        with pytest.raises(ImportError, match=re.escape(_MISSING_AI_EXPORT_DEPS_MSG)):
             graph = LogseqGraph(graph_path=tmp_path, pages={})
             SynapseAdapter.to_context_enriched_chunks([], graph)
 

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -11,6 +11,7 @@ from logseq_matryca_parser.graph import LogseqGraph
 from logseq_matryca_parser.logos_core import LogseqNode
 from logseq_matryca_parser.synapse import (
     SynapseAdapter,
+    _MISSING_AI_EXPORT_DEPS_MSG,
     _strip_markdown_for_embedding,
     build_synapse_metadata,
 )
@@ -70,7 +71,7 @@ def build_ast() -> list[LogseqNode]:
 
 def test_to_langchain_documents_raises_when_dependency_missing() -> None:
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match="Missing AI export dependencies"):
+        with pytest.raises(ImportError, match=_MISSING_AI_EXPORT_DEPS_MSG):
             SynapseAdapter.to_langchain_documents(
                 build_ast(), source_name="test.md")
 
@@ -108,7 +109,7 @@ def test_to_llamaindex_nodes_raises_when_dependency_missing() -> None:
         patch("logseq_matryca_parser.synapse.NodeRelationship", None),
         patch("logseq_matryca_parser.synapse.RelatedNodeInfo", None),
     ):
-        with pytest.raises(ImportError, match="Missing AI export dependencies"):
+        with pytest.raises(ImportError, match=_MISSING_AI_EXPORT_DEPS_MSG):
             SynapseAdapter.to_llamaindex_nodes(build_ast())
 
 
@@ -225,7 +226,7 @@ def test_to_llamaindex_nodes_wires_sibling_next_and_previous() -> None:
 
 def test_to_context_enriched_chunks_raises_when_dependency_missing(tmp_path: Path) -> None:
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match="Missing AI export dependencies"):
+        with pytest.raises(ImportError, match=_MISSING_AI_EXPORT_DEPS_MSG):
             graph = LogseqGraph(graph_path=tmp_path, pages={})
             SynapseAdapter.to_context_enriched_chunks([], graph)
 

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -70,13 +70,15 @@ def build_ast() -> list[LogseqNode]:
 
 def test_to_langchain_documents_raises_when_dependency_missing() -> None:
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match="LangChain"):
-            SynapseAdapter.to_langchain_documents(build_ast(), source_name="test.md")
+        with pytest.raises(ImportError, match="Missing AI export dependencies"):
+            SynapseAdapter.to_langchain_documents(
+                build_ast(), source_name="test.md")
 
 
 def test_to_langchain_documents_uses_visitor_and_graph_metadata() -> None:
     with patch("logseq_matryca_parser.synapse.Document", FakeDocument):
-        docs = SynapseAdapter.to_langchain_documents(build_ast(), source_name="graph.md")
+        docs = SynapseAdapter.to_langchain_documents(
+            build_ast(), source_name="graph.md")
 
     assert len(docs) == 2
     root_doc = docs[0]
@@ -106,7 +108,7 @@ def test_to_llamaindex_nodes_raises_when_dependency_missing() -> None:
         patch("logseq_matryca_parser.synapse.NodeRelationship", None),
         patch("logseq_matryca_parser.synapse.RelatedNodeInfo", None),
     ):
-        with pytest.raises(ImportError, match="LlamaIndex"):
+        with pytest.raises(ImportError, match="Missing AI export dependencies"):
             SynapseAdapter.to_llamaindex_nodes(build_ast())
 
 
@@ -173,7 +175,8 @@ def test_to_llamaindex_nodes_assigns_distinct_source_per_page() -> None:
     ):
         nodes = SynapseAdapter.to_llamaindex_nodes([root_a, root_b])
 
-    source_ids = {nodes[0].relationships["SOURCE"].node_id, nodes[1].relationships["SOURCE"].node_id}
+    source_ids = {nodes[0].relationships["SOURCE"].node_id,
+                  nodes[1].relationships["SOURCE"].node_id}
     assert len(source_ids) == 2
 
 
@@ -212,7 +215,8 @@ def test_to_llamaindex_nodes_wires_sibling_next_and_previous() -> None:
         patch("logseq_matryca_parser.synapse.NodeRelationship", fake_relationship),
         patch("logseq_matryca_parser.synapse.RelatedNodeInfo", FakeRelatedNodeInfo),
     ):
-        nodes = SynapseAdapter.to_llamaindex_nodes([root], page_source_id="page-doc")
+        nodes = SynapseAdapter.to_llamaindex_nodes(
+            [root], page_source_id="page-doc")
 
     by_id = {node.id_: node for node in nodes}
     assert by_id["sibling-b"].relationships["PREVIOUS"].node_id == "sibling-a"
@@ -221,7 +225,7 @@ def test_to_llamaindex_nodes_wires_sibling_next_and_previous() -> None:
 
 def test_to_context_enriched_chunks_raises_when_dependency_missing(tmp_path: Path) -> None:
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match="LangChain"):
+        with pytest.raises(ImportError, match="Missing AI export dependencies"):
             graph = LogseqGraph(graph_path=tmp_path, pages={})
             SynapseAdapter.to_context_enriched_chunks([], graph)
 
@@ -243,7 +247,8 @@ def test_synapse_context_enriched_chunking(tmp_path: Path) -> None:
     demo = graph.pages["Demo"]
 
     with patch("logseq_matryca_parser.synapse.Document", FakeDocument):
-        chunks = SynapseAdapter.to_context_enriched_chunks(demo.root_nodes, graph)
+        chunks = SynapseAdapter.to_context_enriched_chunks(
+            demo.root_nodes, graph)
 
     assert len(chunks) == 2
     child_chunk = chunks[1]
@@ -277,8 +282,10 @@ def test_synapse_recursive_embed_expansion(tmp_path: Path) -> None:
         "- Before {{embed ((" + block_id + "))}} after\n",
         encoding="utf-8",
     )
-    (pages / "SnippetPage.md").write_text("- Line one from snippet\n- Line two from snippet\n", encoding="utf-8")
-    (pages / "PageEmbedHost.md").write_text("- Start {{embed [[SnippetPage]]}} end\n", encoding="utf-8")
+    (pages / "SnippetPage.md").write_text(
+        "- Line one from snippet\n- Line two from snippet\n", encoding="utf-8")
+    (pages / "PageEmbedHost.md").write_text(
+        "- Start {{embed [[SnippetPage]]}} end\n", encoding="utf-8")
 
     graph = LogseqGraph.load_directory(graph_root)
 
@@ -309,7 +316,8 @@ def test_expand_embed_missing_page_completes_without_hang(tmp_path: Path) -> Non
     graph_root = tmp_path / "vault"
     pages = graph_root / "pages"
     pages.mkdir(parents=True)
-    (pages / "P.md").write_text("- x {{embed [[NoSuchPage]]}}\n", encoding="utf-8")
+    (pages /
+     "P.md").write_text("- x {{embed [[NoSuchPage]]}}\n", encoding="utf-8")
     graph = LogseqGraph.load_directory(graph_root)
     text = graph.pages["P"].root_nodes[0].content
 
@@ -342,14 +350,16 @@ def test_expand_cyclic_page_embed_does_not_duplicate_parent_text(tmp_path: Path)
     graph_root = tmp_path / "vault"
     pages = graph_root / "pages"
     pages.mkdir(parents=True)
-    (pages / "A.md").write_text("- before {{embed [[B]]}} after\n", encoding="utf-8")
+    (pages /
+     "A.md").write_text("- before {{embed [[B]]}} after\n", encoding="utf-8")
     (pages / "B.md").write_text("- inner {{embed [[A]]}}\n", encoding="utf-8")
     graph = LogseqGraph.load_directory(graph_root)
     host_page = graph.pages["A"]
     text = host_page.root_nodes[0].content
     chain = frozenset({host_page.title})
 
-    expanded = _expand_macros_and_embeds(text, graph, set(), embed_page_chain=chain)
+    expanded = _expand_macros_and_embeds(
+        text, graph, set(), embed_page_chain=chain)
 
     assert expanded.strip() == "before inner after"
 
@@ -361,7 +371,8 @@ def test_expand_missing_block_embed_completes_without_hang(tmp_path: Path) -> No
     pages = graph_root / "pages"
     pages.mkdir(parents=True)
     missing = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-    (pages / "P.md").write_text(f"- {{{{embed (({missing}))}}}}\n", encoding="utf-8")
+    (pages /
+     "P.md").write_text(f"- {{{{embed (({missing}))}}}}\n", encoding="utf-8")
     graph = LogseqGraph.load_directory(graph_root)
     text = graph.pages["P"].root_nodes[0].content
 
@@ -509,7 +520,7 @@ class TestBuildSynapseMetadata:
         node = LogseqNode(uuid="abc", content="Test", indent_level=0)
         meta = build_synapse_metadata(node, source="test")
         for key in ("uuid", "indent_level", "source", "path", "refs",
-                     "task_status", "task_priority"):
+                    "task_status", "task_priority"):
             assert key in meta
 
     def test_property_serialization(self):


### PR DESCRIPTION
This PR unifies the AI dependency ImportError messages used by the SYNAPSE export helpers.

Previously, different export functions raised inconsistent ImportError messages and referenced different optional packages. This change replaces them with a single shared module-level constant that provides a consistent English message directing users to install the required AI dependencies using:

uv sync --extra ai

The related tests have also been updated to use the shared constant, and a CHANGELOG entry has been added.

## Type of change

- [ ] Bug fix
- [x] Chore / Developer experience (DX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have not introduced breaking changes