### PR TITLE
docs: publish stellar repository roadmap and MKQ knowledge bundle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,12 @@ CI runs the same commands as your local environment: `uv sync --all-extras`, the
 make all
 ```
 
-As of **v1.6.0**, `make all` runs **456** pytest cases with **≥80%** line coverage on `src/logseq_matryca_parser` (currently ~**91%**), plus `make vendor-name-check`. New contributors should mirror patterns in [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) and the module map in that file’s **Test suite** section.
+`make all` runs the current pytest suite with a **≥80%** line-coverage gate on
+`src/logseq_matryca_parser`, plus the vendor-neutral documentation check. Exact
+counts are intentionally not duplicated here; see the dated
+[repository audit](docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) for a verified
+snapshot. New contributors should mirror patterns in
+[`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md).
 
 Or run each step individually:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-22c55e.svg?style=flat-square)](#)
 ![Origin: Matryca.ai](https://img.shields.io/badge/Origin-Matryca.ai-gold?style=for-the-badge)
 
-**v1.6.0** — Clean Architecture slices (`kinetic_export`, `synapse_embed`, layer CI), public `iter_attached_nodes()` / `is_tracked_markdown_path()`. **456 tests**. See [CHANGELOG](CHANGELOG.md).
+**v1.6.0** — Clean Architecture slices (`kinetic_export`, `synapse_embed`, layer CI), public `iter_attached_nodes()` / `is_tracked_markdown_path()`. See [CHANGELOG](CHANGELOG.md); current quality evidence lives in the [repository roadmap](docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md).
 
 > *Turning a forest of local plain-text files into a unified semantic powerhouse.*
 
@@ -22,7 +22,7 @@
 
 [👉 **TRY THE LIVE INTERACTIVE DEMO**](https://MarcoPorcellato.github.io/logseq-matryca-parser/)
 
-[📘 **ARCHITECTURE**](docs/ARCHITECTURE.md) · [Clean Architecture SSOT](docs/CLEAN_CODE_ARCHITECTURE.md) · [AST Primer](docs/logseq_ast_primer.md) · [Cookbook](docs/COOKBOOK.md) · [Good first issues](docs/GOOD_FIRST_ISSUES.md) · [Docs index](docs/README.md) · [CodeQL](docs/CODEQL.md) · [Changelog](CHANGELOG.md) · [Release process](docs/RELEASE_PROCESS.md)
+[📘 **ARCHITECTURE**](docs/ARCHITECTURE.md) · [Clean Architecture SSOT](docs/CLEAN_CODE_ARCHITECTURE.md) · [AST Primer](docs/logseq_ast_primer.md) · [Cookbook](docs/COOKBOOK.md) · [Good first issues](docs/GOOD_FIRST_ISSUES.md) · [Knowledge bundle](docs/index.md) · [Docs index](docs/README.md) · [CodeQL](docs/CODEQL.md) · [Changelog](CHANGELOG.md) · [Release process](docs/RELEASE_PROCESS.md)
 
 </div>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -585,9 +585,15 @@ Recursive and character-budget chunkers assume **approximately flat prose**. Log
 | [`COOKBOOK.md`](COOKBOOK.md) | Integration examples (Synapse, `LogseqGraph`, watcher) |
 | [`GOOD_FIRST_ISSUES.md`](GOOD_FIRST_ISSUES.md) | Picking a first PR ([#19](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/19)–[#52](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/52)); wave 1 in **v1.4.1**, wave 2 in **v1.4.2**, **GFI-11** in **v1.5.0**, Clean Architecture v1 in **v1.6.0** |
 | [`README.md`](README.md) | Project overview and quickstart |
-| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | `uv` setup, `make all` (**456** pytest, ~**91%** coverage, `vendor-name-check`), PR checklist |
+| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | `uv` setup, quality target, coverage threshold, documentation check, PR checklist |
+| [`index.md`](index.md) | Canonical maintained knowledge-bundle entry point |
 | [`design-docs/README.md`](design-docs/README.md) | Warning before using historical DDD blueprints |
 
 ### Quality gate (v1.6.0)
 
-Local and CI parity: `uv sync --all-extras` → `make lint` → `make check` → `make test` → `make vendor-name-check`. The test gate enforces **≥80%** coverage on `src/logseq_matryca_parser` with **456** pytest cases as of **v1.6.0** (layer boundary tests, KINETIC/SYNAPSE structural slices, community waves via [#58](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/58) and **`scan --broken-refs`** via [#77](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/77)). Dedicated modules: `tests/test_layer_boundary.py`, `tests/test_exceptions.py`, `tests/test_extract_changelog.py` — see [`GOOD_FIRST_ISSUES.md`](GOOD_FIRST_ISSUES.md) § Test suite.
+Local and CI parity: `uv sync --all-extras` → `make lint` → `make check` →
+`make test` → `make vendor-name-check`. The test gate enforces **≥80%**
+coverage on `src/logseq_matryca_parser`. Exact totals belong to dated audit
+evidence rather than this maintained architecture contract. Dedicated modules
+include `tests/test_layer_boundary.py`, `tests/test_exceptions.py` and
+`tests/test_extract_changelog.py`.

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -139,7 +139,7 @@ Pick a scoped task from [`GOOD_FIRST_ISSUES.md`](GOOD_FIRST_ISSUES.md) (wave 2: 
 
 ```bash
 uv sync --all-extras
-make all   # 378 pytest cases, ≥80% coverage gate
+make all   # current suite, ≥80% coverage gate
 ```
 
 | Pattern | Example module | Test file |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,27 @@
+---
+type: DocumentationPortal
+title: Logseq Matryca Parser documentation
+description: Human-facing navigation for maintained, active, and historical project documentation.
+status: stable
+classification: canonical
+audience: contributors
+owner: logseq-matryca-parser
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2027-02-02
+supersedes: null
+superseded_by: null
+---
+
 # Documentation index
 
 Use this page to find **active** documentation. Files under [`design-docs/`](design-docs/) are historical blueprints from the Document-Driven Development phase — see [`design-docs/README.md`](design-docs/README.md) before implementing from those specs.
+
+This repository is authoritative for its documentation. Its future projection
+into [Matryca Knowledge](https://github.com/MarcoPorcellato/matryca-knowledge)
+must remain reproducible from an immutable source commit; generated Logseq views
+are navigation layers, not the source of truth. The current target is Matryca
+quality level MKQ-4, not a claim of official OKF conformance.
 
 ## Active documentation
 
@@ -16,6 +37,7 @@ Use this page to find **active** documentation. Files under [`design-docs/`](des
 | [`RELEASE_PROCESS.md`](RELEASE_PROCESS.md) | Maintainers | Semver, tag, and PyPI publish checklist |
 | [`CODEQL.md`](CODEQL.md) | Maintainers | CodeQL default setup notes |
 | [`BUG_HUNT_REPORT.md`](BUG_HUNT_REPORT.md) | Maintainers, contributors | Local static analysis bug audit (Clean Architecture lens, runtime evidence) |
+| [`REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Maintainers, contributors | Evidence-backed repository audit, confirmed defects, issue map, and sequenced improvement roadmap |
 | [`rfc/OLLAMA_RAG.md`](rfc/OLLAMA_RAG.md) | Integrators | Draft RFC for local Ollama RAG (issue [#34](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/34)) |
 | [`roadmaps/`](roadmaps/) | Historians | Executed architectural contracts (Waves 2–12) |
 
@@ -25,6 +47,7 @@ Use this page to find **active** documentation. Files under [`design-docs/`](des
 | :--- | :--- |
 | [`design-docs/`](design-docs/) | Original DDD scaffolds and mldoc parity research |
 | [`error_log.md`](error_log.md) | Informal internal fix log |
+| [`REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md`](REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md) | Superseded audit baseline; retained for provenance |
 
 ## Root-level docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ quality level MKQ-4, not a claim of official OKF conformance.
 
 | Document | Audience | Purpose |
 | :--- | :--- | :--- |
+| [`index.md`](index.md) | Tools, maintainers | Canonical machine entry point for the maintained knowledge bundle |
 | [`CLEAN_CODE_ARCHITECTURE.md`](CLEAN_CODE_ARCHITECTURE.md) | Contributors, maintainers | Uncle Bob rings, SOLID, module maps, layer CI |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Contributors, integrators | LOGOS, SYNAPSE, `LogseqGraph`, agents, data flow |
 | [`quality/`](quality/) | Maintainers | Architecture backlog (v1 complete), GitHub roadmap, triage |
@@ -38,6 +39,10 @@ quality level MKQ-4, not a claim of official OKF conformance.
 | [`CODEQL.md`](CODEQL.md) | Maintainers | CodeQL default setup notes |
 | [`BUG_HUNT_REPORT.md`](BUG_HUNT_REPORT.md) | Maintainers, contributors | Local static analysis bug audit (Clean Architecture lens, runtime evidence) |
 | [`REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Maintainers, contributors | Evidence-backed repository audit, confirmed defects, issue map, and sequenced improvement roadmap |
+| [`quality/ISSUE_RECONCILIATION_2026-08-06.md`](quality/ISSUE_RECONCILIATION_2026-08-06.md) | Maintainers, contributors | Evidence-backed disposition of every issue open at the audit baseline |
+| [`decisions/index.md`](decisions/index.md) | Maintainers | Canonical decision registry and ADR gaps |
+| [`reference/index.md`](reference/index.md) | Maintainers, integrators | Provenance and Matryca ecosystem relations |
+| [`log.md`](log.md) | Maintainers | Maintained documentation chronology |
 | [`rfc/OLLAMA_RAG.md`](rfc/OLLAMA_RAG.md) | Integrators | Draft RFC for local Ollama RAG (issue [#34](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/34)) |
 | [`roadmaps/`](roadmaps/) | Historians | Executed architectural contracts (Waves 2–12) |
 
@@ -48,6 +53,7 @@ quality level MKQ-4, not a claim of official OKF conformance.
 | [`design-docs/`](design-docs/) | Original DDD scaffolds and mldoc parity research |
 | [`error_log.md`](error_log.md) | Informal internal fix log |
 | [`REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md`](REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md) | Superseded audit baseline; retained for provenance |
+| [`quality/ISSUE_TRIAGE_2026-07.md`](quality/ISSUE_TRIAGE_2026-07.md) | Superseded July issue-triage baseline |
 
 ## Root-level docs
 

--- a/docs/REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md
+++ b/docs/REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md
@@ -1,0 +1,438 @@
+---
+type: RepositoryAudit
+title: Studio approfondito della repository - opportunita di miglioramento
+description: Baseline storica del 2026-07-28, superata dal successivo audit stellare.
+status: deprecated
+classification: historical
+audience: maintainers
+owner: logseq-matryca-parser
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2026-08-06
+supersedes: null
+superseded_by: docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+---
+
+# Studio approfondito della repository — opportunità di miglioramento
+
+> **Documento storico.** È conservato come baseline del 2026-07-28 ed è
+> sostituito da [`REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md),
+> che include probe aggiuntivi, stato issue aggiornato e piano documentale MKQ-4.
+
+**Data:** 2026-07-28  
+**Scope:** architettura, correttezza, affidabilità, sicurezza, performance, test, supply chain, release engineering, documentazione e developer experience.  
+**Metodo:** lettura semantica dei flussi, revisione del codice e dei workflow, controlli locali e probe isolati. Non sono state modificate parti del runtime.
+
+## Sintesi esecutiva
+
+Il progetto è una libreria Python matura e ben curata per convertire il Markdown spaziale di Logseq in un AST tipizzato, un indice di grafo e formati di esportazione. I suoi punti più forti sono:
+
+- modello di dominio piccolo e tipizzato;
+- parsing deterministico con copertura eccellente dei casi sintattici difficili;
+- invarianti di indice già difesi (niente nodi orfani dopo reload e collisioni);
+- confini architetturali testati e zero cicli di import;
+- pipeline CI, dependency audit e distribuzione PyPI già presenti.
+
+La direzione consigliata non è riscrivere la base: è rendere espliciti i contratti che oggi sono impliciti. Le priorità concrete sono: evitare perdita silenziosa nelle collisioni di titolo, rendere atomiche le operazioni concorrenti di writer/watcher, trasformare il lint CI in un vero gate non mutante, e creare un corpus di compatibilità e benchmark ripetibili.
+
+| Priorità | Tema | Perché ora | Risultato atteso |
+|---|---|---|---|
+| P0 | Integrità del gate CI | Il lint usato dalla CI corregge anziché rifiutare | Un commit non formattato non può passare senza diff |
+| P1 | Collisioni di pagina | Due file con lo stesso titolo perdono silenziosamente un contenuto | Conflitto diagnosticato o rifiutato in modalità strict |
+| P1 | Concorrenza writer/watcher | Read-modify-write e aggiornamento indici non hanno un contratto di serializzazione | Nessun update perso e snapshot coerenti |
+| P1 | Contratto di compatibilità Logseq | Molti edge case sono testati, ma manca una suite versionata di corpus e metamorphic tests | Regressioni rilevate prima del rilascio |
+| P1 | Hardening release/supply chain | Workflow e artefatti possono avere prove più forti | Release verificabile, riproducibile e attribuibile |
+| P2 | Osservabilità, performance e API | Buon logging, ma mancano SLO, benchmark e contratti macchina | Operatività e diagnosi più rapide |
+| P3 | Modularizzazione parser | Il parser è il grande hub residuo | Cambi locali più sicuri e più leggibili |
+
+## Evidenze raccolte
+
+| Controllo | Esito |
+|---|---:|
+| Test raccolti | 462 |
+| Test eseguiti | 462 passati |
+| Coverage totale | 91,09% |
+| Soglia coverage | 80% |
+| Lint | nessun problema rilevato |
+| Type check | nessun errore rilevato |
+| Cicli di import in `src/` | 0 |
+| Lockfile | coerente con `pyproject.toml` |
+| CLI | `matryca-parse --help` operativo |
+| Artefatti | sdist e wheel di `1.6.0` costruiti correttamente |
+| Audit dipendenze runtime | nessuna vulnerabilità nota al momento della verifica |
+
+Le lacune di coverage più significative non compromettono il gate globale, ma meritano attenzione mirata: `logos_core.py` (75%), `agent_writer.py` (77%) e l'entry point `__main__.py` (0%). La gravità dipende dal flusso: il writer modifica file utente ed è quindi più importante di una semplice percentuale aggregata.
+
+## Architettura attuale
+
+```mermaid
+flowchart LR
+    Files["Vault Logseq\npages/ + journals/"] --> Paths["logseq_paths\nscoperta e normalizzazione"]
+    Paths --> Parser["logos_parser\nStackMachineParser"]
+    Parser --> Domain["logos_core\nLogseqPage / LogseqNode"]
+    Domain --> Graph["graph\nindici, query, watcher"]
+    Graph --> Synapse["synapse + synapse_embed\nRAG e context chunks"]
+    Domain --> Forge["forge\nJSON / Markdown / Obsidian"]
+    Graph --> Writer["agent_writer\nappend atomico + reload"]
+    Graph --> Lens["lens\nnetwork visualization"]
+    Graph --> CLI["kinetic + kinetic_commands/export\nTyper CLI"]
+    Synapse --> CLI
+    Forge --> CLI
+    Writer --> CLI
+```
+
+### Cosa funziona bene nella struttura
+
+1. **Core separato dalle integrazioni.** `logos_core.py` mantiene le entità; gli adapter di RAG, visualizzazione e formati restano laterali e opzionali.
+2. **Grafo come API applicativa.** `LogseqGraph` offre accessi canonici, backlink, query e reload incrementale, evitando che ogni consumer ricostruisca propri indici.
+3. **Parser deterministico.** Il parser mantiene stack, indentazione, proprietà, drawer, riferimenti e normalizzazione in un singolo percorso coerente.
+4. **Protezione contro regressioni già forte.** I test coprono UUID sintetici, embed ciclici, frontmatter, namespace, backlink, strict references, tab width, watcher e writer.
+5. **Buona disciplina di distribuzione.** Lockfile, test su Python 3.12/3.13, audit dipendenze e pubblicazione con OIDC sono una base affidabile.
+
+### Punto di pressione architetturale
+
+`StackMachineParser.parse()` contiene contemporaneamente scansione, gestione stati, costruzione AST, estrazione semantica e recupero da input malformato; è un hub intenzionale, ma lungo circa 400 righe. `_refresh_node()` ricostruisce molte proiezioni derivate del nodo. È corretto preservare il comportamento, ma la prossima evoluzione del parser deve ridurre il costo cognitivo senza spezzarne la determinismo.
+
+```text
+Markdown lines
+    |
+    v
+[classificazione] -> [stato lessicale] -> [evento tipizzato]
+                                                   |
+                                                   v
+                  [riduttore AST] -> [arricchimento semantico] -> LogseqPage
+```
+
+Questa separazione non richiede un framework: basta introdurre confini interni e testare ogni passaggio.
+
+## Findings e interventi raccomandati
+
+### P0 — Rendere il lint CI non mutante
+
+**Evidenza.** `make lint` esegue `ruff check . --fix`, e la CI invoca `make lint`. Il runner può quindi correggere il checkout e concludere con successo: il gate non prova che il commit ricevuto fosse già conforme.
+
+**Rischio.** Si perde il ruolo di barriera preventiva; un contributor può ricevere un verde CI ma un working tree locale diverso da quello verificato. In una futura pipeline che riusi lo stesso checkout, file modificati implicitamente possono contaminare step successivi.
+
+**Intervento.** Separare controllo e correzione, rendendo il primo l'unico usato in CI.
+
+```make
+lint:
+	uv run ruff check .
+
+lint-fix:
+	uv run ruff check . --fix
+
+format-check:
+	uv run ruff format --check .
+
+format:
+	uv run ruff format .
+```
+
+**Criteri di accettazione.**
+
+- un file con import non ordinati fa fallire CI;
+- `make lint-fix` resta ergonomico localmente;
+- CI esegue anche `format-check` oppure verifica esplicitamente che `git diff --exit-code` sia vuoto dopo ogni step mutante.
+
+### P1 — Rendere esplicita la policy sulle collisioni di titolo
+
+**Evidenza.** `LogseqGraph.load_directory()` inserisce le pagine con `pages[page.title] = page` dopo un ordinamento per path. Un probe con `pages/Daily.md` e `journals/Daily.md` ha prodotto una sola pagina canonica (`pages/Daily.md`); il comportamento è coperto intenzionalmente dai test per evitare nodi fantasma.
+
+**Valutazione.** L'invariante attuale è internamente coerente, ma l'esclusione del file perdente è silenziosa: export, ricerca e RAG possono omettere conoscenza senza avviso. È una scelta di prodotto da trasformare in contratto esplicito.
+
+**Proposta.** Mantenere il default retrocompatibile solo per una release minore, ma raccogliere conflitti strutturati; introdurre `strict_title_collisions=True` e una diagnostica leggibile dalla CLI.
+
+```python
+@dataclass(frozen=True)
+class TitleCollision:
+    title: str
+    winner: Path
+    loser: Path
+    reason: Literal["same-derived-title", "title-frontmatter"]
+
+def index_pages(parsed: list[tuple[Path, LogseqPage]], *, strict: bool) -> IndexResult:
+    by_title: dict[str, LogseqPage] = {}
+    collisions: list[TitleCollision] = []
+    for path, page in sorted(parsed, key=stable_path_key):
+        previous = by_title.get(page.title)
+        if previous is not None:
+            conflict = TitleCollision(page.title, winner_path(previous), path, reason(page))
+            collisions.append(conflict)
+            if strict:
+                raise PageTitleCollisionError(conflict)
+        by_title[page.title] = select_deterministic_winner(previous, page)
+    return IndexResult(by_title, collisions)
+```
+
+**Test da aggiungere.** Collisione pages/journals, due `title::` uguali, alias che collide con titolo, CLI `scan --strict-title-collisions`, serializzazione diagnostica JSON. Documentare chiaramente il tie-breaker finché il default rimane permissivo.
+
+### P1 — Contratto di concorrenza per watcher, writer e lettori
+
+**Evidenza.** Il writer effettua un read-modify-write e `os.replace`, poi richiama il reload. Il watcher può aggiornare contemporaneamente gli indici; `invalidate_and_reload_page()` sostituisce `pages`, poi mappa titoli, registro nodi e backlink in passaggi distinti. L'atomic rename protegge dalla scrittura parziale, non da due writer che leggono la stessa versione e sovrascrivono modifiche reciproche.
+
+**Rischio.** In un processo con watcher attivo e richieste simultanee, un lettore può osservare indici transitori; due append possono perdere una modifica. È un rischio di concorrenza da trattare prima di offrire l'API come servizio long-running.
+
+**Proposta.** Definire una sola coda di mutazione per vault e pubblicare snapshot immutabili del grafo.
+
+```python
+class VaultCoordinator:
+    def __init__(self, initial: GraphSnapshot):
+        self._lock = RLock()
+        self._snapshot = initial
+
+    def read(self) -> GraphSnapshot:
+        return self._snapshot                  # snapshot completo, mai parziale
+
+    def mutate_file(self, path: Path, transform: Callable[[str], str]) -> None:
+        with self._lock:
+            original = path.read_text("utf-8-sig")
+            updated = transform(original)
+            atomic_replace(path, updated)
+            self._snapshot = rebuild_delta(self._snapshot, path)
+            emit_change_event(path, self._snapshot.version)
+```
+
+**Criteri di accettazione.** Test con due append concorrenti, lettura mentre avviene un reload, rename/delete durante debounce, callback che non blocca il thread del watcher, nessuna finestra in cui UUID e backlink appartengono a versioni diverse.
+
+### P1 — Corpus di compatibilità e test metamorfici del parser
+
+**Evidenza.** Il parser ha 95% di coverage e un'eccellente suite di esempi, ma la sintassi Logseq ha edge case quasi illimitati e il comportamento dipende dall'evoluzione dell'editor. La coverage da sola non misura la compatibilità semantica.
+
+**Proposta.** Versionare un corpus di vault minimali e aggiungere proprietà invarianti, senza rendere i test fragili o dipendenti dalla rete.
+
+```text
+tests/fixtures/compat/
+  v1/indentation/
+  v1/properties/
+  v1/embeds/
+  v1/journals/
+  v1/recovery/
+  manifest.json  # input, risultato semantico atteso, origine e invariant
+```
+
+```python
+@given(spatial_markdown_strategy())
+def test_parse_serialize_parse_preserves_semantics(text: str) -> None:
+    original = parser.parse(text)
+    reparsed = parser.parse(serialize_logseq_page(original))
+    assert semantic_projection(reparsed) == semantic_projection(original)
+    assert all_unique(reparsed.all_node_uuids())
+    assert parent_links_are_consistent(reparsed)
+
+def test_file_discovery_order_does_not_change_canonical_snapshot(vault: Path) -> None:
+    assert load_with_order(vault, forward) == load_with_order(vault, reverse)
+```
+
+**Nota.** Per gli input volutamente malformati l'assert non deve essere identità testuale: deve essere terminazione, assenza di crash, AST coerente e diagnostica classificata.
+
+### P1 — Rafforzare release engineering e supply chain
+
+**Evidenza.** La CI effettua audit dipendenze e la pubblicazione usa OIDC; sono buone basi. I workflow però usano tag mobili delle action e la release GitHub e la pubblicazione PyPI sono workflow indipendenti attivati dal tag. La pubblicazione ricostruisce artefatti in un job separato dal pre-flight.
+
+**Interventi.**
+
+1. Pin delle action a commit SHA, con commento della versione leggibile.
+2. Build una sola volta dopo il gate; caricare wheel e sdist come artifact; pubblicare esattamente quegli artifact.
+3. Verificare prima della pubblicazione: tag `vX.Y.Z` = metadata del package = `__version__`, `twine check`, e changelog con sezione non vuota.
+4. Collegare la release GitHub alla conclusione del publish oppure farle consumare lo stesso artifact attestato.
+5. Generare SBOM e provenance dell'artefatto se la distribuzione diventa un confine di sicurezza significativo.
+
+```mermaid
+sequenceDiagram
+    participant Tag as Tag firmato
+    participant Gate as Quality gate
+    participant Build as Build unico
+    participant Store as Artifact store
+    participant PyPI as PyPI
+    participant Release as GitHub release
+
+    Tag->>Gate: verifica versione, test, audit, lint non mutante
+    Gate->>Build: autorizza
+    Build->>Store: wheel + sdist + checksum + SBOM
+    Store->>PyPI: pubblica artifact verificato
+    PyPI-->>Release: publish riuscito
+    Store->>Release: allega stessi artifact e provenance
+```
+
+### P2 — Budget prestazionali e scalabilità misurata
+
+**Evidenza.** Il caricamento concorrente è una buona scelta; mancano però benchmark versionati, dataset di dimensione dichiarata e budget di memoria/tempo. `search_content` e molte query sono scansioni lineari: corrette per vault medi, potenzialmente costose per un server o vault molto grandi.
+
+**Proposta.** Aggiungere benchmark separati dal gate veloce e metriche comparabili tra release.
+
+```python
+@benchmark
+def test_load_10k_pages(benchmark, fixture_vault_10k):
+    graph = benchmark(LogseqGraph.load_directory, fixture_vault_10k)
+    assert graph.page_count == 10_000
+
+@benchmark
+def test_incremental_reload(benchmark, loaded_10k_graph, changed_file):
+    benchmark(loaded_10k_graph.invalidate_and_reload_page, changed_file)
+```
+
+Definire budget iniziali realisti (p95 load, p95 reload, RSS) solo dopo una baseline su runner stabile. Se le query diventano un hot path, introdurre indici opzionali per testo/tag con un contratto di invalidazione unico, non ottimizzazioni sparse.
+
+### P2 — Osservabilità orientata al prodotto
+
+**Evidenza.** Esiste logging utile e dettagliato in tutti i moduli. Manca un modello uniforme per diagnosi di parser, collisioni, riferimenti irrisolti, reload e export: oggi molte informazioni sono solo stringhe di log.
+
+**Proposta.** Introdurre un `Diagnostic` serializzabile, mantenendo il logging come sink.
+
+```python
+@dataclass(frozen=True)
+class Diagnostic:
+    code: str                 # e.g. TITLE_COLLISION, BROKEN_BLOCK_REF
+    severity: Literal["info", "warning", "error"]
+    source_path: str | None
+    line: int | None
+    message: str
+    context: Mapping[str, str]
+
+class ParseResult:
+    page: LogseqPage
+    diagnostics: tuple[Diagnostic, ...]
+```
+
+La CLI potrebbe offrire `--diagnostics json`, `scan --fail-on warning` e contatori finali. Ciò rende automatizzabili controlli di qualità sui vault senza introdurre telemetria invasiva.
+
+### P2 — API pubblica, typing e compatibilità
+
+**Evidenza.** `__init__.py` espone esplicitamente molte classi e funzioni, ottimo punto di partenza. Manca il marker `py.typed`, quindi gli integratori potrebbero non ricevere i type hints come package tipizzato. La versione è duplicata tra metadata e modulo, pur essendo coperta da test.
+
+**Interventi.**
+
+- aggiungere `py.typed` al package e verificarne l'inclusione nella wheel;
+- pubblicare una tabella di stabilità API (`stable`, `experimental`, `internal`);
+- usare metadata dinamico o una singola sorgente versione;
+- introdurre test di compatibilità su API pubblica e policy semver; 
+- valutare `mypy --strict` per il core, a ondate, senza imporlo subito agli adapter opzionali.
+
+```text
+public API -> test import -> test signature/semantic contract -> release note
+internal API -> nessuna promessa di stabilità -> refactor libero con test interni
+```
+
+### P2 — Documentazione viva e onboarding affidabile
+
+**Evidenza.** La documentazione è ampia e ben organizzata, ma diversi documenti riportano ancora 378 o 456 test, mentre l'evidenza attuale è 462. Alcuni report storici sono dichiaratamente storici, ma la distinzione deve essere visivamente inequivocabile.
+
+**Interventi.**
+
+1. Sostituire conteggi volatili con un badge/generatore, oppure aggiornare una singola fonte canonica durante la release.
+2. Aggiungere test per snippet Python dei documenti e controlli link interni.
+3. Etichettare in testa ai report: `Storico`, `Attivo`, `Superseded`, con data e owner.
+4. Creare una pagina "decision records" per scelte come collision policy, UUID sintetici, strict references e writer concurrency.
+
+### P2 — Sicurezza del filesystem e del writer
+
+**Aspetti già buoni.** Il writer usa file temporaneo nella stessa directory e `os.replace`; la risoluzione asset rifiuta percorsi assoluti e normalizza i path. L'audit runtime delle dipendenze non ha trovato vulnerabilità note.
+
+**Miglioramenti.**
+
+- aggiungere test di symlink e confine del vault per tutte le operazioni in scrittura;
+- definire una policy esplicita per permessi e owner preservati dal replace;
+- offrire una modalità `dry-run` che produce patch unificata prima di modificare Markdown;
+- limitare dimensione/depth di input configurabili per usare la libreria su vault non fidati;
+- fare girare l'audit dipendenze anche nel workflow tag, non solo nel percorso pull request.
+
+### P3 — Evoluzione incrementale del parser
+
+Non raccomando un big-bang rewrite. La sequenza sicura è:
+
+```mermaid
+flowchart TD
+    A["Congelare corpus e snapshot"] --> B["Estrarre classificatore di linea puro"]
+    B --> C["Estrarre stati lessicali: fence, query, drawer, frontmatter"]
+    C --> D["Estrarre riduttore dello stack AST"]
+    D --> E["Centralizzare arricchimento node e riferimenti"]
+    E --> F["Misurare equivalenza e benchmark"]
+```
+
+Ogni slice deve conservare: output semantico, UUID, ordine dei nodi, line range, normalizzazione proprietà e comportamento `strict_refs`. Prima di modificare gli hub del parser o del grafo va rieseguita un'analisi di impatto e vanno aggiornati corpus e benchmark.
+
+## Architettura obiettivo
+
+```mermaid
+flowchart TB
+    subgraph Core["Core stabile"]
+        Model["Domain model\nPage, Node, Diagnostic"]
+        Events["Parser events\nline classification + state"]
+        Reducer["AST reducer\ndeterministic stack"]
+        Semantics["Semantic enrichment\nrefs, tags, dates"]
+        Model --> Events --> Reducer --> Semantics
+    end
+
+    subgraph App["Application"]
+        Index["Graph index snapshot"]
+        Coord["Vault coordinator\nserialized mutation"]
+        Query["Query and diagnostics API"]
+        Semantics --> Index --> Query
+        Coord --> Index
+    end
+
+    subgraph Adapters["Adapters"]
+        CLI["CLI"]
+        Writer["Writer / patch preview"]
+        RAG["RAG exports"]
+        Viz["Visualization"]
+        CLI --> Query
+        Writer --> Coord
+        RAG --> Query
+        Viz --> Query
+    end
+```
+
+Principio guida: il core produce dati e diagnostica deterministici; l'applicazione ne controlla il ciclo di vita; gli adapter non accedono a registri interni né definiscono proprie regole di indicizzazione.
+
+## Roadmap proposta
+
+### Fase 1 — Fiducia nel delivery (1–3 giorni)
+
+- Separare lint/check da fix/format.
+- Aggiornare i conteggi test nella documentazione attiva.
+- Creare check `version/tag/changelog` e `twine check` per release.
+- Aggiungere `py.typed` e test della wheel.
+
+### Fase 2 — Integrità del vault (3–7 giorni)
+
+- Introdurre `TitleCollision` e strict mode, senza cambiare il default nella prima release.
+- Pubblicare diagnostica JSON e flag CLI fail-fast.
+- Aggiungere writer dry-run e test su symlink/permessi.
+
+### Fase 3 — Robustezza operativa (1–2 settimane)
+
+- Coordinatore/snapshot per reload e writer.
+- Test concorrenti deterministici con barrier e fake watcher.
+- Corpus di compatibilità versionato e prime property-based tests.
+
+### Fase 4 — Evoluzione sostenibile (incrementale)
+
+- Benchmark e budget per 1k/10k pagine.
+- Estrarre classificatore/stati parser una slice alla volta.
+- Stabilire API stability policy, ADR e release notes generate dai contratti.
+
+## Cosa non cambierei ora
+
+- Non introdurrei una gerarchia di package complessa solo per imitare un'architettura teorica: i moduli piatti sono leggibili e gli import cycle sono già zero.
+- Non aggiungerei un database o un motore di ricerca esterno finché benchmark reali non dimostrano che le scansioni lineari sono il collo di bottiglia.
+- Non sostituirei Pydantic o Typer: il costo della migrazione non è giustificato da un problema concreto.
+- Non renderei il parser "più permissivo" senza diagnostica: per un parser di knowledge graph, un risultato ambiguo ma silenzioso è peggiore di un warning strutturato.
+
+## Definition of Done per le prossime modifiche strutturali
+
+```text
+[ ] analisi di impatto sui simboli hub
+[ ] test mirati del comportamento modificato
+[ ] corpus/regressione per input Logseq rappresentativo
+[ ] lint non mutante, type check, test e coverage
+[ ] check dei cicli di import
+[ ] benchmark se cambia un hot path
+[ ] docs/API/ADR aggiornati se cambia un contratto
+[ ] prova di installazione o artifact build se cambia packaging/release
+```
+
+## Conclusione
+
+La repository non necessita di una rifondazione: è già una base di qualità. Il salto successivo è passare da un progetto robusto a una piattaforma affidabile sotto input reali, vault grandi, integrazioni agentiche e release frequenti. Le quattro iniziative con il miglior rapporto valore/rischio sono: gate CI non mutante, collision diagnostics, serializzazione delle mutazioni del vault e corpus di compatibilità. Insieme proteggono le proprietà che rendono il progetto distintivo: determinismo, fedeltà semantica e fiducia nei dati dell'utente.

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -1,0 +1,651 @@
+---
+type: RepositoryAudit
+title: Logseq Matryca Parser - Code Audit e roadmap stellare
+description: Audit verificato della repository, finding riproducibili e piano MKQ-4 allineato a Matryca Knowledge.
+status: stable
+classification: active
+audience: maintainers
+owner: logseq-matryca-parser
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2027-02-02
+source_commit: 8e90b44
+supersedes: docs/REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md
+superseded_by: null
+---
+
+# Logseq Matryca Parser — Code Audit e roadmap verso una repository “stellare”
+
+> **Stato:** studio eseguito e verificato il 2026-08-06  
+> **Checkout analizzato:** `main` @ `8e90b44`  
+> **Natura del documento:** decision record e backlog tecnico; non autorizza implementazione, commit, push, PR, merge o release  
+> **Rapporto con lo studio precedente:** integra e corregge `REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md`, che al momento dell'audit era ancora non tracciato
+
+## 1. Sintesi esecutiva
+
+La repository è già nettamente sopra la media: il quality gate locale passa con **462 test**, **3.233 statement** misurati e **91% di coverage**, Ruff e Mypy puliti, **0 cicli di import**, packaging moderno, API grafo utili, parsing deterministico, writer atomico a livello di singolo file e una buona separazione degli adapter opzionali.
+
+Il salto successivo non richiede una riscrittura né più feature indiscriminate. Richiede, in quest'ordine:
+
+1. correggere due difetti P0 confermati su fixture sintetiche;
+2. rendere espliciti e verificabili i confini di sicurezza del vault;
+3. trasformare il grafo mutabile in uno snapshot coerente per writer, watcher e lettori;
+4. congelare la semantica del parser con corpus versionato e test metamorfici;
+5. rendere delivery, API, diagnostica e documentazione meccanicamente affidabili;
+6. misurare la scala prima di introdurre nuovi indici, database o framework.
+
+La conclusione più importante è che il backlog aperto **#101–#111 è valido ma non completo**. Copre quasi tutta la maturazione strategica, però il presente audit ha confermato anche:
+
+- **P0 — perdita di contenuto su aggiornamenti di nodi annidati oltre il terzo livello**;
+- **P0 — scrittura fuori dal vault attraverso file Markdown symlinkati**;
+- **P1 — risoluzione di URI `file://` senza confinamento al vault**;
+- **P1 — backlink obsoleti dopo una rinomina incrementale di pagina**.
+
+Il primo difetto merita una issue bug dedicata e una correzione chirurgica prima del refactor del parser. I due difetti di confinamento devono diventare criteri espliciti della #106; il backlink stale deve diventare una slice esplicita della #103 o una issue figlia.
+
+## 2. Piano iniziale
+
+Il piano definito prima dell'esplorazione era:
+
+1. raccogliere baseline live, istruzioni del repository, storico e architettura indicizzata;
+2. delegare audit specialistici a GPT-5.3 Codex Spark e GPT-5.6 Luna;
+3. confrontare i risultati e distinguere difetti correnti, debito già tracciato e idee speculative;
+4. eseguire un round correttivo sui punti contraddittori o non provati;
+5. depositare piano, evidenze, priorità, roadmap e limiti in un Markdown versionabile;
+6. validare il documento con i gate prescritti dal repository.
+
+### 2.1 Criteri di accettazione dello studio
+
+- Le raccomandazioni devono derivare da sorgente live, test, workflow o probe riproducibili.
+- I fatti storici non devono essere presentati come stato corrente.
+- Ogni finding deve indicare impatto, confidenza, verifica minima e relazione con #101–#111.
+- Le modifiche a hub devono essere precedute da impact analysis.
+- Devono restare invariati parsing deterministico, UUID, ordinamento, pagine canoniche, no-ghost-node e `strict_refs`.
+- Nessun commit, push, PR, issue o cambio remoto è autorizzato da questo studio.
+
+## 3. Delega, raccolta e correzione del tiro
+
+Sono state lanciate cinque attività read-only in worktree separati, partendo dallo stato corrente incluso il documento non tracciato del 28 luglio.
+
+| Attività | Modello | Motivazione del routing | Esito utile |
+|---|---|---|---|
+| Documentazione e contributor experience | GPT-5.3 Codex Spark | Ricerca prevalentemente meccanica: link, numeri, indici, onboarding | Evidenze raccolte; il report finale è fallito per limite del servizio, quindi le conclusioni sono state ricostruite e riverificate localmente |
+| CI, packaging e release engineering | GPT-5.3 Codex Spark | Workflow e manifest hanno controlli deterministici | Confermati lint mutante, action non pin-nate e lineage degli artifact non immutabile |
+| Architettura e manutenibilità | GPT-5.6 Luna | Richiede ragionamento cross-module e blast radius | Confermati i due hub principali, la necessità di slice incrementali e il backlink stale |
+| Correttezza, sicurezza e performance | GPT-5.6 Luna | Area ad alto rischio con probe e giudizio | Ha individuato quattro anomalie riprodotte poi nel checkout principale |
+| Prodotto, API ed ecosistema | GPT-5.6 Luna | Richiede sintesi di posizionamento e sequenziamento | Confermata la strategia contract-first e il rifiuto di plugin/database prematuri |
+
+### 3.1 Round correttivo
+
+Le prime esecuzioni lunghe delle attività remote sono state interrotte durante la compattazione. Non sono state accettate come risultati completi. Il secondo round ha:
+
+- ridotto lo scope;
+- vietato nuove scansioni ampie;
+- chiesto una chiusura dai dati già raccolti;
+- ridotto il reasoning dove necessario;
+- imposto output compatti e separazione fra fatti e ipotesi.
+
+Quattro attività hanno poi prodotto report finali. L'attività documentale è fallita nuovamente per limite di output; i suoi dati parziali sono stati confrontati direttamente con `README.md`, `docs/README.md`, `CONTRIBUTING.md`, workflow e studio precedente.
+
+### 3.2 Revisione critica dei risultati delegati
+
+Una prima sintesi concludeva che #101–#111 coprissero tutto il lavoro necessario. Questa conclusione è stata rigettata dopo i probe indipendenti: la perdita di soft-break profondo non è un semplice requisito del corpus, ma un bug corrente riproducibile; il confine symlink e il ramo `file://` sono comportamenti di sicurezza attuali, non solo hardening teorico.
+
+Questo è il motivo per cui la roadmap finale inizia con una **Wave 0 di contenimento e correzione**, prima delle iniziative strategiche già aperte.
+
+## 4. Evidenze e baseline live
+
+### 4.1 Stato Git
+
+All'inizio dello studio:
+
+```text
+* main...origin/main
+?? .serena/
+?? docs/REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md
+```
+
+Entrambi i path preesistevano e sono stati preservati. L'aggiornamento locale dell'indice di audit code aveva aggiunto automaticamente contenuto a `AGENTS.md` e `CLAUDE.md`; quelle sole aggiunte generate durante lo studio sono state rimosse, riportando i due file senza diff.
+
+### 4.2 Quality gate
+
+Comando:
+
+```bash
+rtk make all
+```
+
+Risultato:
+
+- Ruff: `All checks passed!`;
+- Mypy: `Success: no issues found in 34 source files`;
+- controllo documentale vendor-neutral: `OK`;
+- Pytest: **462 passed**;
+- coverage: **3.233 statement, 288 mancanti, 91% totale**.
+
+Il target `make all` è verde, ma non è ancora un gate puramente verificativo: `make lint` esegue `ruff check . --fix`. Nel presente run non ha prodotto diff, ma in CI potrebbe correggere il checkout e mascherare una submission non conforme. Questo conferma #101.
+
+### 4.3 Audit code
+
+L'indice locale è stato aggiornato al commit corrente e ha riportato:
+
+```text
+2.133 nodi | 4.040 relazioni | 57 cluster | 169 flussi
+cycleCount: 0
+```
+
+Il server di consultazione ha inizialmente mantenuto in cache un contesto vecchio; per questo nessun risultato stale è stato usato come prova sufficiente. I finding critici sono stati confermati con sorgente live, analisi semantica e probe runtime.
+
+### 4.4 Blast radius degli hub protetti
+
+| Simbolo | Rischio | Impatto rilevato | Conseguenza operativa |
+|---|---:|---|---|
+| `StackMachineParser._refresh_node` | HIGH | 102 simboli, 4 flussi | Modifiche solo con corpus, snapshot semantici e test parser completi |
+| `StackMachineParser._replace_stack_tail_node` | HIGH | 102 simboli, 4 flussi | Il fix P0 deve essere chirurgico e equivalence-tested |
+| `LogseqGraph.load_directory` | CRITICAL | 47 chiamanti diretti, 6 flussi | Nessuna modifica opportunistica; preservare API e determinismo |
+| `LogseqGraph.invalidate_and_reload_page` | LOW locale | 3 chiamanti diretti, 2 flussi | Slice piccola, ma semantica globale degli indici da testare contro cold reload |
+| `_expand_macros_and_embeds_impl` | LOW | 6 simboli, 2 flussi | Seams già sottili; non è un hotspot prioritario |
+
+## 5. Architettura attuale
+
+```mermaid
+flowchart TD
+    V["Vault: pages/ e journals/"] --> D["Discovery e path policy"]
+    D --> P["StackMachineParser"]
+    P --> AST["LogseqPage e LogseqNode immutabili"]
+    AST --> G["LogseqGraph"]
+    G --> IDX["Pagine canoniche, UUID, alias, backlink"]
+    IDX --> Q["Query, namespace, reference checks"]
+    G --> W["Incremental reload e watcher"]
+    G --> A["CLI, agent read/write"]
+    G --> E["Export, RAG e visualizzazione"]
+    W --> G
+    A --> W
+```
+
+La direzione delle dipendenze è buona e il controllo cicli è pulito. I rischi principali non sono cicli o framework sbagliati, ma **coerenza temporale** e **propagazione delle strutture immutabili**:
+
+- il parser ricostruisce nodi immutabili lungo uno stack;
+- il grafo pubblica più indici derivati dalla stessa collezione di pagine;
+- writer e watcher possono aggiornare file e indici in momenti diversi;
+- alias e titoli trasformano una mappa in un insieme di identità canoniche più proiezioni secondarie.
+
+Il design futuro deve rendere questi quattro contratti espliciti.
+
+## 6. Findings confermati
+
+### P0.1 — Perdita di contenuto su nodi annidati profondamente
+
+**Stato:** bug corrente, alta confidenza, non coperto in modo sufficientemente esplicito dalle issue esistenti.
+
+`StackMachineParser._replace_stack_tail_node` aggiorna il nodo, il parent e il grandparent, ma non propaga il nuovo ramo fino alla root per profondità superiori. Il soft-break viene registrato nello stack locale, mentre l'AST restituito conserva una root precedente.
+
+Probe sintetico:
+
+```text
+DEEP_CONTENTS ['a', 'b', 'c', 'd', 'e']
+DEEP_SOFT_BREAK_PRESENT False
+```
+
+Input protetto:
+
+```markdown
+- a
+  - b
+    - c
+      - d
+        - e
+          continuation-e
+```
+
+**Impatto:** perdita silenziosa di contenuto e metadati quando una qualsiasi delle chiamate a `_replace_stack_tail_node` aggiorna un nodo profondo. Il problema non è limitato ai soft-break: lo stesso helper è usato per proprietà, fence, query e finalizzazione delle liste.
+
+**Perché i test non lo vedono:** i test soft-break correnti proteggono casi poco profondi e la coverage di linea esegue l'helper senza verificare l'invariante “ogni aggiornamento allo stack è osservabile dalla root a qualsiasi profondità”.
+
+**Slice minima:** sostituire la propagazione hard-coded a tre livelli con una ricostruzione iterativa dal leaf alla root, senza cambiare classificazione delle linee o semantica del parser.
+
+**Test obbligatori:** profondità 1, 2, 3, 4, 8 e 32; soft-break, proprietà, code fence e lista proprietà; `line_end`; parent/left pointers; UUID; serializzazione e reparse; equivalenza fra shallow e deep nesting.
+
+**Tracking raccomandato:** nuova issue bug dedicata. Collegarla a #104 e rendere il fix un prerequisito della #108.
+
+### P0.2 — Il writer può mutare un file fuori dal vault tramite symlink
+
+**Stato:** vulnerabilità di confinamento corrente; alta confidenza; sovrapposizione diretta con #106.
+
+La discovery accetta Markdown symlinkati sotto `pages/` o `journals/`. `parse_page_file` salva nel nodo `path.resolve()`, cioè il target reale. `append_child_to_node` legge e sostituisce quel `source_path` senza verificare che sia contenuto nel `graph.graph_path`.
+
+Probe eseguito esclusivamente in directory temporanee:
+
+```text
+SYMLINK_SOURCE_OUTSIDE True
+SYMLINK_OUTSIDE_MUTATED True
+```
+
+**Impatto:** un vault non fidato può indurre un'integrazione con permessi locali a modificare un file Markdown esterno al vault.
+
+**Slice minima:** scegliere e documentare una policy symlink fail-closed per tutte le operazioni di scrittura; verificare il target risolto immediatamente prima di leggere e immediatamente prima di `os.replace`; rifiutare mismatch fra root, source registrato e target corrente.
+
+**Test obbligatori:** symlink a file, symlink a directory, cambio symlink fra parse e write, path relativo con traversal, rename race, dry-run senza scrittura, target interno valido.
+
+**Tracking raccomandato:** aggiornare #106 con il probe e questi criteri di accettazione; non duplicare la issue salvo decisione del maintainer.
+
+### P1.1 — `file://` bypassa il confinamento degli asset
+
+**Stato:** difetto di lettura/confinamento corrente; alta confidenza.
+
+`LogseqPage.resolve_asset_path` restituisce immediatamente il path assoluto per URI `file://`, prima del controllo sul `graph_root`. Questo contraddice la documentazione attiva, che dichiara il resolver confinato al vault.
+
+Probe:
+
+```text
+FILE_URI_RESULT /private/etc/passwd
+```
+
+**Impatto:** un documento non fidato può trasformare un token asset in un path locale arbitrario che un adapter a valle potrebbe leggere o ingerire.
+
+**Slice minima:** applicare una sola funzione di canonicalizzazione e containment a tutti i rami, inclusi `file://`, percent-decoding, path Windows e fallback asset. Definire se `file://` interno al vault è supportato o sempre vietato.
+
+**Tracking raccomandato:** nuova issue security separata oppure ampliamento esplicito di #106 da “write boundary” a “filesystem boundary”.
+
+### P1.2 — Backlink obsoleti dopo rinomina incrementale
+
+**Stato:** bug corrente, alta confidenza, vicino a #103 ma non esplicitato nei criteri attuali.
+
+Il full load ricostruisce tutti i backlink. `invalidate_and_reload_page` rimuove i nodi della sola pagina modificata e aggiunge i backlink in uscita della pagina fresca; non ricalcola le chiavi dei link provenienti da pagine non modificate quando cambia il titolo o un alias del target.
+
+Probe:
+
+```text
+RENAME_BACKLINKS 1 1 0
+```
+
+Interpretazione: prima della rinomina esiste un backlink; dopo `Target → Renamed`, la vecchia chiave continua a restituire un risultato e la nuova non ne restituisce nessuno.
+
+**Contratto corretto:** dopo ogni incremental reload, lo snapshot osservabile deve essere semanticamente equivalente a un cold load sullo stesso filesystem.
+
+**Slice minima:** introdurre un risultato di delta che segnali cambi di identità pagina/alias; in quel caso ricostruire gli indici globalmente dipendenti o usare indici reverse-dependency espliciti. Prima ottimizzare la correttezza, poi misurare.
+
+**Tracking raccomandato:** issue figlia della #103 o ampliamento esplicito della stessa; collegare #102 e #110.
+
+### P1.3 — Collisioni titolo/alias possono nascondere una pagina
+
+**Stato:** confermato e già correttamente coperto dalla #102.
+
+Le pagine sono indicizzate in un dizionario title-keyed e gli alias possono rimappare una chiave canonica. Il comportamento è deterministico e il registry evita molti ghost node, ma la perdita di visibilità resta perlopiù un log.
+
+**Azione:** non aprire una nuova iniziativa; implementare diagnostica strutturata, entrambe le path, winner policy stabile e strict mode come già richiesto da #102.
+
+### P1.4 — Writer, watcher e lettori non condividono uno snapshot atomico
+
+**Stato:** rischio architetturale confermato; coperto dalla #103.
+
+Il writer offre `mkstemp` + `os.replace`, che protegge dall'osservazione di file parziali, ma non serializza due read-modify-write concorrenti. L'incremental reload assegna e aggiorna più strutture derivate in passi distinti.
+
+**Azione:** un coordinatore per vault con lock per mutazioni e pubblicazione di un singolo snapshot immutabile. Nessun lock globale di processo.
+
+### P1.5 — Il lint CI è mutante
+
+**Stato:** confermato; coperto dalla #101.
+
+Separare `lint`/`format-check` da `lint-fix`/`format`, aggiungere controllo dirty-tree e mantenere `make all` come gate non mutante.
+
+### P1.6 — Artifact release non qualificato una sola volta
+
+**Stato:** confermato; coperto dalla #105.
+
+Pre-flight, build PyPI e GitHub Release non consumano necessariamente lo stesso wheel/sdist immutabile. Le action usano tag mobili e il VCS override `nltk` è tag-based anziché commit-based.
+
+**Azione:** build once, checksum, artifact attestato, publish exact bytes, release exact bytes; tag/version/changelog coerenti; action pin-nate a SHA.
+
+### P2 — Debito strategico valido ma non urgente quanto i finding precedenti
+
+- #104: corpus di compatibilità e proprietà metamorfica;
+- #107: `py.typed`, policy API e fonte versione;
+- #109: lifecycle documentale, link/snippet checks e numeri generati;
+- #110: diagnostica strutturata;
+- #111: benchmark 1k/10k pagine e budget RSS/p95;
+- #108: estrazione incrementale delle fasi parser solo dopo #104 e il fix P0.1.
+
+## 7. Perché 91% di coverage non equivale a 91% di affidabilità
+
+La suite è forte, ma la coverage di linea non esprime quattro dimensioni decisive:
+
+| Dimensione | Esempio mancante | Tecnica necessaria |
+|---|---|---|
+| Profondità strutturale | aggiornamento leaf a profondità arbitraria | test generativi su alberi e metamorphic depth invariance |
+| Coerenza temporale | incremental reload equivalente al cold load | state-machine test e snapshot oracle |
+| Confine filesystem | symlink, TOCTOU, `file://` | abuse-case fixtures in tmp, path policy centralizzata |
+| Concorrenza | due writer e watcher simultanei | test deterministici con barrier, non sleep casuali |
+
+La metrica target non deve essere “95% coverage” in astratto. Deve essere: **100% degli invarianti critici protetti da oracle semantici**.
+
+## 8. Repository e documentazione — profilo Matryca Knowledge
+
+### 8.1 Baseline normativa e provenance
+
+Questa parte del piano adotta i parametri correnti di
+[`MarcoPorcellato/matryca-knowledge`](https://github.com/MarcoPorcellato/matryca-knowledge)
+alla revisione `7a3ebd8` del 2026-08-06. I riferimenti normativi sono:
+
+- [`ENGINEERING_PRINCIPLES.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/ENGINEERING_PRINCIPLES.md): determinismo prima dell'automazione, evidenze, baseline, test e rollback;
+- [`OKF_SOURCE_GOVERNANCE.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/OKF_SOURCE_GOVERNANCE.md): identità Markdown stabile, link ordinari, entry point e ownership;
+- [`FOUNDATION_GOVERNANCE_OKF_EXECUTION_PLAN.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/FOUNDATION_GOVERNANCE_OKF_EXECUTION_PLAN.md): separazione fra OKF ufficiale e qualità Matryca, livelli MKQ e Gate G6 dedicato al parser;
+- [`SYNC_POLICY.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/SYNC_POLICY.md): sorgenti autorevoli, projection riproducibile, allowlist e rifiuto delle sorgenti dirty.
+
+La baseline OKF esterna registrata da Matryca Knowledge è la specifica Google
+OKF v0.2 al commit `3fcbb9f828c2f23d109c855ee403c3a4c81f3a96`, blob
+`a516d50128f5aa1f5746d1464661a39f7143e875`. Questo repository **non dichiara
+conformità OKF ufficiale**: fino all'implementazione e alla verifica del layer
+ufficiale, il profilo corretto è `matryca_okf_inspired_quality`.
+
+Il repository sorgente resta l'autorità sui propri documenti. Matryca Knowledge
+ne può mantenere una proiezione revisionata e riproducibile, sempre riconducibile
+a repository, commit, path e hash immutabili; la vista Logseq generata non è la
+source of truth.
+
+### 8.2 Stato corrente misurato
+
+Al checkout analizzato:
+
+- sono presenti 39 file Markdown sotto `docs/`, incluso questo report;
+- nessun documento mantenuto usa ancora un vero frontmatter YAML uniforme;
+- `docs/README.md` è l'unico portale documentale esplicito;
+- mancano entry point distinti per macchina, cronologia, decisioni e reference;
+- il repository è registrato in `matryca-knowledge/sources.toml`, ma non espone
+  ancora `okf_entry_points`, quindi il validator corrente non ne può auditare un
+  bundle mantenuto;
+- i report storici e i blueprint sono già distinguibili semanticamente, ma la
+  distinzione non è ancora verificata da metadata e CI.
+
+### 8.3 Punti di forza
+
+- `docs/README.md` separa attivo, storico e design docs.
+- `CLEAN_CODE_ARCHITECTURE.md` esplicita hub, anelli e anti-pattern.
+- `logseq_ast_primer.md` codifica regole di dominio difficili.
+- Le roadmap storiche rendono visibile l'evoluzione per wave.
+- CONTRIBUTING, issue template e Good First Issues offrono un percorso di ingresso reale.
+
+### 8.4 Problemi correnti
+
+- Lo studio del 28 luglio non è tracciato né indicizzato.
+- I numeri test sono hand-maintained e divergono fra README/CONTRIBUTING/COOKBOOK/studi.
+- Documenti “eseguiti”, “attivi”, “storici” e “proposte” non hanno metadata e lifecycle uniformi.
+- Le roadmap sono numerose ma non esiste una sola mappa `Now / Next / Later / Rejected` collegata alle issue correnti.
+- Non esiste un gate offline per link Markdown, anchor, snippet Python e comandi CLI documentati.
+- La documentazione di asset resolution dichiara un confine che il ramo `file://` non rispetta.
+
+### 8.5 Contratto metadata
+
+Solo i documenti mantenuti e dichiarati nell'allowlist devono avere metadata
+obbligatori. Gli archivi non vanno riscritti in massa. Il contratto di transizione
+adotta già la separazione prevista dall'ultima evoluzione di Matryca Knowledge:
+
+```yaml
+type: ArchitectureGuide
+title: Titolo stabile
+description: Descrizione breve e utile alla discovery
+status: draft | stable | deprecated
+classification: canonical | active | historical | generated
+owner: logseq-matryca-parser
+last_verified: YYYY-MM-DD
+verified: YYYY-MM-DD
+stale_after: YYYY-MM-DD
+supersedes: null
+superseded_by: null
+```
+
+`status` è riservato al lifecycle compatibile con OKF v0.2; `classification`
+esprime invece il ruolo Matryca. `last_verified` resta compatibile con il
+validator corrente, mentre `verified` e `stale_after` preparano il modello di
+freshness esplicito. I numeri volatili — test, coverage, versione, numero moduli
+— non devono essere copiati a mano: una routine deterministica li genera oppure
+il testo evita il valore assoluto.
+
+### 8.6 Bundle mantenuto target
+
+| Path | Classificazione | Responsabilità |
+|---|---|---|
+| `docs/index.md` | canonical | Entry point machine-readable e mappa del bundle |
+| `docs/README.md` | canonical | Portale umano e navigazione per audience |
+| `docs/log.md` | active | Cronologia delle evoluzioni documentali verificabili |
+| `docs/decisions/index.md` | canonical | Registro ADR, stato e supersessioni |
+| `docs/reference/index.md` | canonical | Provenance, sorgenti esterne e contratti pubblici |
+| `docs/quality/README.md` | active | Backlog, gate e roadmap di qualità correnti |
+
+I path devono restare stabili; rinomine e split richiedono redirect o link di
+supersessione. I link Markdown ordinari costituiscono gli edge della knowledge
+graph. I riferimenti locali e gli anchor devono essere validati offline. Nessun
+documento pubblico può contenere secret, path locali assoluti, dump runtime o
+log non sanitizzati.
+
+### 8.7 Maturità MKQ e Gate G6
+
+| Livello | Evidenza richiesta nel parser |
+|---|---|
+| MKQ-0 | Sorgente registrata con repository e provenance immutabile |
+| MKQ-1 | Entry point stabile e navigazione del bundle |
+| MKQ-2 | Metadata e freshness sui soli documenti mantenuti |
+| MKQ-3 | Link, anchor, lifecycle, owner canonici e classificazioni coerenti |
+| MKQ-4 | Verifica deterministica in CI dalla repository sorgente |
+| MKQ-5 | Federation, storia e relazioni semantiche; fase successiva, non gate immediato |
+
+Il Gate G6 è raggiunto quando Logseq Matryca Parser arriva a **MKQ-4 senza
+degradare il comportamento Logseq**. La documentazione deve inoltre collegare
+esplicitamente [Matryca Knowledge](https://github.com/MarcoPorcellato/matryca-knowledge)
+e [Matryca Plumber](https://github.com/MarcoPorcellato/matryca-plumber), senza
+trasferire l'autorità dei contenuti fuori dal repository sorgente.
+
+### 8.8 Piano di migrazione documentale
+
+1. Inventariare e classificare i documenti senza modificarne in massa lo storico.
+2. Stabilizzare `docs/index.md`, il portale umano e gli indici decision/reference.
+3. Applicare metadata e ownership a una allowlist iniziale di documenti mantenuti.
+4. Validare link, anchor, lifecycle, canonical role e freshness offline.
+5. Aggiungere un gate CI non mutante e riproducibile dalla sorgente pulita.
+6. Dichiarare gli entry point nel registro di Matryca Knowledge tramite PR separata.
+7. Proiettare solo commit puliti e immutabili; verificare che la vista Logseq non
+   cambi la semantica dei documenti sorgente.
+
+## 9. Strategia di prodotto e API
+
+Posizionamento consigliato:
+
+> Parser e grafo Logseq local-first, deterministici e model-neutral, con export e adapter opzionali; le scritture agentiche sono operazioni esplicite, confinate e verificabili.
+
+### 9.1 Contratti da pubblicare
+
+Separare chiaramente tre compatibilità:
+
+1. **API Python:** import, firme, eccezioni, typing e deprecazioni;
+2. **semantica Logseq:** AST, UUID, gerarchia, proprietà, riferimenti e round-trip;
+3. **CLI:** stdout/stderr, exit code, JSON schema e stabilità dei comandi.
+
+Classificare le superfici come `stable`, `experimental`, `internal`. Gli adapter AI, visualizzazione e watcher restano optional dependencies; il writer resta opt-in.
+
+### 9.2 Cosa non costruire ora
+
+- Nessuna riscrittura big-bang del parser.
+- Nessun plugin registry prima di un adapter protocol tipizzato usato da almeno due integrazioni esterne.
+- Nessun database o motore di ricerca prima che #111 dimostri un collo di bottiglia.
+- Nessuna GUI desktop prima di segnali di adozione di library e CLI.
+- Nessuna promessa “10k+ a 60 FPS” senza benchmark riproducibile.
+- Nessuna orchestrazione LLM proprietaria nel core: il parser deve restare model-neutral.
+- Nessuna nuova modalità permissiva senza diagnostica strutturata.
+
+## 10. Roadmap proposta
+
+### Wave 0 — Contenimento e correttezza (prima di ogni refactor)
+
+| Slice | Priorità | Deliverable | Gate |
+|---|---:|---|---|
+| Propagazione leaf-to-root arbitraria | P0 | Fix chirurgico + test depth matrix | Output semantico invariato per fixture esistenti; deep soft-break preservato |
+| Confinamento writer su symlink | P0 | Policy fail-closed + revalidation | Nessuna fixture può mutare path esterni |
+| Confinamento asset URI | P1 | Path policy unica | Nessun resolver restituisce path esterni |
+| Backlink rename correctness | P1 | Delta identity o rebuild corretto | Incremental snapshot = cold-load snapshot |
+
+### Wave 1 — Trust baseline
+
+- #101 lint e format non mutanti;
+- #107 typing metadata e API stability table;
+- #109 bundle MKQ, status/classification separati, freshness, numeri generati,
+  link/anchor/snippet gate e provenance immutabile;
+- aggiornare #106 con i due abuse case filesystem;
+- aggiornare #103 con rename/backlink equivalence.
+
+### Wave 2 — Safe vault semantics
+
+- #110 diagnostica strutturata;
+- #102 collisioni title/alias con strict mode;
+- #106 dry-run e preview patch;
+- codici diagnostici stabili per recovery, collisioni, confini e reload.
+
+### Wave 3 — Safe automation
+
+- #103 snapshot atomico per vault e mutazioni serializzate;
+- #104 corpus versionato, semantic projection e test metamorfici;
+- test watcher/writer con barrier e failure injection;
+- equivalenza incremental/cold load come gate universale.
+
+### Wave 4 — Release confidence
+
+- #105 build once / publish exact bytes;
+- action pin-nate a SHA;
+- commit pin per VCS dependency;
+- wheel installato in ambiente pulito, `RECORD` e checksum verificati;
+- changelog/tag/version/artifact unificati.
+
+### Wave 5 — Scale qualificata
+
+- #111 generatori offline da 1k e 10k pagine;
+- load, single-page reload, search, backlink, RAG export, RSS e p95;
+- budget registrati per Python 3.12 e 3.13;
+- solo dopo le misure, eventuali indici secondari.
+
+### Wave 6 — Evoluzione architetturale
+
+- #108: estrarre classifier, lexical state, reducer ed enrichment una fase alla volta;
+- nessun cambio visibile senza decisione di compatibilità;
+- ogni slice deve passare corpus, metamorphic suite, benchmark e impact review.
+
+## 11. Backlog agent-ready
+
+### Nuova issue A — `bug(parser): propagate immutable node refreshes through arbitrary depth`
+
+**Scope:** solo `_replace_stack_tail_node`, test parser e changelog se richiesto.  
+**Non scope:** riscrittura di `parse`, nuovi eventi, package split.  
+**Definition of Done:** depth matrix verde; invarianti UUID/order/line range; round-trip semantico; `make all`; 0 cicli; impact review documentata.
+
+### Estensione #106 — `security(writer): reject external symlink targets and unify filesystem confinement`
+
+**Scope:** discovery/write boundary, `file://`, containment centralizzato, dry-run.  
+**Definition of Done:** nessun path esterno viene letto o scritto dai flussi vault-bound; test POSIX e casi Windows normalizzati; typed error e diagnostic code.
+
+### Estensione #103 — `graph: make incremental identity changes cold-load equivalent`
+
+**Scope:** titolo, alias, backlink, lower-title map e registry derivati.  
+**Definition of Done:** per create/edit/rename/delete, la semantic projection dello snapshot incrementale è identica al reload completo.
+
+### Ordine delle issue esistenti
+
+```text
+Nuova bug parser P0
+  ├─> #104 compatibility corpus
+  └─> #108 parser phase extraction
+
+#106 filesystem boundary
+  └─> #110 structured diagnostics
+
+#101 + #107 + #109
+  └─> #105 immutable release
+
+#102 + #103 + #110
+  └─> #104 operational/semantic oracles
+      └─> #111 benchmarks
+          └─> #108 refactor slices
+```
+
+## 12. Metriche di successo
+
+### 30 giorni
+
+- 0 P0 noti aperti senza owner e riproduzione;
+- CI non mutante e dirty-tree check;
+- confine filesystem testato su symlink e `file://`;
+- documentazione mantenuta a MKQ-2 con status/classification separati e senza numeri divergenti;
+- issue #101–#111 etichettate per wave e dipendenze.
+
+### 60 giorni
+
+- incremental reload semanticamente equivalente al cold load;
+- diagnostica JSON stabile per collisioni, riferimenti e filesystem;
+- corpus Logseq versionato con provenance;
+- wheel tipizzato e API stability table pubblica;
+- artifact release costruito una sola volta.
+- bundle documentale a MKQ-3 con link, anchor, lifecycle e canonical role verificati.
+
+### 90 giorni
+
+- benchmark 1k/10k pubblicati con RSS e p95;
+- almeno due integrazioni esterne validate contro il contratto API;
+- zero regressioni degli invarianti su corpus e metamorphic suite;
+- prima estrazione parser completata senza semantic drift.
+- Gate G6: MKQ-4 in CI senza regressioni del comportamento Logseq.
+
+## 13. Comandi di riproduzione e verifica
+
+Baseline:
+
+```bash
+rtk git status --short --branch
+rtk make all
+rtk make vendor-name-check
+rtk uv run coverage report
+rtk git diff --check
+```
+
+Audit code:
+
+```text
+status dell'indice al commit corrente
+query/context sui flussi parser, grafo, writer e watcher
+impact upstream sugli hub protetti
+check(cycles) => cycleCount: 0
+```
+
+I quattro probe runtime sono stati eseguiti su directory temporanee e non su vault reali. Output:
+
+```text
+DEEP_CONTENTS ['a', 'b', 'c', 'd', 'e']
+DEEP_SOFT_BREAK_PRESENT False
+RENAME_BACKLINKS 1 1 0
+SYMLINK_SOURCE_OUTSIDE True
+SYMLINK_OUTSIDE_MUTATED True
+FILE_URI_RESULT /private/etc/passwd
+```
+
+## 14. Limiti e affermazioni non autorizzate
+
+- Non è stato eseguito un benchmark su vault reale o da 10k pagine.
+- Non è stata qualificata una release pubblica né verificato un wheel installato pulito.
+- Non sono state modificate issue, milestone, branch protection o workflow remoti.
+- Lo studio non dimostra compatibilità totale con tutte le versioni Logseq.
+- Il probe symlink dimostra il comportamento su macOS/POSIX; la policy deve includere una matrice Windows.
+- Nessuna raccomandazione autorizza refactor di hub senza nuovo impact review al momento dell'implementazione.
+
+## 15. Decisione finale
+
+La repository non ha bisogno di “più cose”; ha bisogno di rendere **impossibile perdere dati senza segnalarlo**, **impossibile uscire dal vault**, e **misurabile ogni promessa pubblica**.
+
+La traiettoria consigliata è quindi:
+
+```text
+correggere i P0
+→ confinare il filesystem
+→ rendere coerente lo snapshot
+→ congelare la semantica
+→ rendere verificabile il delivery
+→ misurare la scala
+→ refactor incrementale
+```
+
+Se queste wave vengono eseguite nell'ordine indicato, Logseq Matryca Parser può diventare una reference implementation credibile: non perché accumula feature, ma perché offre contratti deterministici, sicurezza locale, regressioni riproducibili e prove di qualità che un integratore può verificare autonomamente.

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -529,7 +529,7 @@ Classificare le superfici come `stable`, `experimental`, `internal`. Gli adapter
 
 ## 11. Backlog agent-ready
 
-### Nuova issue A — `bug(parser): propagate immutable node refreshes through arbitrary depth`
+### [Issue #113](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/113) — `bug(parser): propagate immutable node refreshes through arbitrary depth`
 
 **Scope:** solo `_replace_stack_tail_node`, test parser e changelog se richiesto.  
 **Non scope:** riscrittura di `parse`, nuovi eventi, package split.  
@@ -627,7 +627,10 @@ FILE_URI_RESULT /private/etc/passwd
 
 - Non è stato eseguito un benchmark su vault reale o da 10k pagine.
 - Non è stata qualificata una release pubblica né verificato un wheel installato pulito.
-- Non sono state modificate issue, milestone, branch protection o workflow remoti.
+- La successiva fase di pubblicazione ha aperto la PR #112, creato la issue
+  #113, aggiornato le issue impattate e chiuso solo completati/duplicati
+  documentati nel registro di riconciliazione. Milestone, branch protection e
+  workflow remoti non sono stati modificati.
 - Lo studio non dimostra compatibilità totale con tutte le versioni Logseq.
 - Il probe symlink dimostra il comportamento su macOS/POSIX; la policy deve includere una matrice Windows.
 - Nessuna raccomandazione autorizza refactor di hub senza nuovo impact review al momento dell'implementazione.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,0 +1,33 @@
+---
+type: DecisionIndex
+title: Architecture decision index
+description: Canonical registry of architectural decisions and required ADRs.
+status: draft
+classification: canonical
+audience: maintainers
+owner: logseq-matryca-parser
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2027-02-02
+supersedes: null
+superseded_by: null
+---
+
+# Architecture decision index
+
+The existing architecture guides remain authoritative while formal ADRs are
+introduced incrementally. Do not rewrite historical roadmaps into ADRs.
+
+| Decision area | Current authority | ADR status |
+|---|---|---|
+| Clean Architecture rings and graph API | [`CLEAN_CODE_ARCHITECTURE.md`](../CLEAN_CODE_ARCHITECTURE.md) | Recorded in guide; ADR pending |
+| Logseq AST and synthetic identity | [`logseq_ast_primer.md`](../logseq_ast_primer.md) | ADR pending |
+| Title and alias collision policy | [Issue #102](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/102) | Proposed |
+| Writer/watcher concurrency | [Issue #103](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/103) | Proposed |
+| Filesystem confinement | [Issue #106](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/106) | Proposed |
+| Public API stability | [Issue #107](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/107) | Proposed |
+| Documentation lifecycle and MKQ | [Issue #109](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/109) | Proposed |
+
+Every future ADR must identify owner, status, decision date, supersession links,
+compatibility impact, verification evidence, and rollback.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,40 @@
+---
+type: KnowledgeBundle
+title: Logseq Matryca Parser knowledge bundle
+description: Canonical machine entry point for maintained project knowledge.
+status: stable
+classification: canonical
+audience: maintainers
+owner: logseq-matryca-parser
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2027-02-02
+okf_profile: matryca_okf_inspired_quality
+supersedes: null
+superseded_by: null
+---
+
+# Logseq Matryca Parser knowledge bundle
+
+This is the stable entry point for tools that consume maintained repository
+knowledge. The source repository is authoritative; generated projections are
+navigation layers only.
+
+## Maintained entry points
+
+| Resource | Role |
+|---|---|
+| [Documentation portal](README.md) | Human navigation by audience |
+| [Architecture](CLEAN_CODE_ARCHITECTURE.md) | Canonical architecture and public graph API |
+| [Repository roadmap](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Current evidence-backed improvement plan |
+| [Issue reconciliation](quality/ISSUE_RECONCILIATION_2026-08-06.md) | Current GitHub backlog decisions |
+| [Decision index](decisions/index.md) | Architectural decisions and missing ADRs |
+| [Reference index](reference/index.md) | Provenance and external relations |
+| [Documentation log](log.md) | Chronology of maintained knowledge changes |
+
+## Quality claim
+
+The current target is Matryca quality level **MKQ-4**. This bundle does not
+claim official OKF conformance. Validation must remain offline, deterministic,
+non-mutating, and reproducible from a clean source commit.
+

--- a/docs/log.md
+++ b/docs/log.md
@@ -23,8 +23,9 @@ superseded_by: null
 - Adopted separate OKF lifecycle status and Matryca classification metadata.
 - Added decision, reference, quality, and issue-reconciliation entry points.
 - Removed volatile test totals from active operational guidance.
+- Published draft PR #112, opened parser P0 #113, reconciled the strategic
+  backlog and closed nine completed or duplicate issues with evidence.
 
 Earlier release-specific documentation history remains in
 [`CHANGELOG.md`](../CHANGELOG.md). Historical counts there are release evidence,
 not current quality claims.
-

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,0 +1,30 @@
+---
+type: DocumentationLog
+title: Documentation evolution log
+description: Verifiable chronology for the maintained knowledge bundle.
+status: stable
+classification: active
+audience: maintainers
+owner: logseq-matryca-parser
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2027-02-02
+supersedes: null
+superseded_by: null
+---
+
+# Documentation evolution log
+
+## 2026-08-06
+
+- Added the canonical [knowledge bundle entry point](index.md).
+- Published the [stellar repository audit](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md).
+- Classified the 2026-07-28 study as a superseded historical baseline.
+- Adopted separate OKF lifecycle status and Matryca classification metadata.
+- Added decision, reference, quality, and issue-reconciliation entry points.
+- Removed volatile test totals from active operational guidance.
+
+Earlier release-specific documentation history remains in
+[`CHANGELOG.md`](../CHANGELOG.md). Historical counts there are release evidence,
+not current quality claims.
+

--- a/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
+++ b/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
@@ -11,6 +11,7 @@ verified: 2026-08-06
 stale_after: 2026-09-05
 supersedes: docs/quality/ISSUE_TRIAGE_2026-07.md
 superseded_by: null
+publication_pr: 112
 ---
 
 # GitHub issue reconciliation — 2026-08-06
@@ -18,6 +19,10 @@ superseded_by: null
 This ledger reviews all 37 issues that were open at the audit baseline. A
 closure is justified only by current code, tests or an explicit duplicate;
 runtime behavior without a dedicated regression test remains tracked.
+
+The reconciliation was published in [PR #112](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/112).
+After the actions below, the live backlog contains 29 open issues, including
+the newly filed parser P0.
 
 ## Decisions
 
@@ -60,13 +65,20 @@ runtime behavior without a dedicated regression test remains tracked.
 | #109 | Expand to MKQ-4 | Wave 1 | Bundle, metadata, lifecycle, links and deterministic source CI |
 | #110 | Expand | Wave 2 | Add filesystem and reload diagnostic codes |
 | #111 | Expand | Wave 5 | Include #87 seed and incremental/cold-load correctness budgets |
+| #113 | Opened, priority P0 | Wave 0 | Arbitrary-depth immutable node refresh loses deep updates |
 
-## New issue required
+## GitHub actions applied
 
-Open one dedicated P0 parser bug for immutable node refreshes that fail to
-propagate from arbitrary depth to the root. The issue must include the minimized
-probe, impact result, depth matrix, round-trip invariants and prerequisite links
-to #104 and #108.
+- Opened [#113](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/113)
+  with the minimized probe, impact result, depth matrix, round-trip invariants
+  and prerequisite links to #104 and #108.
+- Closed completed issues #8, #25, #26, #28, #63, #66 and #96 with live
+  implementation/test evidence.
+- Closed #6 as a duplicate of #3 and #97 as a duplicate subset of #89.
+- Added audit dispositions and dependencies to every remaining strategic,
+  product and contributor issue whose scope or priority changed.
+- Expanded #103, #104, #106, #108, #109, #110 and #111 with the new acceptance
+  criteria from the audit.
 
 ## Operating order
 
@@ -82,4 +94,3 @@ deep parser P0 + #106 filesystem boundary
 
 Product RFCs and contributor issues may proceed in parallel only when they do
 not touch protected parser/graph hubs or weaken these gates.
-

--- a/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
+++ b/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
@@ -1,0 +1,85 @@
+---
+type: IssueReconciliation
+title: GitHub issue reconciliation - 2026-08-06
+description: Evidence-backed disposition of every open repository issue after the stellar audit.
+status: stable
+classification: active
+audience: maintainers
+owner: logseq-matryca-parser
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2026-09-05
+supersedes: docs/quality/ISSUE_TRIAGE_2026-07.md
+superseded_by: null
+---
+
+# GitHub issue reconciliation — 2026-08-06
+
+This ledger reviews all 37 issues that were open at the audit baseline. A
+closure is justified only by current code, tests or an explicit duplicate;
+runtime behavior without a dedicated regression test remains tracked.
+
+## Decisions
+
+| Issue | Decision | Wave | Evidence or dependency |
+|---:|---|---|---|
+| #3 | Keep as canonical GUI RFC | Later | Requires adoption evidence and #111 budgets |
+| #4 | Keep; make contract-first | Next | Depends on #107 public API and #110 diagnostics |
+| #5 | Keep as integration epic | Later | Depends on #4, #106, #107 and #110 |
+| #6 | Close as duplicate of #3 | — | Same desktop GUI outcome |
+| #7 | Keep, defer | Later | Measure topology scale under #111 first |
+| #8 | Close completed | Shipped | Obsidian visitor, CLI export, docs and tests exist |
+| #25 | Close completed | Shipped | `docs/COOKBOOK.md` and links exist |
+| #26 | Close completed | Shipped | Docs index, historical warning and contributor link exist |
+| #28 | Close completed | Shipped | Example uses package imports and English operator text |
+| #33 | Keep as bounded contributor feature | Later | No CSV exporter exists |
+| #34 | Keep as draft RFC | Next | RFC exists; approval and implementation slices remain |
+| #63 | Close completed | Shipped | Malformed JSON and wrapper tests exist |
+| #64 | Keep | Next | Strict indentation remains opt-in design work; depends on #104/#110 |
+| #66 | Close completed | Shipped | Missing page and block embeds now both fail-safe to empty |
+| #69 | Keep | Now-small | Italian optional-dependency errors remain in `synapse.py` |
+| #87 | Keep, high priority | Now | Deterministic pathological parser latency; feeds #111 |
+| #88 | Keep | Next | Direct strategy-module tests are still absent |
+| #89 | Keep as canonical graph API test issue | Next | Dedicated boundary tests remain incomplete |
+| #90 | Keep | Next | `examples/run_synapse_rag.py` is absent |
+| #91 | Keep | Next | Direct `kinetic_export` tests are absent |
+| #92 | Keep, narrow to regression protection | Next | Runtime resolves canonical aliases; dedicated alias test is absent |
+| #93 | Keep, narrow to LENS recipe | Next | Broken-ref tip exists; complete visualization recipe is absent |
+| #94 | Keep as test-only | Next | Runtime deduplicates page objects; alias regression test is absent |
+| #95 | Keep | Next | Requested table-driven CLI matrix remains incomplete |
+| #96 | Close completed | Shipped | Current symmetric empty replacement is table-tested |
+| #97 | Close as duplicate of #89 | — | Orphan exclusion is a subset of #89 |
+| #101 | Keep, priority | Wave 1 | CI lint remains mutating |
+| #102 | Keep | Wave 2 | Collision diagnostics and strict mode remain absent |
+| #103 | Expand | Wave 0/3 | Add rename/backlink cold-load equivalence |
+| #104 | Expand | Wave 0/3 | Add arbitrary-depth parser regression matrix |
+| #105 | Keep | Wave 4 | Immutable build-once release lineage remains absent |
+| #106 | Expand, priority | Wave 0 | Add symlink write escape and `file://` read boundary |
+| #107 | Keep | Wave 1 | Typing marker and stability contract remain absent |
+| #108 | Keep blocked by prerequisites | Wave 6 | Begin only after deep parser fix and #104 corpus |
+| #109 | Expand to MKQ-4 | Wave 1 | Bundle, metadata, lifecycle, links and deterministic source CI |
+| #110 | Expand | Wave 2 | Add filesystem and reload diagnostic codes |
+| #111 | Expand | Wave 5 | Include #87 seed and incremental/cold-load correctness budgets |
+
+## New issue required
+
+Open one dedicated P0 parser bug for immutable node refreshes that fail to
+propagate from arbitrary depth to the root. The issue must include the minimized
+probe, impact result, depth matrix, round-trip invariants and prerequisite links
+to #104 and #108.
+
+## Operating order
+
+```text
+deep parser P0 + #106 filesystem boundary
+  -> #103 snapshot correctness + #104 semantic corpus
+  -> #101 + #107 + #109 trust baseline
+  -> #102 + #110 safe diagnostics
+  -> #105 release provenance
+  -> #111 measured scale
+  -> #108 parser phase extraction
+```
+
+Product RFCs and contributor issues may proceed in parallel only when they do
+not touch protected parser/graph hubs or weaken these gates.
+

--- a/docs/quality/README.md
+++ b/docs/quality/README.md
@@ -1,11 +1,28 @@
+---
+type: QualityIndex
+title: Quality and architecture audits
+description: Canonical navigation for current quality plans, triage, and historical audits.
+status: stable
+classification: canonical
+audience: maintainers
+owner: logseq-matryca-parser
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2027-02-02
+supersedes: null
+superseded_by: null
+---
+
 # Quality & architecture audits
 
 Maintainer-facing triage and backlog for Clean Architecture / Clean Code work.
 
 | Document | Purpose |
 |----------|---------|
+| [`ISSUE_RECONCILIATION_2026-08-06.md`](ISSUE_RECONCILIATION_2026-08-06.md) | Current disposition of every open GitHub issue and stellar-roadmap integration |
+| [`../REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](../REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Current repository-wide evidence, priorities and MKQ-4 plan |
 | [`GITHUB_CLEAN_ARCH_ROADMAP.md`](GITHUB_CLEAN_ARCH_ROADMAP.md) | Milestone, project board, epic + phase issues (v1.6) |
-| [`ISSUE_TRIAGE_2026-07.md`](ISSUE_TRIAGE_2026-07.md) | July 2026 backlog triage vs v1.6 track |
+| [`ISSUE_TRIAGE_2026-07.md`](ISSUE_TRIAGE_2026-07.md) | Superseded July 2026 backlog baseline |
 | [`CLEAN_ARCH_BACKLOG.md`](CLEAN_ARCH_BACKLOG.md) | v1 structural debt **complete** — v2 epic (`logos_parser` split) |
 | [`../BUG_HUNT_REPORT.md`](../BUG_HUNT_REPORT.md) | Full bug-hunt report (2026-06) with runtime evidence |
 | [`../CLEAN_CODE_ARCHITECTURE.md`](../CLEAN_CODE_ARCHITECTURE.md) | **SSOT** — rings, module maps, contributor checklist |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,43 @@
+---
+type: ReferenceIndex
+title: Reference and provenance index
+description: Canonical external relations and immutable provenance for maintained documentation.
+status: stable
+classification: canonical
+audience: maintainers
+owner: logseq-matryca-parser
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2027-02-02
+supersedes: null
+superseded_by: null
+---
+
+# Reference and provenance index
+
+## Matryca relations
+
+| Repository | Relationship |
+|---|---|
+| [Matryca Knowledge](https://github.com/MarcoPorcellato/matryca-knowledge) | Federated knowledge projection and MKQ governance; never the source authority for this repository |
+| [Matryca Plumber](https://github.com/MarcoPorcellato/matryca-plumber) | Downstream consumer of parser, graph and CLI contracts |
+
+## Governance baseline
+
+The documentation profile was verified against Matryca Knowledge commit
+[`7a3ebd8`](https://github.com/MarcoPorcellato/matryca-knowledge/commit/7a3ebd8).
+The official OKF v0.2 baseline recorded there is pinned to commit
+`3fcbb9f828c2f23d109c855ee403c3a4c81f3a96` and blob
+`a516d50128f5aa1f5746d1464661a39f7143e875`.
+
+This repository currently declares `matryca_okf_inspired_quality`, not official
+OKF conformance.
+
+## Local contracts
+
+- [Architecture](../CLEAN_CODE_ARCHITECTURE.md)
+- [AST primer](../logseq_ast_primer.md)
+- [Release process](../RELEASE_PROCESS.md)
+- [Security policy](../../SECURITY.md)
+- [Current roadmap](../REPOSITORY_STELLAR_ROADMAP_2026-08-06.md)
+


### PR DESCRIPTION
## Summary

- publishes the evidence-backed repository audit and sequenced stellar roadmap
- aligns documentation governance with Matryca Knowledge at commit `7a3ebd8`
- separates official OKF lifecycle status from Matryca document classification
- adds canonical bundle, decision, reference, chronology, and quality entry points
- reviews every issue open at the 2026-08-06 baseline and records its disposition
- removes volatile test totals from active operational guidance while preserving historical release evidence

## Verified evidence

- 462 tests passed
- Ruff clean
- Mypy clean across 34 source files
- 91.09% coverage
- vendor-neutral documentation check passed
- zero import cycles in `src/`
- four audit probes reproduced: deep parser content loss, symlink write escape, external `file://` resolution, and stale backlinks after incremental rename

## Scope

Documentation and GitHub backlog governance only. No runtime behavior is changed.

- [x] Documentation update
- [x] `make all` passed
- [x] Relevant documentation updated
- [x] No CHANGELOG entry: no shipped runtime behavior

The branch intentionally excludes the local untracked `.serena/` directory.