### PR TITLE
test: add edge case tests for embed expansion functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Synapse RAG example** — [`examples/run_synapse_rag.py`](examples/run_synapse_rag.py) demonstrates all four `SynapseAdapter` methods (`to_langchain_documents`, `to_llamaindex_nodes`, `to_context_enriched_chunks`, `_expand_macros_and_embeds`) plus table-driven embed expansion edge cases.
+- **Embed expansion edge-case tests** — `TestEmbedExpansionEdgeCases` in [`tests/test_synapse.py`](tests/test_synapse.py) covers cycles, missing targets, and happy-path for both `{{embed [[Page]]}}` and `{{embed ((uuid))}}` (closes [#71](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/71)).
+
 ### Changed
 
 - **Ghost Tooling** — removed remaining vendor indexer blocks from `AGENTS.md` / `CLAUDE.md`; maintainer guidance now uses **audit code** terminology only.

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -370,8 +370,106 @@ def test_expand_missing_block_embed_completes_without_hang(tmp_path: Path) -> No
     assert "{{embed" not in expanded
 
 
-# ── _strip_markdown_for_embedding tests (issue #44) ─────────────────────
+class TestEmbedExpansionEdgeCases:
+    """Table-driven tests for embed expansion edge cases (cycles, missing targets, happy path)."""
 
+    @pytest.fixture(scope="class")
+    def graph(self, tmp_path_factory: pytest.TempPathFactory) -> LogseqGraph:
+        vault = tmp_path_factory.mktemp("embed_edge_vault")
+        pages = vault / "pages"
+        pages.mkdir(parents=True)
+
+        # Happy path page embed: A → B
+        (pages / "B.md").write_text("- Content from page B\n", encoding="utf-8")
+        (pages / "AEmbedsB.md").write_text(
+            "- Before {{embed [[B]]}} after\n", encoding="utf-8"
+        )
+
+        # Cycle detection: A ↔ B
+        (pages / "CycleA.md").write_text(
+            "- before {{embed [[CycleB]]}} after\n", encoding="utf-8"
+        )
+        (pages / "CycleB.md").write_text(
+            "- inner {{embed [[CycleA]]}}\n", encoding="utf-8"
+        )
+
+        # Missing page target
+        (pages / "MissingPage.md").write_text(
+            "- x {{embed [[NoSuchPage]]}}\n", encoding="utf-8"
+        )
+
+        # Missing block target
+        missing_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        (pages / "MissingBlock.md").write_text(
+            f"- {{{{embed (({missing_uuid}))}}}}\n", encoding="utf-8"
+        )
+
+        # Happy path block embed
+        block_uuid = "bbbbbbbb-cccc-cccc-cccc-dddddddddddd"
+        (pages / "BlockTarget.md").write_text(
+            f"- Secret transcluded line\n  id:: {block_uuid}\n", encoding="utf-8"
+        )
+        (pages / "BlockHost.md").write_text(
+            f"- Before {{{{embed (({block_uuid}))}}}} after\n", encoding="utf-8"
+        )
+
+        return LogseqGraph.load_directory(vault)
+
+    @pytest.mark.parametrize(
+        ("page_title", "embed_page_chain", "expected", "unexpected"),
+        [
+            (
+                "AEmbedsB",
+                frozenset(),
+                ["Content from page B"],
+                ["{{embed [[B]]}}"],
+            ),
+            (
+                "CycleA",
+                frozenset({"CycleA"}),
+                ["before inner after"],
+                ["before inner before"],
+            ),
+            (
+                "MissingPage",
+                frozenset(),
+                ["x"],
+                ["{{embed [[NoSuchPage]]}}"],
+            ),
+            (
+                "MissingBlock",
+                frozenset(),
+                [],
+                ["{{embed"],
+            ),
+            (
+                "BlockHost",
+                frozenset(),
+                ["Secret transcluded line", "Before", "after"],
+                ["{{embed (("],
+            ),
+        ],
+    )
+    def test_expand_macros_and_embeds_edge_cases(
+        self,
+        graph: LogseqGraph,
+        page_title: str,
+        embed_page_chain: frozenset[str],
+        expected: list[str],
+        unexpected: list[str],
+    ) -> None:
+        from logseq_matryca_parser.synapse import _expand_macros_and_embeds
+
+        page = graph.pages[page_title]
+        text = page.root_nodes[0].content
+        expanded = _expand_macros_and_embeds(
+            text, graph, set(), embed_page_chain=embed_page_chain
+        )
+
+        for sub in expected:
+            assert sub in expanded, f"Expected {sub!r} in {expanded!r}"
+        for sub in unexpected:
+            assert sub not in expanded, f"Found unexpected {sub!r} in {expanded!r}"
 
 class TestStripMarkdownForEmbedding:
     """Table-driven tests for ``_strip_markdown_for_embedding()`` cleaner."""


### PR DESCRIPTION
## Description
Fixes # (#71)Adds embed expansion edge-case tests TestEmbedExpansionEdgeCases in [tests/test_synapse.py](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/test/development/ai/logseq-matryca-parser/tests/test_synapse.py) covers cycles, missing targets, and happy-path for both {{embed [[Page]]}} and {{embed ((uuid))}}

## Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🛡️ Sovereign Developer Checklist
- [x] I have read [`CONTRIBUTING.md`](../CONTRIBUTING.md) (or picked a task from [`docs/GOOD_FIRST_ISSUES.md`](../docs/GOOD_FIRST_ISSUES.md)).
- [x] I have executed `make all` locally, and all linters (Ruff), type-checkers (Mypy), and tests (Pytest) pass successfully.
- [x] I have added/updated tests for my changes (if applicable).
- [x] I have updated the relevant documentation (`README.md`, `docs/`, `CONTRIBUTING.md` as needed).
- [x] I updated [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]` for user-visible behavior changes.
- [x] My code follows the project's typing conventions (explicit hints on new functions; Pydantic `strict=True` on domain models).

## Screenshots / CLI Output (if applicable)
