### PR TITLE
fix(lens): skip unresolved page references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Ghost Tooling** — removed remaining vendor indexer blocks from `AGENTS.md` / `CLAUDE.md`; maintainer guidance now uses **audit code** terminology only.
 
+### Fixed
+
+- **LENS topology** — unresolved wikilinks no longer create phantom page nodes when visualization uses a loaded `LogseqGraph`; valid page aliases and tags remain visible ([#59](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/59)).
+
 ## [1.6.0] - 2026-07-02
 
 Minor release — Clean Architecture v1 structural slices (SRP/OCP), new public graph APIs, layer-boundary CI, and documentation SSOT. **No intentional breaking changes** to existing `matryca-parse` CLI behavior or stable package exports.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -301,6 +301,8 @@ The KINETIC **`export --format langchain-enriched`** path serializes these docum
 
 **LENS** (`logseq_matryca_parser.lens.GraphVisualizer`) builds a **`networkx.Graph`** over **page ⇄ wiki/tag reference** projections using `NetworkXVisitor` during AST preorder walks. Nodes receive **degree-based sizing** (“sun” hotspots) and subgroup classification (`page`, `tag`, `journal`, etc.). **NetworkX** and **PyVis** are **lazy-imported** (optional **`[viz]`** extra) so core installs avoid pulling visualization dependencies until `GraphVisualizer` is used.
 
+When LENS receives a loaded **`LogseqGraph`**, wikilinks resolve through `get_page`: canonical pages and aliases are included, unresolved page links are omitted, and tag nodes remain visible independently of page resolution.
+
 Visualization export uses **`pyvis`** with **`force_atlas_2based`** physics, fullscreen canvas, HUD filters, glassmorphism control chrome, and stabilized layout configuration suitable for **large graphs at interactive frame rates** in the browser (product positioning targets fluid exploration of graphs on the order of **10⁴ nodes**).
 
 ### 3.4 AGENT WRITER — Append-Only Sandboxing & Headless Splicer

--- a/src/logseq_matryca_parser/lens.py
+++ b/src/logseq_matryca_parser/lens.py
@@ -24,13 +24,13 @@ class NetworkXVisitor(ASTVisitor):
         graph: Any,
         page_title: str,
         *,
-        title_resolver: Callable[[str], str] | None = None,
+        title_resolver: Callable[[str], str | None] | None = None,
     ) -> None:
         self._graph = graph
         self._page_title = page_title
         self._title_resolver = title_resolver
 
-    def _canonical_ref(self, ref: str) -> str:
+    def _canonical_ref(self, ref: str) -> str | None:
         if self._title_resolver is None:
             return ref
         return self._title_resolver(ref)
@@ -40,8 +40,10 @@ class NetworkXVisitor(ASTVisitor):
             self._graph.add_node(self._page_title, group="page")
 
         for ref in node.refs:
-            canonical = self._canonical_ref(ref)
             ref_group = "tag" if (ref in node.tags or ref.startswith("#")) else "page"
+            canonical = ref if ref_group == "tag" else self._canonical_ref(ref)
+            if canonical is None:
+                continue
             if not self._graph.has_node(canonical):
                 self._graph.add_node(canonical, group=ref_group)
             self._graph.add_edge(self._page_title, canonical)
@@ -85,11 +87,11 @@ class GraphVisualizer:
         self._graph = nx.Graph()
         page_block_counts = {page.title: self._count_page_blocks(page) for page in self._pages}
 
-        def _resolve_ref_title(ref: str) -> str:
+        def _resolve_ref_title(ref: str) -> str | None:
             if self._graph_ref is None:
                 return ref
             page = self._graph_ref.get_page(ref)
-            return page.title if page is not None else ref
+            return page.title if page is not None else None
 
         for page in self._pages:
             self._graph.add_node(page.title, group="page")

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import networkx as nx  # type: ignore[import-untyped]
 
+from logseq_matryca_parser.graph import LogseqGraph
 from logseq_matryca_parser.lens import GraphVisualizer, NetworkXVisitor
 from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
 
@@ -61,6 +62,26 @@ def test_graph_visualizer_build_network_creates_expected_topology() -> None:
     assert stats["largest_pages"] == [{"page": "MainPage", "block_count": 2}]
     assert stats["top_connected_nodes"][0]["node"] == "MainPage"
     assert stats["top_connected_nodes"][0]["degree"] == 3
+
+
+def test_graph_visualizer_skips_unresolved_wikilinks_with_graph(
+    tmp_path: Path,
+) -> None:
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir()
+    (pages_dir / "Src.md").write_text(
+        "- See [[Target]] and [[GhostPage]] #alpha\n",
+        encoding="utf-8",
+    )
+    (pages_dir / "Target.md").write_text("- Existing page\n", encoding="utf-8")
+
+    graph = LogseqGraph.load_directory(tmp_path)
+    visualizer = GraphVisualizer(list(graph.iter_canonical_pages()), graph=graph)
+    visualizer.build_network()
+
+    assert visualizer.graph.has_edge("Src", "Target")
+    assert visualizer.graph.has_edge("Src", "alpha")
+    assert "GhostPage" not in visualizer.graph
 
 
 def test_lens_module_imports_without_viz_dependencies() -> None:


### PR DESCRIPTION
## Description

Fixes #59

- Skip unresolved wikilink targets when LENS builds from a loaded `LogseqGraph`.
- Preserve canonical page/alias edges and tag nodes.
- Document the resolution contract and add an Unreleased changelog entry.

## Root cause

`GraphVisualizer` returned the original reference whenever `LogseqGraph.get_page()` could not resolve it, so `NetworkXVisitor` created a normal page node for missing targets.

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update

## Testing

- `uv run pytest -q tests/test_lens.py` (12 passed)
- `make all` (Ruff, Mypy, vendor-name check, 462 tests, 91.09% coverage)

## 🛡️ Sovereign Developer Checklist
- [x] I have read `CONTRIBUTING.md`.
- [x] I have executed `make all` locally, and all linters, type-checkers, and tests pass.
- [x] I have added regression coverage for the change.
- [x] I have updated the relevant architecture documentation.
- [x] I updated `CHANGELOG.md` under `[Unreleased]`.
- [x] My code follows the project typing conventions.

## AI assistance disclosure

OpenAI Codex was used to investigate the issue, implement the focused change, and run the local checks. The final diff was checked with the regression test and full project gate listed above.