### PR TITLE
docs: standardize English documentation and governance

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -27,10 +27,10 @@ build/
 *.egg-info/
 
 # =========================
-# Lockfiles (Letali per il Codebase Indexing)
+# Lockfiles (harmful to codebase indexing)
 # =========================
-# I lockfile devono stare su Git, ma l'IA non deve MAI leggerli,
-# sono solo un muro di versioni incomprensibili.
+# Lockfiles belong in Git, but the AI should never read them because they are
+# only a wall of dependency versions with no useful semantic context.
 poetry.lock
 uv.lock
 package-lock.json
@@ -38,36 +38,36 @@ yarn.lock
 pnpm-lock.yaml
 
 # =========================
-# Output AI e Report (Evitare loop di contesto)
+# AI Outputs and Reports (avoid context loops)
 # =========================
-# Se committi per sbaglio un output, non vogliamo che Cursor lo studi.
+# If an output is committed accidentally, keep it out of the code index.
 repomix-output.*
 output_langchain/
 mappa_cervello.html
 
 # =========================
-# Dati di Test e Fixtures Mock
+# Test Data and Mock Fixtures
 # =========================
-# Se hai dei file Markdown o JSON enormi che usi solo per testare il parser,
-# a Git servono, ma all'IA confondono solo le idee.
+# Large Markdown or JSON fixtures may belong in Git for parser tests, but they
+# should not consume indexing context.
 tests/fixtures/*.json
 tests/fixtures/*.edn
 tests/fixtures/*.md
 *.csv
 
 # =========================
-# Assets Vettoriali
+# Vector Assets
 # =========================
-# Le immagini PNG/JPG Cursor le ignora da solo, ma gli SVG sono file di testo!
-# Se l'IA legge un SVG, legge migliaia di coordinate matematiche inutili.
+# PNG and JPG files are ignored automatically, while SVG files are text and can
+# add thousands of irrelevant coordinate values to the index.
 *.svg
 
 # =========================
-# File di Configurazione Editor
+# Editor Configuration Files
 # =========================
 .vscode/
 .idea/
 .clinerules
 
-# Esclude lo storico delle metriche per preservare il contesto LLM
+# Exclude historical metrics to preserve LLM context.
 metrics/history.json

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,5 +1,5 @@
 # .cursorignore
-# (Nota: Cursor ignora già automaticamente tutto ciò che è nel .gitignore)
+# Note: Cursor already ignores everything listed in .gitignore.
 
 # =========================
 # Python & Virtual Environments

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Mantiene aggiornate le dipendenze Python (legge il pyproject.toml)
+  # Keep Python dependencies current (reads pyproject.toml).
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Mantiene aggiornate le GitHub Actions (legge il tuo .github/workflows/ci.yml)
+  # Keep GitHub Actions current (reads .github/workflows/ci.yml).
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/daily-metrics.yml
+++ b/.github/workflows/daily-metrics.yml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 
 env:
-  # Forza l'ambiente di esecuzione su Node.js 24 per prevenire i warning di deprecazione di giugno 2026
+  # Force the Node.js 24 runtime to prevent the June 2026 deprecation warnings.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/.github/workflows/daily-metrics.yml
+++ b/.github/workflows/daily-metrics.yml
@@ -2,8 +2,8 @@ name: Daily Metrics Saver
 
 on:
   schedule:
-    - cron: '0 3 * * *' # Gira ogni giorno alle 03:00 UTC
-  workflow_dispatch: # Permette l'avvio manuale con un click
+    - cron: '0 3 * * *' # Runs daily at 03:00 UTC.
+  workflow_dispatch: # Allows one-click manual runs.
 
 concurrency:
   group: daily-metrics-${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Ghost Tooling** — removed remaining vendor indexer blocks from `AGENTS.md` / `CLAUDE.md`; maintainer guidance now uses **audit code** terminology only.
+- **Repository language** — translated the historical audit reports, design references, Logseq Read skill, maintainer configuration comments, parser warning, demo labels, and optional SYNAPSE dependency errors into English; contributor guidance now makes English the repository default ([#69](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/69)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Documentation system guide** — [`docs/DOCUMENTATION_SYSTEM.md`](docs/DOCUMENTATION_SYSTEM.md) explains source authority, maintained versus historical surfaces, metadata, freshness, validation, the Matryca Knowledge projection workflow, and the repository's documentation evolution.
 - **Synapse RAG example** — [`examples/run_synapse_rag.py`](examples/run_synapse_rag.py) demonstrates all four `SynapseAdapter` methods (`to_langchain_documents`, `to_llamaindex_nodes`, `to_context_enriched_chunks`, `_expand_macros_and_embeds`) plus table-driven embed expansion edge cases.
 - **Embed expansion edge-case tests** — `TestEmbedExpansionEdgeCases` in [`tests/test_synapse.py`](tests/test_synapse.py) covers cycles, missing targets, and happy-path for both `{{embed [[Page]]}}` and `{{embed ((uuid))}}` (closes [#71](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/71)).
 - **Contributor onboarding (wave 4)** — ten new Good First Issues (GFI-39…GFI-48) filed on GitHub ([#88](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/88)–[#97](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/97)); index updated in [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md).
 
 ### Changed
 
+- **Federated documentation profile** — aligned the maintained bundle with Matryca Knowledge `origin/main` at `7a3ebd8`, separating OKF lifecycle from Matryca classification and recording authority, freshness, provenance, and the still-pending private registry activation.
 - **Ghost Tooling** — removed remaining vendor indexer blocks from `AGENTS.md` / `CLAUDE.md`; maintainer guidance now uses **audit code** terminology only.
 - **Repository language** — translated the historical audit reports, design references, Logseq Read skill, maintainer configuration comments, parser warning, demo labels, and optional SYNAPSE dependency errors into English; contributor guidance now makes English the repository default ([#69](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/69)).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,16 @@ User-facing behavior is documented in:
 - [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) — curated starter tasks for new contributors
 - [`docs/COOKBOOK.md`](docs/COOKBOOK.md) — integration recipes (Synapse, graph query, watcher)
 - [`docs/README.md`](docs/README.md) — documentation index (active vs historical)
+- [`docs/DOCUMENTATION_SYSTEM.md`](docs/DOCUMENTATION_SYSTEM.md) — documentation authority, metadata, lifecycle, validation, and federation workflow
 - [`docs/rfc/OLLAMA_RAG.md`](docs/rfc/OLLAMA_RAG.md) — draft RFC for Ollama local RAG ([#34](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/34))
 - [`docs/quality/`](docs/quality/) — architecture backlog, GitHub roadmap (v1.6), triage
 - [`docs/internal/STATIC_ANALYSIS_POLICY.md`](docs/internal/STATIC_ANALYSIS_POLICY.md) — Ghost Tooling policy (vendor-agnostic CI and public docs)
 
 When you add or change observable parser or graph behavior, update the relevant doc sections and add a bullet under **`## [Unreleased]`** in `CHANGELOG.md` (see [`.cursor/rules/05-auto-changelog.mdc`](.cursor/rules/05-auto-changelog.mdc)).
+
+For documentation changes, first classify the target as maintained, active,
+historical, or generated. Follow the metadata, freshness, supersession, and
+projection rules in [`docs/DOCUMENTATION_SYSTEM.md`](docs/DOCUMENTATION_SYSTEM.md).
 
 ### Repository language
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,15 @@ User-facing behavior is documented in:
 
 When you add or change observable parser or graph behavior, update the relevant doc sections and add a bullet under **`## [Unreleased]`** in `CHANGELOG.md` (see [`.cursor/rules/05-auto-changelog.mdc`](.cursor/rules/05-auto-changelog.mdc)).
 
+### Repository language
+
+Use English for documentation, changelog entries, issue and pull-request text,
+code comments, log messages, CLI help, and maintainer-facing configuration.
+Non-English text is appropriate only when it is the data under test, a quoted
+source title, or an intentionally localized runtime fixture. Generated repository
+packs are read-only snapshots: regenerate them from their source files instead of
+editing their embedded copies.
+
 ### Tooling policy
 
 CI and automation in this repository are limited to the core runtime and standard open-source linters (Ruff, Mypy, Pytest, CodeQL). Do not add third-party AST indexers, experimental analysis scripts, or custom MCP servers to the public tree, workflows, or `pyproject.toml`. See [`docs/internal/STATIC_ANALYSIS_POLICY.md`](docs/internal/STATIC_ANALYSIS_POLICY.md).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 [👉 **TRY THE LIVE INTERACTIVE DEMO**](https://MarcoPorcellato.github.io/logseq-matryca-parser/)
 
-[📘 **ARCHITECTURE**](docs/ARCHITECTURE.md) · [Clean Architecture SSOT](docs/CLEAN_CODE_ARCHITECTURE.md) · [AST Primer](docs/logseq_ast_primer.md) · [Cookbook](docs/COOKBOOK.md) · [Good first issues](docs/GOOD_FIRST_ISSUES.md) · [Knowledge bundle](docs/index.md) · [Docs index](docs/README.md) · [CodeQL](docs/CODEQL.md) · [Changelog](CHANGELOG.md) · [Release process](docs/RELEASE_PROCESS.md)
+[📘 **ARCHITECTURE**](docs/ARCHITECTURE.md) · [Clean Architecture SSOT](docs/CLEAN_CODE_ARCHITECTURE.md) · [AST Primer](docs/logseq_ast_primer.md) · [Cookbook](docs/COOKBOOK.md) · [Good first issues](docs/GOOD_FIRST_ISSUES.md) · [Knowledge bundle](docs/index.md) · [Docs index](docs/README.md) · [Documentation system](docs/DOCUMENTATION_SYSTEM.md) · [CodeQL](docs/CODEQL.md) · [Changelog](CHANGELOG.md) · [Release process](docs/RELEASE_PROCESS.md)
 
 </div>
 
@@ -470,6 +470,7 @@ We welcome issues, pull requests, and constructive feedback.
 | **Contributing** | [CONTRIBUTING.md](CONTRIBUTING.md) — setup, tests, PR workflow |
 | **Cookbook** | [docs/COOKBOOK.md](docs/COOKBOOK.md) — integration recipes (Synapse, graph query, watcher) |
 | **Documentation index** | [docs/README.md](docs/README.md) — active vs historical docs |
+| **Documentation system** | [docs/DOCUMENTATION_SYSTEM.md](docs/DOCUMENTATION_SYSTEM.md) — authority, lifecycle, metadata, and federation |
 | **Code of Conduct** | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community standards |
 | **Security** | [SECURITY.md](SECURITY.md) — report vulnerabilities privately |
 

--- a/claude-skill-logseq-read/SKILL.md
+++ b/claude-skill-logseq-read/SKILL.md
@@ -1,82 +1,82 @@
 ---
 name: logseq-read
-description: "Legge e interroga la knowledge base Logseq personale dell'utente (appunti, note, journal, task). Il percorso del graph si configura con la variabile d'ambiente LOGSEQ_GRAPH_PATH oppure con il placeholder predefinito nello script (vedi sotto). USA sempre questa skill prima di rispondere a domande sulle note personali, la conoscenza, i progetti o i task — non inventare dalla memoria. Attivala quando l'utente chiede di una persona, progetto o argomento nelle note (\"leggi le note su X\", \"cosa so su Y\", \"chi è X\"); chiede cosa ha da fare (\"cosa ho da fare\", \"TODO aperti\", \"task in sospeso\"); chiede il journal di oggi o del passato (\"journal di oggi\", \"cosa ho fatto ieri\"); vuole cercare nelle note (\"cerca nelle note\", \"dove ho scritto di X\"); vuole elencare pagine o graph. Attivala anche per domande su lavoro, clienti, progetti o piani personali."
+description: "Read and query the user's personal Logseq knowledge base (notes, journals, tasks). The graph path is configured via the LOGSEQ_GRAPH_PATH environment variable or the default placeholder in the script (see below). Always use this skill before answering questions about personal notes, knowledge, projects, or tasks—never hallucinate missing data. Activate it when the user asks about a person, project, or topic in the notes (\"read notes about X\", \"what do I know about Y\", \"who is X\"); asks for tasks (\"what do I need to do\", \"open TODOs\", \"tasks in progress\"); asks for today's or historical journal (\"today's journal\", \"what I did yesterday\"); wants to search notes (\"search notes\", \"where did I write about X\"); wants to list pages or graph. Also use it for questions about work, customers, projects, or personal plans."
 ---
 
 # Logseq Read
 
-Skill per leggere il graph Logseq dell'utente mantenendo gerarchia, wikilink, tag, proprietà e stato dei task.
+Skill for reading the user's Logseq graph while preserving hierarchy, wikilinks, tags, properties, and task state.
 
-**Graph path:** `/path/to/your/logseq/graph` (oppure imposta la variabile d'ambiente `LOGSEQ_GRAPH_PATH` sul percorso assoluto del tuo graph Logseq prima di eseguire lo script)
-- `pages/` → note su persone, progetti, argomenti
-- `journals/` → diari giornalieri (`YYYY_MM_DD.md`)
+**Graph path:** `/path/to/your/logseq/graph` (or set the `LOGSEQ_GRAPH_PATH` environment variable to the absolute path of your Logseq graph before running the script)
+- `pages/` → notes about people, projects, and topics
+- `journals/` → daily journals (`YYYY_MM_DD.md`)
 
 ---
 
-## Esecuzione
+## Execution
 
-Il percorso base di questa skill è indicato nell'intestazione "Base directory for this skill:" all'inizio di questo documento in Claude Desktop. Usa quel percorso per lo script:
+The base path for this skill is shown in the header `Base directory for this skill:` at the top of this document in Claude Desktop. Use that path in the script:
 
 ```bash
 python "/SKILL_BASE_DIR/scripts/parse_logseq.py" <ARGS>
 ```
 
-Sostituisci `/SKILL_BASE_DIR` con il percorso base estratto dall'intestazione.
+Replace `/SKILL_BASE_DIR` with the base path extracted from the header.
 
 ---
 
-## Comandi disponibili
+## Available commands
 
-| Argomento | Quando usarlo |
+| Topic | When to use |
 |-----------|--------------|
-| `--page "Nome"` | Leggi una pagina (persona, progetto, argomento) |
-| `--journal today` | Journal di oggi |
-| `--journal 2026-05-15` | Journal di una data specifica (ISO) |
-| `--todos` | Tutti i task aperti (TODO/DOING/LATER) da tutte le note |
-| `--search "termine"` | Ricerca full-text in tutte le note |
-| `--list` | Lista tutte le pagine e i journal disponibili |
+| `--page "Name"` | Read one page (person, project, topic) |
+| `--journal today` | Today's journal |
+| `--journal 2026-05-15` | Journal for a specific date (ISO) |
+| `--todos` | All open tasks (TODO/DOING/LATER) across all notes |
+| `--search "term"` | Full-text search across all notes |
+| `--list` | List all available pages and journals |
 
 ---
 
-## Come mappare la richiesta dell'utente
+## How to map user requests
 
-- *"leggi le note su [nome/progetto]"* → `--page "[nome]"`
-- *"cosa ho da fare / task aperti / TODO"* → `--todos`
-- *"journal di oggi / cosa ho fatto oggi"* → `--journal today`
-- *"journal del [data verbale o ISO]"* → `--journal YYYY-MM-DD`
-- *"cerca [termine] nelle note"* → `--search "[termine]"`
-- *"quali pagine ho / lista note"* → `--list`
-- Domanda su una persona o progetto specifico → `--page "[nome]"`
+- *"read notes about [person/project]"* → `--page "[name]"`
+- *"what do I need to do / open tasks / TODO"* → `--todos`
+- *"today's journal / what I did today"* → `--journal today`
+- *"journal for [spoken date or ISO]"* → `--journal YYYY-MM-DD`
+- *"search [term] in notes"* → `--search "[term]"`
+- *"which pages do I have / list notes"* → `--list`
+- Question about a specific person or project → `--page "[name]"`
 
-Se la richiesta è ambigua, inizia con `--list` per mostrare le pagine disponibili, poi leggi quella pertinente.
-
----
-
-## Struttura dell'output
-
-Lo script restituisce markdown strutturato con:
-- **Proprietà** della pagina (`title::`, `tags::`, `type::`, `status::`, ecc.)
-- **Gerarchia** dei bullet point preservata (indentazione = profondità)
-- **Task** con stato: `TODO`, `DOING`, `DONE`, `LATER`
-- **Wikilink** come `[[Nome Pagina]]`
-- **Scheduled** e annotazioni temporali
+If the request is ambiguous, start with `--list` to show available pages, then read the relevant one.
 
 ---
 
-## Come usare l'output
+## Output structure
 
-1. Leggi le note con il comando appropriato
-2. Rispondi alla domanda dell'utente sintetizzando le informazioni rilevanti
-3. Cita sempre task aperti se presenti e pertinenti alla domanda
-4. Se nell'output ci sono `[[Wikilink]]` a pagine correlate, offriti di leggerle anche quelle con `--page`
-5. Non inventare mai informazioni non presenti nelle note — citale o ammetti che non ci sono
+The script returns structured markdown containing:
+- **Properties** of the page (`title::`, `tags::`, `type::`, `status::`, etc.)
+- **Hierarchy** of bullet points preserved (indentation = depth)
+- **Tasks** with state: `TODO`, `DOING`, `DONE`, `LATER`
+- **Wikilink** as `[[Page Name]]`
+- **Scheduled** items and timeline annotations
 
 ---
 
-## Setup automatico
+## How to use the output
 
-Lo script installa `logseq-matryca-parser` automaticamente se mancante.
-In caso di errore di installazione, esegui manualmente:
+1. Read notes with the appropriate command
+2. Respond to the user question by summarizing relevant information
+3. Always include open tasks if they are present and relevant
+4. If output includes `[[Wikilink]]` to related pages, offer to read those pages too with `--page`
+5. Never invent information not present in the notes—cite it or say it is missing
+
+---
+
+## Automatic setup
+
+The script installs `logseq-matryca-parser` automatically if missing.
+If installation fails, install manually with:
 
 ```bash
 uv pip install logseq-matryca-parser

--- a/claude-skill-logseq-read/scripts/parse_logseq.py
+++ b/claude-skill-logseq-read/scripts/parse_logseq.py
@@ -4,7 +4,7 @@ Parse Logseq notes and return structured content for Claude.
 Part of the logseq-read skill.
 
 Usage:
-  parse_logseq.py --page "Progetto Alpha"
+  parse_logseq.py --page "Project Alpha"
   parse_logseq.py --journal today
   parse_logseq.py --journal 2026-05-15
   parse_logseq.py --todos
@@ -51,15 +51,15 @@ def format_node(node, depth=0) -> list[str]:
         icon = TASK_ICONS.get(task, task)
         text = f"{icon} {text}"
 
-    # Wikilink e tag estratti dal parser ma omessi dal prompt predefinito per
-    # risparmiare token nel contesto; si possono concatenare a `text` se servono.
+    # Wikilinks and tags are extracted by the parser but omitted from the default
+    # prompt to save context tokens; append them to `text` when needed.
     _wikilinks = getattr(node, "wikilinks", []) or []
     _tags = getattr(node, "tags", []) or []
 
-    # Numero di riga 1-based nel file sorgente (logseq-matryca-parser v0.2.2+):
-    # consente citazioni precise nei riferimenti LLM, es. "[Riga 42] ...".
+    # One-based line number in the source file (logseq-matryca-parser v0.2.2+),
+    # enabling precise citations in LLM references, for example "[Line 42] ...".
     line_start = getattr(node, "line_start", None)
-    line_prefix = f"[Riga {line_start}] " if line_start is not None else ""
+    line_prefix = f"[Line {line_start}] " if line_start is not None else ""
 
     lines = [f"{indent}- {line_prefix}{text}"]
 
@@ -118,8 +118,8 @@ def cmd_page(name: str) -> str:
             for f in PAGES_PATH.glob("*.md")
         )
         return (
-            f"Nessuna pagina trovata per '{name}'.\n\n"
-            f"Pagine disponibili: {', '.join(all_pages)}"
+            f"No page found for '{name}'.\n\n"
+            f"Available pages: {', '.join(all_pages)}"
         )
 
     parts = []
@@ -140,15 +140,15 @@ def cmd_journal(date_arg: str) -> str:
         try:
             target = date.fromisoformat(date_arg)
         except ValueError:
-            return f"Formato data non valido: '{date_arg}'. Usa YYYY-MM-DD o 'today'."
+            return f"Invalid date format: '{date_arg}'. Use YYYY-MM-DD or 'today'."
 
     path = JOURNALS_PATH / f"{target.year}_{target.month:02d}_{target.day:02d}.md"
     if not path.exists():
         available = sorted(JOURNALS_PATH.glob("*.md"), reverse=True)[:5]
         nearby = [f.stem.replace("_", "-") for f in available]
         return (
-            f"Nessun journal per {target}.\n\n"
-            f"Journal recenti: {', '.join(nearby)}"
+            f"No journal found for {target}.\n\n"
+            f"Recent journals: {', '.join(nearby)}"
         )
 
     return f"# Journal {target}\n\n{format_page(path)}"
@@ -183,9 +183,9 @@ def cmd_todos() -> str:
             results[section] = file_todos
 
     if not results:
-        return "Nessun task aperto trovato."
+        return "No open tasks found."
 
-    lines = ["# Task aperti\n"]
+    lines = ["# Open tasks\n"]
     for section, todos in results.items():
         lines.append(f"### {section}")
         lines.extend(todos)
@@ -224,9 +224,9 @@ def cmd_search(query: str) -> str:
             results.extend(matches)
 
     if not results:
-        return f"Nessun risultato per '{query}'."
+        return f"No results for '{query}'."
 
-    return f"# Ricerca: '{query}'\n" + "\n".join(results)
+    return f"# Search: '{query}'\n" + "\n".join(results)
 
 
 def cmd_list() -> str:
@@ -237,7 +237,7 @@ def cmd_list() -> str:
     lines.append("## Pages")
     for p in pages:
         lines.append(f"- {p.stem.replace('___', '/').replace('_', ' ')}")
-    lines.append("\n## Journal (ultimi 15)")
+    lines.append("\n## Journals (latest 15)")
     for j in journals:
         lines.append(f"- {j.stem.replace('_', '-')}")
 
@@ -250,11 +250,11 @@ def cmd_list() -> str:
 def main():
     parser = argparse.ArgumentParser(description="Parse Logseq notes for Claude.")
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--page", metavar="NAME", help="Leggi una pagina per nome")
-    group.add_argument("--journal", metavar="DATE", help="Leggi journal: 'today' o YYYY-MM-DD")
-    group.add_argument("--todos", action="store_true", help="Lista tutti i task aperti")
-    group.add_argument("--search", metavar="QUERY", help="Ricerca full-text")
-    group.add_argument("--list", action="store_true", help="Lista tutte le pagine")
+    group.add_argument("--page", metavar="NAME", help="Read a page by name")
+    group.add_argument("--journal", metavar="DATE", help="Read a journal: 'today' or YYYY-MM-DD")
+    group.add_argument("--todos", action="store_true", help="List all open tasks")
+    group.add_argument("--search", metavar="QUERY", help="Run a full-text search")
+    group.add_argument("--list", action="store_true", help="List all pages")
 
     args = parser.parse_args()
     ensure_installed()

--- a/docs/BUG_HUNT_REPORT.md
+++ b/docs/BUG_HUNT_REPORT.md
@@ -1,53 +1,53 @@
 # Bug Hunt Report — logseq-matryca-parser
 
-**Data:** 2026-06-23 (audit) · **Risoluzione:** 2026-06-23  
-**Scope:** audit statico + dinamico del repository (The Logos Protocol)  
-**Strumenti:** analisi statica locale (graph-based), `make all`, `scripts/debug_pre_release.py`, probe Python ad hoc  
-**Riferimenti architetturali:** [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) (R. C. Martin), [`ARCHITECTURE.md`](ARCHITECTURE.md)
+**Date:** 2026-06-23 (audit) · **Resolution:** 2026-06-23
+**Scope:** static + dynamic repository audit (The Logos Protocol)
+**Tools:** local graph-based static analysis, `make all`, `scripts/debug_pre_release.py`, ad-hoc Python probes
+**Architecture references:** [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) (R. C. Martin), [`ARCHITECTURE.md`](ARCHITECTURE.md)
 
-> **Stato risoluzione (2026-06-23):** tutti i **BUG-001…031** e le limitazioni **LIM-001/002** sono stati affrontati nel codice (vedi `CHANGELOG.md` **v1.4.0**). **DEBT-001** (`iter_canonical_pages`, `page_for_node`) è implementato; debito architetturale residuo (SRP su `kinetic.py`, OCP embed strategy) resta backlog non bloccante.
+> **Resolution status (2026-06-23):** all **BUG-001…031** and limitations **LIM-001/002** were addressed in code (see `CHANGELOG.md` **v1.4.0**). **DEBT-001** (`iter_canonical_pages`, `page_for_node`) is implemented; residual architectural debt (SRP in `kinetic.py`, OCP embed strategy) remains as non-blocking backlog.
 >
-> **Aggiornamento test (2026-06-24, v1.4.1):** GFI-04 (`logseq_paths` fallback), GFI-14 (`normalize_logseq_timestamp`), GFI-03/05/06/09/12/13 e suite totale **378** pytest — vedi `CHANGELOG.md` **v1.4.1**.
+> **Test update (2026-06-24, v1.4.1):** GFI-04 (`logseq_paths` fallback), GFI-14 (`normalize_logseq_timestamp`), GFI-03/05/06/09/12/13 and total suite **378** pytest — see `CHANGELOG.md` **v1.4.1**.
 
 ---
 
 ## 1. Executive summary
 
-| Metrica | Esito |
+| Metric | Result |
 | :--- | :--- |
 | `make all` (Ruff + Mypy + 378 pytest) | **PASS** |
-| Coverage | **90.18%** (soglia 80%; **378** pytest, v1.4.1) |
+| Coverage | **90.18%** (threshold 80%; **378** pytest, v1.4.1) |
 | Round-trip corpus (`debug_pre_release.py`) | **19/19 OK** |
-| analisi statica `check` (cicli IMPORTS) | **0 cicli** |
-| analisi statica index | `logseq-matryca-parser` — 1074 embeddings, commit `7d3f77b` |
+| Static `check` analysis (IMPORT cycles) | **0 cycles** |
+| Static index analysis | `logseq-matryca-parser` — 1074 embeddings, commit `7d3f77b` |
 
-Nonostante la suite verde, l’analisi guidata da analisi statica e da probe runtime ha individuato **31 bug/issue ID** (3 Critical parser-crash, 15 Medium/High, 13 Low) e debiti architetturali (violazione *Interface Segregation* su `graph.pages`).
+Despite a green suite, static analysis and runtime probes identified **31 bug/issue IDs** (3 Critical parser crashes, 15 Medium/High, 13 Low) and architectural debt (Interface Segregation violation on `graph.pages`).
 
-**Priorità immediata:** (1) **BUG-017** — `IndexError` su bullet vuoto + proprietà (crash `load_directory` / `scan`); (2) SYNAPSE embed hang (BUG-001); (3) collisione titoli in `load_directory` (BUG-010/013); (4) **grafo in-memory stale dopo `agent-write`** (BUG-016); (5) delete-safe invalidate (BUG-005).
+**Immediate priority:** (1) **BUG-017** — `IndexError` on empty bullet + properties (crash in `load_directory` / `scan`); (2) SYNAPSE embed hang (BUG-001); (3) title collisions in `load_directory` (BUG-010/013); (4) **in-memory graph stale after `agent-write`** (BUG-016); (5) delete-safe invalidate (BUG-005).
 
-**Wave 2 (2026-06-23):** +4 bug confermati via analisi statica `query` su `_enrich_pages_index` / `invalidate_and_reload_page` e probe alias-heavy vaults.
+**Wave 2 (2026-06-23):** +4 confirmed bugs via static `query` analysis on `_enrich_pages_index` / `invalidate_and_reload_page` and alias-heavy vault probes.
 
-**Wave 3 (2026-06-23):** +3 bug confermati via analisi statica `context(load_directory)`, `impact(get_node_by_embed_ref)`, `query(append_child_to_node)` — integrità indice graph e headless writer.
+**Wave 3 (2026-06-23):** +3 confirmed bugs via static `context(load_directory)`, `impact(get_node_by_embed_ref)`, `query(append_child_to_node)` — graph index integrity and headless writer.
 
-**Wave 4 (2026-06-23):** +4 bug via analisi statica `query(forge/agent_write)`, `context(LogseqGraphWatcher)` — grafo in-memory stale, watcher incompleto, `title::` collision cross-file.
+**Wave 4 (2026-06-23):** +4 bugs via static `query(forge/agent_write)`, `context(LogseqGraphWatcher)` — stale in-memory graph, incomplete watcher, cross-file `title::` collision.
 
-**Wave 5–6 (2026-06-23):** +4 bug via analisi statica `impact(_refresh_node)` risk **CRITICAL**, probe `load_directory` / `_parse_graph` / LENS / SYNAPSE — crash parser su outline Logseq reale, metadata RAG errati, statistiche LENS duplicate.
+**Wave 5–6 (2026-06-23):** +4 bugs via static `impact(_refresh_node)` risk **CRITICAL**, probes on `load_directory` / `_parse_graph` / LENS / SYNAPSE — parser crash on real Logseq outline, incorrect RAG metadata, duplicate LENS statistics.
 
-**Wave 7 (2026-06-23):** +5 bug via analisi statica `impact(search_content)` → `agent_read`, probe serialize / export markdown / ghost registry — round-trip 4 spazi, nodi orfani in search/agent-read/RAG, export markdown duplicato, `strict_refs` solo same-page.
+**Wave 7 (2026-06-23):** +5 bugs via static `impact(search_content)` → `agent_read`, serialize/export markdown/ghost registry probes — 4-space round-trip, orphan nodes in search/agent-read/RAG, duplicate markdown export, `strict_refs` only same-page.
 
-**Wave 8 (2026-06-23):** +6 bug via analisi statica `query(resolve_relative_page_link)`, `query(agent_press)`, probe backlink/namespace/tag case, `_export_json`, `resolve_asset_path` — chiusura mappatura moduli core.
+**Wave 8 (2026-06-23):** +6 bugs via static `query(resolve_relative_page_link)`, `query(agent_press)`, namespace/tag/backlink case probes, `_export_json`, `resolve_asset_path` — completion of core module mapping.
 
-**Wave 9–10 (2026-06-29):** issue GitHub [#59](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/59)–[#71](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/71) — LENS ghost wikilinks, X-Ray state corrupto, SYNAPSE cyclic embed / unresolved semantics, kinetic dead code, watcher DIP, DX inglese, OCP embed refactor. Vedi `CHANGELOG.md` [Unreleased].
+**Wave 9–10 (2026-06-29):** GitHub issues [#59](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/59)–[#71](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/71) — LENS ghost wikilinks, corrupted X-Ray state, SYNAPSE cyclic embed / unresolved semantics, kinetic dead code, watcher DIP, English DX, OCP embed refactor. See `CHANGELOG.md` [Unreleased].
 
-**Wave 11 (2026-06-29):** [#72](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/72) — `append_child_to_node` corrompe il Markdown quando l'ultima riga del file sorgente **non** termina con `\n` (splice sulla stessa riga → outline corrotto dopo `agent-write`). Probe: `impact(append_child_to_node)` → CLI `agent_write`. Paired test issue [#73](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/73).
+**Wave 11 (2026-06-29):** [#72](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/72) — `append_child_to_node` corrupts markdown when the source file last line **does not** end with `\n` (same-line splice → corrupted outline after `agent-write`). Probe: `impact(append_child_to_node)` → CLI `agent_write`. Paired test issue [#73](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/73).
 
 ---
 
-## 2. Metodologia (Clean Architecture lens)
+## 2. Methodology (Clean Architecture lens)
 
-### 2.1 Anelli concentrici del progetto
+### 2.1 Project concentric layers
 
-Il codice mappa ragionevolmente sugli anelli di Clean Architecture:
+The code maps reasonably to Clean Architecture rings:
 
 ```mermaid
 flowchart TB
@@ -81,241 +81,241 @@ flowchart TB
     KN --> FG
 ```
 
-**Regola delle dipendenze:** le frecce puntano verso l’interno. Violazioni osservate (vedi §6) sono concentrate negli adapter che aggirano API pubbliche del dominio.
+**Dependency rule:** arrows point inward. Observed violations (see §6) are concentrated in adapters that bypass public domain APIs.
 
-### 2.2 Pipeline di indagine
+### 2.2 Investigation pipeline
 
-1. **Bootstrap analisi statica locale** — `check(cycles)`, `query`, `impact`, `context` su `StackMachineParser`, `serialize_logseq_page`, `LogseqGraph`, `logseq_agent_write`.
-2. **Gate qualità** — `make all`.
-3. **Corpus round-trip** — `uv run python scripts/debug_pre_release.py`.
-4. **Probe mirati** — script Python isolati con `SIGALRM` per rilevare hang; confronto semantico settimane ISO vs `%W`.
-5. **Mappatura coverage** — linee non coperte vs rischio (vedi §7).
+1. **Local static analysis bootstrap** — `check(cycles)`, `query`, `impact`, `context` on `StackMachineParser`, `serialize_logseq_page`, `LogseqGraph`, `logseq_agent_write`.
+2. **Quality gate** — `make all`.
+3. **Round-trip corpus** — `uv run python scripts/debug_pre_release.py`.
+4. **Targeted probes** — isolated Python scripts with `SIGALRM` to detect hangs; semantic comparison of ISO weeks vs `%W`.
+5. **Coverage mapping** — uncovered lines vs risk (see §7).
 
 ---
 
-## 3. Evidenze strutturali (analisi statica locale)
+## 3. Static evidence (local analysis)
 
-| Query / tool | Risultato | Implicazione |
+| Query / tool | Result | Implication |
 | :--- | :--- | :--- |
-| `check(cycles)` | `cycleCount: 0` | Nessun ciclo di import tra file; layering import è sano. |
-| `impact(StackMachineParser, upstream)` | risk **MEDIUM**, 6 caller diretti | Refactor parser = blast radius moderato; serve `impact` prima di ogni modifica FSM. |
-| `impact(serialize_logseq_page, upstream)` | risk **LOW**, 1 caller | Serialization è confinata; round-trip testabile in isolamento. |
-| `context(LogseqGraph)` | Importato da `kinetic`, `synapse`, `agent_writer`, `__init__` | Hub applicativo — API graph devono restare stabili e complete. |
-| `impact(logseq_agent_write, downstream)` | 2 processi (`logseq_agent_write`, `_demo`) | Cambio naming file settimanale impatta solo KINETIC/agent path. |
-| `impact(_refresh_node, upstream)` | risk **CRITICAL**, 5 processi (`scan`, `load_and_convert`, `parse`) | BUG-017 — un guard mancante blocca tutti gli entrypoint parse. |
-| `impact(load_directory, upstream)` | risk **HIGH**, `agent_read` / `export` / `agent_write` | BUG-010/013/017 condividono il percorso `load_directory`. |
-| `query(to_llamaindex_nodes SOURCE)` | `LlamaIndexVisitor`, `page_source_node_id` | BUG-018 — SOURCE singolo su root multi-pagina. |
-| `query(get_deep_statistics largest_pages)` | `GraphVisualizer._count_page_blocks` | BUG-019 — lista `_pages` senza dedup alias. |
-| `impact(search_content, upstream)` | risk **LOW**, processo `agent_read` | BUG-022 — scan su `_node_registry` include nodi fantasma. |
-| `query(strict_refs BlockReferenceError)` | `_validate_references`, `BlockReferenceError` | BUG-025 — validazione solo intra-pagina. |
-| `impact(resolve_relative_page_link)` | **0 caller** upstream | API pubblica ma non usata internamente; BUG-029 gap `../`. |
-| `query(agent_press to_xray_markdown)` | `SessionAliasRegistry`, `agent_read` | Dup X-Ray solo se consumer passa `pages.values()` roots. |
+| `check(cycles)` | `cycleCount: 0` | No import cycles between files; layering is healthy. |
+| `impact(StackMachineParser, upstream)` | risk **MEDIUM**, 6 direct callers | Parser refactor has moderate blast radius; run `impact` before any FSM change. |
+| `impact(serialize_logseq_page, upstream)` | risk **LOW**, 1 caller | Serialization is contained; round-trip can be tested in isolation. |
+| `context(LogseqGraph)` | Imported by `kinetic`, `synapse`, `agent_writer`, `__init__` | Application hub — graph APIs must stay stable and complete. |
+| `impact(logseq_agent_write, downstream)` | 2 processes (`logseq_agent_write`, `_demo`) | Weekly file naming change impacts only KINETIC/agent path. |
+| `impact(_refresh_node, upstream)` | risk **CRITICAL**, 5 processes (`scan`, `load_and_convert`, `parse`) | BUG-017 — missing guard blocks all parse entrypoints. |
+| `impact(load_directory, upstream)` | risk **HIGH**, `agent_read` / `export` / `agent_write` | BUG-010/013/017 share the `load_directory` path. |
+| `query(to_llamaindex_nodes SOURCE)` | `LlamaIndexVisitor`, `page_source_node_id` | BUG-018 — single SOURCE for multi-page root. |
+| `query(get_deep_statistics largest_pages)` | `GraphVisualizer._count_page_blocks` | BUG-019 — `_pages` list without alias dedup. |
+| `impact(search_content, upstream)` | risk **LOW**, process `agent_read` | BUG-022 — scan on `_node_registry` includes orphan nodes. |
+| `query(strict_refs BlockReferenceError)` | `_validate_references`, `BlockReferenceError` | BUG-025 — validation only intra-page. |
+| `impact(resolve_relative_page_link)` | **0 caller** upstream | Public API currently unused internally; BUG-029 gap for `../`. |
+| `query(agent_press to_xray_markdown)` | `SessionAliasRegistry`, `agent_read` | X-Ray duplicates only when consumer passes `pages.values()` roots. |
 
-**Staleness:** l’indice locale è allineato al commit indicizzato; dopo merge significativi eseguire `refresh dell'indice locale`.
+**Staleness:** local index is aligned to indexed commit; after significant merges, run a local index refresh.
 
 ---
 
-## 4. Findings — bug confermati (runtime evidence)
+## 4. Findings — confirmed bugs (runtime evidence)
 
-### BUG-001 — CRITICAL: loop infinito in espansione page embed (SYNAPSE)
+### BUG-001 — CRITICAL: infinite loop during page embed expansion (SYNAPSE)
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/synapse.py` |
-| **Funzione** | `_expand_macros_and_embeds_impl` (circa L164–217) |
-| **Severità** | **Critical** (hang / CPU 100% su export RAG) |
-| **Clean Architecture** | Violazione *robustness* nel adapter; il use case `LogseqGraph.get_page` esiste ma non viene usato. |
+| **Function** | `_expand_macros_and_embeds_impl` (around L164–217) |
+| **Severity** | **Critical** (hang / CPU at 100% on RAG export) |
+| **Clean Architecture** | Robustness violation in adapter; use case `LogseqGraph.get_page` exists but is not used. |
 
-**Root cause:** quando `graph.pages.get(title)` non trova la pagina, `replacement = match.group(0)` lascia la stringa **identica**. Il `while True` ri-matcha lo stesso embed all’infinito.
+**Root cause:** when `graph.pages.get(title)` fails, `replacement = match.group(0)` keeps the same string. The `while True` loop rematches the same embed indefinitely.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# Pagina inesistente → hang confermato (SIGALRM 3s)
+# Missing page → hang confirmed (SIGALRM 3s)
 missing page INFINITE_LOOP
 
-# Casing errato (Logseq routing case-insensitive via get_page)
-embed [[target]] con pagina "Target" → INFINITE_LOOP
+# Wrong case (Logseq routing case-insensitive via get_page)
+embed [[target]] with page "Target" → INFINITE_LOOP
 embed [[Target]] → OK: 'x shared content'
 
-# UUID block valido ma assente nel grafo → hang
+# Valid block UUID missing from graph → hang
 double-brace missing uuid INFINITE_LOOP
 ```
 
-**Percorso utente:** `SynapseAdapter.to_context_enriched_chunks` → `kinetic export --format langchain-enriched` su un grafo con embed irrisolti.
+**User path:** `SynapseAdapter.to_context_enriched_chunks` → `kinetic export --format langchain-enriched` on a graph with unresolved embeds.
 
-**Fix raccomandato (SRP + fail-safe):**
+**Recommended fix (SRP + fail-safe):**
 
-1. Usare `graph.get_page(title)` al posto di `graph.pages.get(title)` (case-insensitive).
-2. Su risoluzione fallita: sostituire con stringa vuota o placeholder, **mai** con `match.group(0)`.
-3. Aggiungere test regressione in `tests/test_synapse.py` per: pagina mancante, casing errato, UUID block assente.
+1. Use `graph.get_page(title)` instead of `graph.pages.get(title)` (case-insensitive).
+2. On failed resolution, replace with empty string or placeholder, **never** with `match.group(0)`.
+3. Add regression tests in `tests/test_synapse.py` for: missing page, wrong case, missing UUID block.
 
-**Blast radius (analisi statica):** `impact(SynapseAdapter.to_context_enriched_chunks, upstream)` prima del fix.
+**Blast radius (static analysis):** `impact(SynapseAdapter.to_context_enriched_chunks, upstream)` before fix.
 
 ---
 
-### BUG-005 — HIGH: `invalidate_and_reload_page` crash su file cancellato
+### BUG-005 — HIGH: `invalidate_and_reload_page` crashes on deleted file
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L641–647 |
-| **Severità** | **High** (watcher / incremental index) |
-| **Clean Architecture** | Use case non gestisce evento *delete* del driver filesystem. |
+| **Severity** | **High** (watcher / incremental index) |
+| **Clean Architecture** | Use case does not handle filesystem *delete* event. |
 
-**Root cause:** `invalidate_and_reload_page` chiama sempre `parse_page_file(resolved)` senza verificare `resolved.exists()`. Su cancellazione pagina → `FileNotFoundError`.
+**Root cause:** `invalidate_and_reload_page` always calls `parse_page_file(resolved)` without checking `resolved.exists()`. On page deletion → `FileNotFoundError`.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 BUG-005 exception: FileNotFoundError .../pages/Gone.md
 ```
 
-**Percorso utente:** `LogseqGraphWatcher` → `_route_event` → `invalidate_and_reload_page` quando l’utente elimina un `.md` in Logseq.
+**User path:** `LogseqGraphWatcher` → `_route_event` → `invalidate_and_reload_page` when user deletes a `.md` in Logseq.
 
-**Fix raccomandato:** se `not resolved.exists()`, purgare chiavi/backlink/nodi per quel `source_path` (simmetrico a reload) e uscire senza parse.
+**Recommended fix:** if `not resolved.exists()`, purge key/backlink/node entries for that `source_path` (symmetrical with reload) and return without parse.
 
-**Analisi statica:** `context(invalidate_and_reload_page)` — caller diretto: watcher handler; test esistente copre solo *edit*, non *delete*.
+**Static analysis:** `context(invalidate_and_reload_page)` — direct caller is watcher handler; existing test only covers *edit*, not *delete*.
 
 ---
 
-### BUG-006 — MEDIUM: `langchain-enriched` export duplica chunk per alias pagina
+### BUG-006 — MEDIUM: `langchain-enriched` export duplicates chunks per page alias
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/kinetic.py` L347–349 |
-| **Severità** | **Medium** (RAG embeddings duplicati, costo/token doppio) |
+| **Severity** | **Medium** (duplicate RAG embeddings, token / cost overhead) |
 
-**Root cause:** `_export_langchain_enriched` fa `for page in graph.pages.values()`; `_enrich_pages_index` duplica la stessa `LogseqPage` sotto chiavi alias (`alias::`). `all_roots.extend(page.root_nodes)` inserisce gli stessi blocchi N volte.
+**Root cause:** `_export_langchain_enriched` does `for page in graph.pages.values()`; `_enrich_pages_index` duplicates the same `LogseqPage` under alias keys (`alias::`). `all_roots.extend(page.root_nodes)` inserts the same blocks N times.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# alias:: Alt su pagina con 1 blocco
+# alias:: Alt on a page with 1 block
 BUG-006 chunk count: 2 payload len: 2
 BUG-006 duplicate contents: ['[P] only block', '[P] only block']
 ```
 
-**Fix raccomandato:** introdurre `LogseqGraph.iter_canonical_pages()` (pattern già in `_enrich_pages_index` L219: `key == page.title` + dedup `id(page)`).
+**Recommended fix:** introduce `LogseqGraph.iter_canonical_pages()` (pattern already in `_enrich_pages_index` L219: `key == page.title` + `id(page)` dedup).
 
 ---
 
-### BUG-007 — MEDIUM: `get_namespace_children` restituisce duplicati con alias namespace-like
+### BUG-007 — MEDIUM: `get_namespace_children` duplicates entries with namespace-like aliases
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L558–577 |
-| **Severità** | **Medium** (API graph errata per tooling namespace) |
+| **Severity** | **Medium** (incorrect namespace API) |
 
-**Root cause:** itera `self.pages.items()` senza dedup per oggetto pagina. Un `alias:: NS/AliasLeaf` crea una chiave `NS/AliasLeaf` che matcha il prefisso `NS/` oltre alla chiave canonica `NS/Leaf`.
+**Root cause:** iterates `self.pages.items()` without dedup by page object. `alias:: NS/AliasLeaf` creates key `NS/AliasLeaf` that also matches prefix `NS/` in addition to canonical `NS/Leaf`.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 H17 ns children count: 2 ['NS/Leaf', 'NS/Leaf']
 ```
 
-**Fix raccomandato:** stesso helper `iter_canonical_pages()` o `seen_page_ids` come in `_build_backlink_registry`.
+**Recommended fix:** reuse `iter_canonical_pages()` helper or `seen_page_ids` like `_build_backlink_registry`.
 
 ---
 
-### BUG-008 — LOW: `search_content` case-sensitive vs routing case-insensitive
+### BUG-008 — LOW: `search_content` is case-sensitive while routing is case-insensitive
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L521–528 |
-| **Severità** | **Low** (inconsistenza API) |
+| **Severity** | **Low** (API inconsistency) |
 
-**Evidenza:**
+**Evidence:**
 
 ```text
-search_content('hello') → 0 risultati
-search_content('Hello') → 1 risultato
+search_content('hello') → 0 results
+search_content('Hello') → 1 result
 ```
 
-`get_page` e `get_backlinks` sono case-insensitive; `search_content` no. Documentare o allineare.
+`get_page` and `get_backlinks` are case-insensitive; `search_content` is not. Document or align.
 
 ---
 
-### BUG-009 — LOW: `SessionAliasRegistry.load_from_disk` stato inconsistente con UUID duplicati
+### BUG-009 — LOW: `SessionAliasRegistry.load_from_disk` inconsistent state with duplicate UUIDs
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/agent_press.py` L70–78 |
-| **Severità** | **Low** (agent session corrupta su disco) |
+| **Severity** | **Low** (corrupt on-disk agent session) |
 
-**Evidenza:**
+**Evidence:**
 
 ```text
 load {"0": "uuid-a", "1": "uuid-a"}
 resolve_alias(0) → uuid-a, resolve_alias(1) → uuid-a
-alias_for_uuid('uuid-a') → 1  # alias 0 “orfano” per reverse lookup
+alias_for_uuid('uuid-a') → 1  # alias 0 is “orphan” in reverse lookup
 ```
 
-**Fix raccomandato:** validazione al load (rifiuta o merge duplicati); test regressione.
+**Recommended fix:** validate on load (reject or merge duplicates); add regression test.
 
 ---
 
-### BUG-010 — HIGH: collisione titolo `pages/` vs `journals/` + nodi fantasma nel registry
+### BUG-010 — HIGH: `pages/` vs `journals/` title collision + ghost registry nodes
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L384–387 |
-| **Severità** | **High** (integrità indice, agent-read, RAG) |
-| **Clean Architecture** | Use case `load_directory` viola invariante “un titolo → una pagina indexata”. |
+| **Severity** | **High** (index integrity, agent-read, RAG) |
+| **Clean Architecture** | `load_directory` use case violates invariant “one title → one indexed page”. |
 
-**Root cause:** `pages[page.title] = page` usa solo il titolo come chiave. File distinti con lo stesso stem (es. `pages/Daily.md` e `journals/Daily.md`) collidono; l’ultimo path ordinato vince nel dizionario, ma **entrambi** i nodi restano in `_node_registry` (registrati nel loop precedente L386–387).
+**Root cause:** `pages[page.title] = page` uses title as only key. Distinct files with same stem (e.g., `pages/Daily.md` and `journals/Daily.md`) collide. The sorted later path wins in dict; **both** nodes remain in `_node_registry` (registered in previous loop L386–387).
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# pages/Daily.md + journals/Daily.md (stesso titolo "Daily")
+# pages/Daily.md + journals/Daily.md (same title "Daily")
 registry nodes: ['from-journals', 'from-pages']  # count: 2
-pages['Daily'] → pages/Daily.md (vincitore)
-_page_for_node(journal_node) → None  # fantasma
-query().execute() → 2 nodi, uno orfano
+pages['Daily'] → pages/Daily.md (winner)
+_page_for_node(journal_node) → None  # ghost
+query().execute() → 2 nodes, one orphan
 ```
 
-**Percorso utente:** `agent-read` senza filtri include nodi journal non collegati a nessuna `LogseqPage`; export enriched indicizza contenuto “fantasma”.
+**User path:** unfiltered `agent-read` includes journal nodes not linked to any `LogseqPage`; enriched export indexes ghost content.
 
-**Fix raccomandato:** chiave composta `(source_kind, title)` o namespace titoli journal (`[[Apr 25th, 2024]]`); oppure purge registry nodes non appartenenti alla pagina vincitrice dopo merge.
+**Recommended fix:** use composite key `(source_kind, title)` or journal title namespace (`[[Apr 25th, 2024]]`); alternatively purge non-winning `_node_registry` nodes after merge.
 
-**Analisi statica:** `context(load_directory)` — 25+ test caller; `impact` risk alto su refactor.
+**Static analysis:** `context(load_directory)` — 25+ test callers; high `impact` risk on refactor.
 
 ---
 
-### BUG-011 — MEDIUM: `append_child_to_node` ignora indentazione reale del file
+### BUG-011 — MEDIUM: `append_child_to_node` ignores real file indentation
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/agent_writer.py` L192–194 |
-| **Severità** | **Medium** (headless writer corrompe outline) |
+| **Severity** | **Medium** (headless writer corrupts outline) |
 
-**Root cause:** indent calcolato come `graph.tab_size` (hardcoded 2) × `indent_level`, non dagli spazi effettivi nel sorgente. Vault con indentazione 4 spazi (o mista) ricevono bullet figli con 2 spazi.
+**Root cause:** indentation is computed as hardcoded `graph.tab_size` (2) × `indent_level`, not actual spaces in source. Vaults using 4-space or mixed indentation add children with 2 spaces.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 # File: '- root\n    - four-space child\n'
 append_child_to_node(..., 'appended')
-→ ['- root', '    - four-space child', '  - appended']  # 2 spazi, non 4
+→ ['- root', '    - four-space child', '  - appended']  # 2 spaces, not 4
 ```
 
-**Fix raccomandato:** derivare indent dal bullet parent nel file (`line_start` / regex sulle leading spaces) o da `node.indent_level` × indent width rilevato per pagina.
+**Recommended fix:** derive indentation from parent bullet in source (`line_start` / leading-space regex) or from `node.indent_level` × detected per-page indent width.
 
-**Analisi statica:** `impact(append_child_to_node)` → `agent_write` CLI (7 process hits).
+**Static analysis:** `impact(append_child_to_node)` → `agent_write` CLI (7 process hits).
 
 ---
 
-### BUG-012 — MEDIUM: `get_node_by_embed_ref` case-sensitive su UUID
+### BUG-012 — MEDIUM: `get_node_by_embed_ref` is case-sensitive for UUID
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L432–445 |
-| **Severità** | **Medium** (embed Obsidian / Synapse falliscono) |
+| **Severity** | **Medium** (Obsidian / Synapse embeds fail) |
 
-**Root cause:** lookup diretto `get_node_by_uuid(stripped)` e confronto `node.source_uuid == stripped` senza normalizzazione case; Logseq/OS spesso usano UUID lowercase negli embed `((...))` mentre `id::` nel file può essere uppercase.
+**Root cause:** direct lookup `get_node_by_uuid(stripped)` and `node.source_uuid == stripped` compare without case normalization. Logseq/Obsidian often uses lowercase UUIDs in `((...))` while page `id::` may be uppercase.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 id:: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA
@@ -323,58 +323,58 @@ get_node_by_embed_ref(upper) → hit
 get_node_by_embed_ref(lower) → miss
 ```
 
-**Fix raccomandato:** normalizzare a lowercase per confronto UUID (come `_node_identity_keys` in `forge.py`).
+**Recommended fix:** normalize UUID comparisons to lowercase (as with `_node_identity_keys` in `forge.py`).
 
-**Analisi statica:** `impact(get_node_by_embed_ref)` → `to_context_enriched_chunks`, `embed_resolver` Obsidian.
+**Static analysis:** `impact(get_node_by_embed_ref)` → `to_context_enriched_chunks`, Obsidian `embed_resolver`.
 
 ---
 
-### BUG-013 — HIGH: collisione `title::` identico su file diversi (variante BUG-010)
+### BUG-013 — HIGH: identical `title::` collision across files (BUG-010 variant)
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L384–387 |
-| **Severità** | **High** (stesso meccanismo di BUG-010) |
+| **Severity** | **High** (same mechanism as BUG-010) |
 
-**Scenario:** `pages/A.md` e `pages/B.md` entrambi con `title:: Shared`. Il dizionario `pages` conserva un solo vincitore (`B.md` per sort path), ma **entrambi** i nodi (`from-A`, `from-B`) restano in `_node_registry`.
+**Scenario:** `pages/A.md` and `pages/B.md` both have `title:: Shared`. Dict keeps one winner (`B.md` by path order), but both nodes (`from-A`, `from-B`) remain in `_node_registry`.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 shared title pages dict: 1
-registry nodes: ['a', 'b']   # o ['from-A', 'from-B']
+registry nodes: ['a', 'b']   # or ['from-A', 'from-B']
 winner: B.md / from-B
 ```
 
-**Fix:** unificare con BUG-010 — chiave indice = `source_path` o `(kind, canonical_title)`; purge registry orphan.
+**Fix:** unify with BUG-010 — index key should be `source_path` or `(kind, canonical_title)`; purge orphan registry entries.
 
 ---
 
-### BUG-014 — MEDIUM: `LogseqGraphWatcher` senza `on_deleted` / `on_moved`
+### BUG-014 — MEDIUM: `LogseqGraphWatcher` without `on_deleted` / `on_moved`
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L725–730 |
-| **Severità** | **Medium** (indice stale finché non si riavvia) |
+| **Severity** | **Medium** (stale index until restart) |
 
-**Root cause:** handler registra solo `on_modified` e `on_created`. Cancellazione o rename di `.md` non invalida l’indice (a differenza di Logseq che aggiorna il DB).
+**Root cause:** handler registers only `on_modified` and `on_created`. Deleted/renamed `.md` files do not invalidate index (unlike Logseq DB updates).
 
-**Evidenza:** ispezione sorgente `start()` — assenza `on_deleted`/`on_moved`; combinato con BUG-005 se un evento successivo tenta reload su path sparito.
+**Evidence:** source inspection of `start()` shows missing `on_deleted`/`on_moved`; combined with BUG-005 if a later event attempts reload on missing path.
 
-**Analisi statica:** `context(LogseqGraphWatcher)` — processi `on_modified`/`on_created` only.
+**Static analysis:** `context(LogseqGraphWatcher)` — only `on_modified`/`on_created` processes.
 
-**Fix:** aggiungere `on_deleted` → purge per `source_path`; `on_moved` → invalidate old + new path.
+**Fix:** add `on_deleted` → purge by `source_path`; `on_moved` → invalidate old + new path.
 
 ---
 
-### BUG-015 — LOW: `GraphQuery.has_tag` non accetta prefisso `#`
+### BUG-015 — LOW: `GraphQuery.has_tag` does not accept `#` prefix
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L93–96 |
-| **Severità** | **Low** (UX API / CLI) |
+| **Severity** | **Low** (API / CLI UX) |
 
-**Evidenza:**
+**Evidence:**
 
 ```text
 node.tags: ['mytag']
@@ -382,310 +382,310 @@ has_tag('mytag') → 1
 has_tag('#mytag') → 0
 ```
 
-Il parser normalizza `#` via `tags`; `has_tag` confronta literal. Stessa classe di inconsistenza di BUG-008 (`search_content` case).
+Parser normalizes `#` via `tags`; `has_tag` does literal comparison. Same inconsistency class as BUG-008 (`search_content` case).
 
-**Fix:** strip `#` in `has_tag` (e opzionalmente `search_content` casefold).
+**Fix:** strip `#` in `has_tag` (and optionally casefold `search_content`).
 
 ---
 
-### BUG-016 — HIGH: `append_child_to_node` non aggiorna il grafo in-memory
+### BUG-016 — HIGH: `append_child_to_node` does not update in-memory graph
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/agent_writer.py` L181–228; `kinetic.py` `agent_write` L641 |
-| **Severità** | **High** (workflow agente incoerente) |
+| **Severity** | **High** (inconsistent agent workflow) |
 
-**Root cause:** splice scrive solo su disco. `LogseqGraph` caricato prima della scrittura resta con AST/registry obsoleti; nessuna chiamata a `invalidate_and_reload_page`.
+**Root cause:** splice writes to disk only. A `LogseqGraph` loaded before write keeps stale AST/registry; no call to `invalidate_and_reload_page`.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 registry before/after append: 1 1
-parent.children after append: 0   # AST non aggiornato
-# file on disk contiene il nuovo bullet
+parent.children after append: 0   # AST not updated
+# file on disk contains new bullet
 ```
 
-**Percorso utente:** `agent-read` → `agent-write` nella stessa sessione Python / pipeline che riusa `LogseqGraph` → export o query ignorano il blocco appena scritto.
+**User path:** `agent-read` → `agent-write` in same Python session/pipeline reusing `LogseqGraph` → export/query ignores just-written block.
 
-**Fix:** dopo splice, `graph.invalidate_and_reload_page(source_path)` (o parse incrementale del sottoalbero).
+**Fix:** after splice, call `graph.invalidate_and_reload_page(source_path)` (or incremental subtree parse).
 
-**Analisi statica:** `impact(append_child_to_node)` → `agent_write` (7 process hits).
+**Static analysis:** `impact(append_child_to_node)` → `agent_write` (7 process hits).
 
 ---
 
-### BUG-017 — CRITICAL: `IndexError` in `_refresh_node` su bullet vuoto con proprietà blocco
+### BUG-017 — CRITICAL: `IndexError` in `_refresh_node` on empty bullet with block properties
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/logos_parser.py` L1376–1379 |
-| **Funzione** | `StackMachineParser._refresh_node` |
-| **Severità** | **Critical** (crash parse — intero grafo non caricabile) |
-| **Clean Architecture** | Use case parser non rispetta invariante “outline Logseq valido”; nessun fail-soft su contenuto vuoto dopo strip proprietà. |
+| **Function** | `StackMachineParser._refresh_node` |
+| **Severity** | **Critical** (parse crash — full graph cannot load) |
+| **Clean Architecture** | Parser use case violates invariant “valid Logseq outline”; no fail-soft on empty content after property strip. |
 
-**Root cause:** alla riga 1376 `first_line` usa un guard `if content.splitlines() else ""`, ma alla riga 1379 `_extract_task_status(content.splitlines()[0].strip())` **non** ha lo stesso guard. Quando il bullet parent ha solo spazi dopo `-` e le proprietà (`id::`, `tags::`, …) sono su righe figlie indentate, `content` risulta stringa vuota → `splitlines()[0]` → `IndexError`.
+**Root cause:** at line 1376 `first_line` uses guard `if content.splitlines() else ""`, but line 1379 `_extract_task_status(content.splitlines()[0].strip())` does not use the same guard. When a parent bullet has only spaces after `-` and child properties (`id::`, `tags::`, …) are on indented child lines, `content` becomes empty string → `splitlines()[0]` raises `IndexError`.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 Input: '- \n  id:: abc\n  - real\n'
 parse() → IndexError: list index out of range  (L1379)
 
-Varianti che crashano (senza figlio obbligatorio):
+Variants that crash (without mandatory child):
   '- \n  id:: abc\n'
   '- \n  tags:: foo\n  - c\n'
   'id:: page\n\n- \n  id:: block\n  - c\n'
 
-load_directory con 1 file valido + 1 file bad → IndexError (nessuna pagina caricata)
-_parse_graph (kinetic scan) → IndexError a metà progress bar
+load_directory with 1 valid + 1 bad file → IndexError (no pages loaded)
+_parse_graph (kinetic scan) → IndexError mid progress bar
 ```
 
-**Percorso utente:** vault Logseq con bullet “contenitore” vuoto e `id::` / metadati sul blocco (pattern comune per block embed); `logseq-matryca-parser scan`, `export`, `agent-read` su grafo intero.
+**User path:** Logseq vault with empty “container” bullet and `id::` / metadata on block (common for block embed); `logseq-matryca-parser scan`, `export`, `agent-read` on full graph.
 
-**Fix raccomandato:** riusare `first_line` (o `content.splitlines()[0] if content.splitlines() else ""`) anche per `_extract_task_status`; test regressione `test_empty_bullet_with_block_properties` (distinto da `test_empty_bullet_without_trailing_space` che copre solo `"-"`).
+**Recommended fix:** reuse `first_line` (or `content.splitlines()[0] if content.splitlines() else ""`) for `_extract_task_status` too; add regression test `test_empty_bullet_with_block_properties` (separate from `test_empty_bullet_without_trailing_space` which covers only `"-"`).
 
-**Analisi statica:** `impact(_refresh_node, upstream)` → risk **CRITICAL**, processi `load_and_convert`, `scan`, `parse`, `parse_file`, `main` (debug_pre_release).
+**Static analysis:** `impact(_refresh_node, upstream)` → risk **CRITICAL**, processes `load_and_convert`, `scan`, `parse`, `parse_file`, `main` (debug_pre_release).
 
 ---
 
-### BUG-018 — MEDIUM: `to_llamaindex_nodes` con radici multi-pagina condivide un solo `SOURCE`
+### BUG-018 — MEDIUM: `to_llamaindex_nodes` assigns one `SOURCE` for multi-page roots
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/synapse.py` L354–359 |
-| **Severità** | **Medium** (metadata RAG errati se si passano root di più pagine) |
+| **Severity** | **Medium** (incorrect RAG metadata when passing multi-page roots) |
 
-**Root cause:** se `page_source_id` non è fornito, viene calcolato una sola volta dal `first_path` del primo nodo in ordine preorder. Tutti i nodi LlamaIndex ricevono lo stesso `NodeRelationship.SOURCE`.
+**Root cause:** if `page_source_id` omitted, it is computed once from first path among first node in preorder. All LlamaIndex nodes receive same `NodeRelationship.SOURCE`.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# Root da pages A.md e B.md in un'unica lista
+# Root from A.md and B.md in one list
 to_llamaindex_nodes(all_roots) → SOURCE count: 1, nodes: 2
 ```
 
-**Percorso utente:** integrazione custom che aggrega `graph.pages.values()` root_nodes (stesso anti-pattern di BUG-006) prima di `to_llamaindex_nodes`. KINETIC non espone oggi export LlamaIndex bulk, ma l’API pubblica è fuorviante.
+**User path:** custom integration aggregates `graph.pages.values()` roots (same anti-pattern as BUG-006) before calling `to_llamaindex_nodes`. KINETIC does not currently expose bulk LlamaIndex export, but the public API is misleading.
 
-**Fix raccomandato:** documentare che `to_llamaindex_nodes` è per-page; oppure derivare `SOURCE` per nodo da `node.source_path` / `page_source_node_id(page_title, path)`.
+**Fix:** document `to_llamaindex_nodes` as per-page, or derive `SOURCE` from `node.source_path` / `page_source_node_id(page_title, path)`.
 
-**Analisi statica:** `query(to_llamaindex_nodes SOURCE)` → `LlamaIndexVisitor`, test `test_to_llamaindex_nodes_injects_parent_child_relationships`.
+**Static analysis:** `query(to_llamaindex_nodes SOURCE)` → `LlamaIndexVisitor`, test `test_to_llamaindex_nodes_injects_parent_child_relationships`.
 
 ---
 
-### BUG-019 — LOW/MEDIUM: `get_deep_statistics` duplica `largest_pages` con alias in `_pages`
+### BUG-019 — LOW/MEDIUM: `get_deep_statistics` duplicates `largest_pages` for alias entries in `_pages`
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/lens.py` L109–117 |
-| **Severità** | **Low/Medium** (statistiche HTML/KINETIC visualize se alimentate da `graph.pages.values()`) |
+| **Severity** | **Low/Medium** (HTML/LENS stats can be incorrect if fed alias-expanded `graph.pages.values()`) |
 
-**Root cause:** `largest_pages` itera `self._pages` senza dedup; stesso oggetto `LogseqPage` compare due volte se la lista proviene da `list(graph.pages.values())` (chiave canonica + alias).
+**Root cause:** `largest_pages` iterates `self._pages` without dedup; same `LogseqPage` appears multiple times when list originates from `list(graph.pages.values())` (canonical key + alias).
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 # alias:: Alt, _pages = list(graph.pages.values())
 largest_pages: [{'page': 'P', 'block_count': 2}, {'page': 'P', 'block_count': 2}]
 ```
 
-**Nota:** `kinetic visualize` usa `_parse_graph` (una entry per file) — non colpito di default. Colpito se un consumer passa il dizionario graph arricchito.
+**Note:** `kinetic visualize` uses `_parse_graph` (one entry per file), so default flow is not affected. Affected only when consumer passes enriched graph dict.
 
-**Fix:** dedup per `id(page)` o `iter_canonical_pages()` (DEBT-001).
+**Fix:** dedup by `id(page)` or `iter_canonical_pages()` (DEBT-001).
 
 ---
 
-### BUG-020 — LOW: LENS crea nodo “pagina fantasma” per alias wikilink
+### BUG-020 — LOW: LENS creates “ghost page” node for alias wikilink
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/lens.py` `NetworkXVisitor.visit_node` L26–30 |
-| **Severità** | **Low** (visualizzazione fuorviante) |
+| **Severity** | **Low** (misleading visualization) |
 
-**Root cause:** ogni `ref` in `node.refs` diventa nodo grafo con `group="page"`. Un wikilink `[[Alt]]` dove `Alt` è solo `alias::` della pagina `P` crea nodo `Alt` separato da `P`, con arco `P → Alt`.
+**Root cause:** every `ref` in `node.refs` becomes a graph node with `group="page"`. A wikilink `[[Alt]]` where `Alt` is only `alias::` for page `P` creates separate `Alt` node and edge `P → Alt`.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# pages/P.md: alias:: Alt, contenuto - [[Alt]]
+# pages/P.md: alias:: Alt, content - [[Alt]]
 lens nodes: ['P', 'Alt'], edges: 1
 ```
 
-**Fix opzionale:** risolvere ref via `graph.get_page(ref)` e usare `page.title` canonico come nodo destinazione (richiede passare `LogseqGraph` al visualizer).
+**Optional fix:** resolve refs via `graph.get_page(ref)` and use canonical `page.title` as destination node (requires passing `LogseqGraph` to visualizer).
 
 ---
 
-### BUG-021 — MEDIUM: `serialize_logseq_page` forza `tab_size=2` e corrompe vault a 4 spazi
+### BUG-021 — MEDIUM: `serialize_logseq_page` hardcodes `tab_size=2` and corrupts 4-space vaults
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/logseq_markdown.py` L168–186, L211 |
-| **Severità** | **Medium** (round-trip altera indentazione reale) |
+| **Severity** | **Medium** (round-trip changes real indentation) |
 
-**Root cause:** la serializzazione calcola indent come `node.indent_level * tab_size` con default `tab_size=2`. Il parser registra solo `indent_level` (0, 1, 2…), non la larghezza effettiva in spazi del sorgente. Un file con figli a 4 spazi viene riscritto a 2 spazi.
+**Root cause:** serialization computes indent as `node.indent_level * tab_size` with default `tab_size=2`. Parser stores only indent level (0, 1, 2, …), not original width in source spaces. 4-space child file is rewritten to 2-space indentation.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-Input file:  '- root\n    - child\n'   # 4 spazi
-parse → indent_level root=0 child=1
-serialize_logseq_page(page) → '- root\n  - child\n'   # 2 spazi — match=False
-serialize_logseq_page(page, tab_size=4) → match=True   # ma tab_size non è auto-rilevato
+Input file:  '- root\n    - child\n'   # 4 spaces
+parse → root indent=0 child=1
+serialize_logseq_page(page) → '- root\n  - child\n'   # 2 spaces — match=False
+serialize_logseq_page(page, tab_size=4) → match=True   # tab_size is not auto-detected
 ```
 
-**Percorso utente:** `write_logseq_page`, round-trip test, qualsiasi pipeline che riscrive AST senza conoscere `tab_size` del vault.
+**User path:** `write_logseq_page`, round-trip tests, any pipeline re-writing AST without knowing vault tab size.
 
-**Fix raccomandato:** rilevare `tab_size` per pagina al parse (GCD degli incrementi di indent) e propagarlo su `LogseqPage` / `LogseqGraph.tab_size`; oppure memorizzare leading spaces originali.
+**Recommended fix:** detect `tab_size` per page at parse time (GCD of indent increments) and propagate to `LogseqPage` / `LogseqGraph.tab_size`, or store leading spaces.
 
-**Relazione:** stessa famiglia di BUG-011 (`append_child_to_node`); analisi statica `impact(serialize_logseq_page)` risk **LOW**.
+**Relation:** same family as BUG-011 (`append_child_to_node`); static `impact(serialize_logseq_page)` risk **LOW**.
 
 ---
 
-### BUG-022 — HIGH: `search_content` / `GraphQuery` / `agent-read` includono nodi fantasma
+### BUG-022 — HIGH: `search_content` / `GraphQuery` / `agent-read` include ghost nodes
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L521–528; `kinetic.py` `agent_read` L567–573 |
-| **Severità** | **High** (manifestazione user-visible di BUG-010/013) |
+| **Severity** | **High** (user-visible manifestation of BUG-010/013) |
 
-**Root cause:** `search_content` e `GraphQuery.execute()` iterano `self._node_registry.values()` senza filtrare nodi il cui `_page_for_node(node)` è `None`. Dopo collisione `pages/` vs `journals/` (o `title::` duplicato), i nodi del file “perdente” restano nel registry ma non in `pages`.
+**Root cause:** `search_content` and `GraphQuery.execute()` iterate `self._node_registry.values()` without filtering nodes where `_page_for_node(node)` is `None`. After page collision (`pages/` vs `journals/` or duplicate `title::`), losing-file nodes remain in registry but not in `pages`.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# pages/Daily.md + journals/Daily.md (collisione titolo)
-search_content('journals-only') → 1 hit ['journals-only-text']   # nodo fantasma
-query().execute() → 2 nodi, 1 orfano
-agent-read (no filter) → X-Ray include 'GHOST-UNIQUE' dal journal perdente
-get_nodes_by_tag('orphan') → 1 hit su nodo fantasma
+# pages/Daily.md + journals/Daily.md (title collision)
+search_content('journals-only') → 1 hit ['journals-only-text']   # ghost node
+query().execute() → 2 nodes, 1 orphan
+agent-read (no filter) → X-Ray includes 'GHOST-UNIQUE' from losing journal
+get_nodes_by_tag('orphan') → 1 hit on ghost node
 ```
 
-**Percorso utente:** `logseq-matryca-parser agent-read` su vault con journal + page stesso stem; `--query` trova contenuto “fantasma” non collegato a nessuna pagina indicizzata.
+**User path:** `logseq-matryca-parser agent-read` on vault with same-stem page/journal; `--query` surfaces ghost content not attached to any indexed page.
 
-**Fix raccomandato:** unificare con BUG-010 purge; oppure `iter_attached_nodes()` che esclude orfani; `agent_read` dovrebbe usarlo di default.
+**Recommended fix:** align with BUG-010 purge, or provide `iter_attached_nodes()` excluding orphans; make `agent_read` use that by default.
 
-**Analisi statica:** `impact(search_content, upstream)` → `agent_read` (6 process hits).
+**Static analysis:** `impact(search_content, upstream)` → `agent_read` (6 process hits).
 
 ---
 
-### BUG-023 — MEDIUM: SYNAPSE enriched chunk su nodo fantasma — metadata incompleti
+### BUG-023 — MEDIUM: SYNAPSE enriched chunk on ghost node has incomplete metadata
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/synapse.py` `_build_breadcrumbs`, `to_context_enriched_chunks` |
-| **Severità** | **Medium** (RAG chunk senza contesto pagina) |
+| **Severity** | **Medium** (RAG chunk without page context) |
 
-**Root cause:** per nodi orfani `_page_for_node` → `None`; breadcrumbs vuoti, `page_title` metadata `""`, ma `get_effective_properties` eredita ancora proprietà dagli antenati nel registry.
+**Root cause:** for ghost nodes, `_page_for_node` → `None`; breadcrumbs empty, `page_title` metadata `""`, but `get_effective_properties` still inherits ancestor properties from registry.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# journals/T.md vince su pages/T.md; child 'child' con tags:: inherited è fantasma
+# journals/T.md wins over pages/T.md; child 'child' with inherited tags is ghost
 _build_breadcrumbs(ghost) → ('', None)
 to_context_enriched_chunks([ghost_child], graph):
   metadata page_title=''  effective_properties={'tags': 'inherited'}
 ```
 
-**Fix:** dipende da BUG-010 purge; in alternativa saltare nodi orfani in export enriched.
+**Fix:** depends on BUG-010 purge; alternatively skip ghost nodes in enriched export.
 
-**Analisi statica:** `impact(get_effective_properties)` → `to_context_enriched_chunks`.
+**Static analysis:** `impact(get_effective_properties)` → `to_context_enriched_chunks`.
 
 ---
 
-### BUG-024 — MEDIUM: `_export_markdown` duplica sezioni `# Title` con alias
+### BUG-024 — MEDIUM: `_export_markdown` duplicates `# Title` sections with alias
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/kinetic.py` L318–325 |
-| **Severità** | **Medium** (export markdown ridondante) |
+| **Severity** | **Medium** (duplicated markdown output) |
 
-**Root cause:** `_export_markdown(pages)` riceve `list(graph.pages.values())` con alias duplicati; ogni entry genera `# {page.title}` anche se stesso oggetto.
+**Root cause:** `_export_markdown(pages)` receives `list(graph.pages.values())` with alias duplicates; each entry renders `# {page.title}` even for same object.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# alias:: Alt su pagina P
+# alias:: Alt
 _export_markdown(list(g.pages.values()), out)
-graph.md → '# P' compare 2 volte, stesso body 'body'
+graph.md → '# P' appears 2 times with same body 'body'
 ```
 
-**Fix:** `iter_canonical_pages()` (DEBT-001) — stesso pattern di BUG-002/006.
+**Fix:** use `iter_canonical_pages()` (DEBT-001), same pattern as BUG-002/006.
 
 ---
 
-### BUG-025 — LOW: `strict_refs=True` valida solo ref intra-pagina
+### BUG-025 — LOW: `strict_refs=True` validates only same-page references
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/logos_parser.py` `_validate_references` L1329–1342 |
-| **Severità** | **Low** (inconsistenza API / documentazione) |
+| **Severity** | **Low** (API / docs inconsistency) |
 
-**Root cause:** `strict_refs` solleva `BlockReferenceError` solo per `((uuid))` irrisolti **nella stessa pagina**. Ref cross-page verso UUID assente passano silenziosamente.
+**Root cause:** `strict_refs` raises `BlockReferenceError` only for unresolved `((uuid))` **inside the same page**. Cross-page `((uuid))` errors pass silently.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 parse_page_file('- ((missing-uuid))') strict_refs=True → OK (no raise)
 parse_page_file('- ((aaaaaaaa-...))') same-page missing strict_refs=True → BlockReferenceError
 ```
 
-**Fix:** documentare il comportamento o estendere validazione cross-graph (con `LogseqGraph` caricato).
+**Fix:** document current behavior or expand cross-graph validation with loaded `LogseqGraph`.
 
-**Analisi statica:** `query(strict_refs BlockReferenceError)` → test `test_strict_refs_raises_on_unresolved_block_reference` copre solo same-page.
+**Static analysis:** `query(strict_refs BlockReferenceError)` → `test_strict_refs_raises_on_unresolved_block_reference` covers same-page only.
 
 ---
 
-### BUG-026 — MEDIUM: `get_backlinks` non risolve alias → titolo canonico
+### BUG-026 — MEDIUM: `get_backlinks` does not resolve aliases to canonical title
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` `_append_page_backlinks` L626–631, `get_backlinks` L465–481 |
-| **Severità** | **Medium** (API graph incoerente con `get_page`) |
+| **Severity** | **Medium** (API inconsistency with `get_page`) |
 
-**Root cause:** i backlink sono indicizzati sulla stringa letterale del wikilink (`node.wikilinks`), normalizzata in lowercase. `get_page('Alt')` e `get_page('P')` risolvono entrambi la stessa pagina con `alias::`, ma `get_backlinks('P')` non trova link scritti come `[[Alt]]` e viceversa.
+**Root cause:** backlinks are indexed using literal wikilink string (`node.wikilinks`) lowercased. `get_page('Alt')` and `get_page('P')` both resolve to same page via `alias::`, but `get_backlinks('P')` does not match links written as `[[Alt]]`, and vice versa.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
 # P.md: alias:: Alt; Src.md: - [[Alt]]
 get_backlinks('Alt') → 1
 get_backlinks('P')   → 0
 
-# Src.md: - [[P]]  (link al titolo canonico)
+# Src.md: - [[P]] (canonical link)
 get_backlinks('P')   → 1
 get_backlinks('Alt') → 0
 ```
 
-**Fix raccomandato:** all’indicizzazione, risolvere ogni wikilink via `get_page` e registrare il backlink anche sotto `page.title` e tutti gli alias.
+**Recommended fix:** during index build, resolve each wikilink through `get_page` and record backlinks under both `page.title` and aliases.
 
 ---
 
-### BUG-027 — MEDIUM: `_export_json` duplica entry pagina con `alias::`
+### BUG-027 — MEDIUM: `_export_json` duplicates page entry with `alias::`
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
-| **File** | `src/logseq_matryca_parser/kinetic.py` `_export_json` (passa `list(graph.pages.values())`) |
-| **Severità** | **Medium** (payload JSON doppio, stessi UUID blocco) |
+| **File** | `src/logseq_matryca_parser/kinetic.py` `_export_json` (passes `list(graph.pages.values())`) |
+| **Severity** | **Medium** (duplicated JSON payload, same block UUIDs) |
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# alias:: Alt, un solo blocco
+# alias:: Alt, one block
 _export_json(list(g.pages.values()), out)
 → len(graph.json pages) = 2
-→ block UUIDs nel payload: 2 entry, 1 unique uuid
+→ block UUIDs in payload: 2 entries, 1 unique uuid
 ```
 
-**Fix:** `iter_canonical_pages()` (DEBT-001).
+**Fix:** use `iter_canonical_pages()` (DEBT-001).
 
 ---
 
-### BUG-028 — LOW: `get_namespace_children` case-sensitive
+### BUG-028 — LOW: `get_namespace_children` is case-sensitive
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L558–571 |
-| **Severità** | **Low** (inconsistenza con `get_page` case-insensitive) |
+| **Severity** | **Low** (inconsistency with case-insensitive `get_page`) |
 
-**Evidenza:**
+**Evidence:**
 
 ```text
 pages/MyNS/Page.md
@@ -693,18 +693,18 @@ get_namespace_children('MyNS') → ['MyNS/Page']
 get_namespace_children('myns') → []
 ```
 
-**Fix:** casefold del prefisso o lookup via `lower_title_map`.
+**Fix:** casefold namespace prefix or lookup via `lower_title_map`.
 
 ---
 
-### BUG-029 — LOW/MEDIUM: `resolve_relative_page_link` ignora `../` e `./`
+### BUG-029 — LOW/MEDIUM: `resolve_relative_page_link` ignores `../` and `./`
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L531–556 |
-| **Severità** | **Low/Medium** (API incompleta vs Logseq OG) |
+| **Severity** | **Low/Medium** (public API incomplete vs Logseq OG semantics) |
 
-**Evidenza:**
+**Evidence:**
 
 ```text
 current='NS/Child', target='Global'   → 'Global'
@@ -712,40 +712,40 @@ current='NS/Child', target='../Global' → None
 current='NS/Child', target='./Global'  → None
 ```
 
-**Nota analisi statica:** `impact(resolve_relative_page_link)` → 0 caller diretti; API pubblica non usata internamente.
+**Static analysis note:** `impact(resolve_relative_page_link)` → 0 direct callers; API is currently unused internally.
 
-**Fix:** normalizzare path relativi Logseq (`../`, `./`) prima del loop namespace.
+**Fix:** normalize Logseq relative paths (`../`, `./`) before namespace loop.
 
 ---
 
-### BUG-030 — LOW: `resolve_asset_path` risolve path assoluti fuori dal vault
+### BUG-030 — LOW: `resolve_asset_path` resolves absolute paths outside vault
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/logos_core.py` L125–128 |
-| **Severità** | **Low** (superficie security per tooling automatizzato) |
+| **Severity** | **Low** (security surface for automation tooling) |
 
-**Root cause:** `(Path(page.parent) / '/etc/passwd').resolve()` → `/etc/passwd`; se il path esiste, viene restituito senza vincolo al `graph_root`.
+**Root cause:** `(Path(page.parent) / '/etc/passwd').resolve()` becomes `/etc/passwd`; if file exists, it is returned without `graph_root` containment enforcement.
 
-**Evidenza:**
+**Evidence:**
 
 ```text
 content: - ![](/etc/passwd)
-resolve_asset_path('/etc/passwd') → '/private/etc/passwd'  (se file esiste)
+resolve_asset_path('/etc/passwd') → '/private/etc/passwd'  (if file exists)
 ```
 
-**Fix:** rifiutare link assoluti o richiedere che il risultato risieda sotto `graph_root`.
+**Fix:** reject absolute links or require resolved path to stay under `graph_root`.
 
 ---
 
-### BUG-031 — LOW: `get_nodes_by_tag` case-sensitive
+### BUG-031 — LOW: `get_nodes_by_tag` is case-sensitive
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/graph.py` L513–518 |
-| **Severità** | **Low** (stessa famiglia BUG-008 / BUG-015) |
+| **Severity** | **Low** (same family as BUG-008 / BUG-015) |
 
-**Evidenza:**
+**Evidence:**
 
 ```text
 content: - #MyTag
@@ -753,190 +753,190 @@ get_nodes_by_tag('MyTag') → 1
 get_nodes_by_tag('mytag') → 0
 ```
 
-**Fix:** casefold tag in query e in parser, o documentare.
+**Fix:** casefold tags in query and parser, or document behavior.
 
 ---
 
-### Pattern architetturale — DEBT-001: leaky `graph.pages` dict
+### Architectural pattern — DEBT-001: leaky `graph.pages` dict
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
-| **Severità** | **Design debt** (causa radice di BUG-002, BUG-006, BUG-007, BUG-024, BUG-027) |
-| **Principio Uncle Bob** | **ISP** — i consumer non dovrebbero conoscere alias vs chiavi canoniche. |
+| **Severity** | **Design debt** (root cause of BUG-002, BUG-006, BUG-007, BUG-024, BUG-027) |
+| **Uncle Bob principle** | **ISP** — consumers should not rely on alias-aware keys in public dict internals. |
 
-**Sintomo:** `_enrich_pages_index` espone un `dict[str, LogseqPage]` con più chiavi per la stessa pagina (feature per `get_page` / backlink). I consumer che iterano `.values()` senza dedup violano la *dependency rule* verso l’invariante “una pagina = un oggetto”.
+**Symptom:** `_enrich_pages_index` exposes `dict[str, LogseqPage]` with multiple keys per page (feature for `get_page` / backlinks). Consumers iterating `.values()` without dedup are bypassing dependency rule for invariant “one physical page = one object”.
 
-**Raccomandazione Clean Architecture:** aggiungere al use case `LogseqGraph`:
+**Clean Architecture recommendation:** add to `LogseqGraph` use case:
 
 ```python
 def iter_canonical_pages(self) -> Iterator[LogseqPage]:
-    """Yield each physical page once (title key == page.title, dedupe by id)."""
+    """Yield each physical page once (key title equals page.title), deduplicating by id."""
 ```
 
-Usarlo in `kinetic._export_*`, `get_namespace_children`, e documentarlo in `ARCHITECTURE.md`.
+Use it in `kinetic._export_*`, `get_namespace_children`, and document in `ARCHITECTURE.md`.
 
-**Analisi statica:** `query("pages.values alias enrich_pages_index")` → hub `_enrich_pages_index` collegato ad `agent_write`, `scan`, `_export_langchain_enriched`.
+**Static analysis:** `query("pages.values alias enrich_pages_index")` → `_enrich_pages_index` hub connected to `agent_write`, `scan`, `_export_langchain_enriched`.
 
 ---
 
-### BUG-002 — MEDIUM: export Obsidian conta e processa alias duplicati (KINETIC)
+### BUG-002 — MEDIUM: Obsidian export counts and processes alias duplicates (KINETIC)
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/kinetic.py` |
-| **Funzione** | `_export_obsidian` (circa L380–414) |
-| **Severità** | **Medium** (conteggio errato, lavoro ridondante; possibile overwrite) |
+| **Function** | `_export_obsidian` (around L380–414) |
+| **Severity** | **Medium** (wrong counts, redundant processing, possible overwrite) |
 
-**Root cause:** `for page in graph.pages.values()` itera **tutte** le chiavi del dizionario, incluse **alias** (`alias::`) che puntano allo stesso oggetto `LogseqPage`. `_enrich_pages_index` in `graph.py` inietta alias come chiavi aggiuntive.
+**Root cause:** `for page in graph.pages.values()` iterates all dictionary keys, including alias entries (`alias::`) that point to same `LogseqPage`. `_enrich_pages_index` inserts aliases as extra keys.
 
-**Evidenza runtime:**
+**Runtime evidence:**
 
 ```text
-# Pagina con alias:: Alt
+# page with alias:: Alt
 obsidian files: ['Real.md'] count= 2
-# count=2 ma un solo file — stessa page.title "Real" scritta due volte
+# count=2 but single file — same page.title "Real" written twice
 ```
 
-**Fix raccomandato:** iterare pagine canoniche (es. `title == page.title` e `source_path` unico), pattern già usato in `_build_backlink_registry`.
+**Recommended fix:** iterate canonical pages only (e.g., `title == page.title` and unique `source_path`), pattern already used in `_build_backlink_registry`.
 
 ---
 
-### BUG-003 — MEDIUM: page embed case-sensitive in SYNAPSE (sottoinsieme di BUG-001)
+### BUG-003 — MEDIUM: SYNAPSE page embed resolution is case-sensitive (BUG-001 subset)
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/synapse.py` L197 |
-| **Severità** | **Medium** (comportamento diverso da `LogseqGraph.get_page`) |
+| **Severity** | **Medium** (different behavior from `LogseqGraph.get_page`) |
 
-**Evidenza:**
+**Evidence:**
 
 ```text
 get_page('mypage') → True   # case-insensitive
-pages.get('mypage') → None  # usato da synapse
+pages.get('mypage') → None  # used by synapse
 ```
 
-**Principio Uncle Bob:** *Consistency* — un solo modo di risolvere i titoli (API graph pubblica).
+**Uncle Bob principle:** *Consistency* — one title resolution path via public graph API.
 
 ---
 
-### BUG-004 — LOW / design ambiguity: week file agent usa `%W` non settimana ISO
+### BUG-004 — LOW / design ambiguity: agent week file uses `%W` not ISO week
 
-| Campo | Valore |
+| Field | Value |
 | :--- | :--- |
 | **File** | `src/logseq_matryca_parser/agent_writer.py` L144 |
-| **Codice** | `week_id = now.strftime("%Y-W%W")` |
-| **Severità** | **Low** (comportamento documentato dai test, ma semanticamente ambiguo) |
+| **Code** | `week_id = now.strftime("%Y-W%W")` |
+| **Severity** | **Low** (documented in tests, but semantically ambiguous) |
 
-**Evidenza:**
+**Evidence:**
 
 ```text
 2026-05-10  isocal=2026-W19  strftime_W=2026-W18  match=False
 2026-01-01  isocal=2026-W01  strftime_W=2026-W00  match=False
 ```
 
-Il test `test_logseq_agent_write_append_only` **codifica** `2026-W18-agent.md` per il 2026-05-10 (`%W` US week). Se l’operatore si aspetta **ISO 8601** (comune in tooling europeo), i file settimanali finiscono nella settimana sbagliata a inizio/fine anno.
+`test_logseq_agent_write_append_only` currently encodes `2026-W18-agent.md` for 2026-05-10 (`%W` US week). If users expect **ISO 8601** (common in European tooling), weekly files land in wrong week around year boundaries.
 
-**Raccomandazione:** decisione di prodotto esplicita in `ARCHITECTURE.md`; se ISO → `isocalendar()` + aggiornamento test.
+**Recommendation:** make explicit product decision in `ARCHITECTURE.md`; if ISO is required, use `isocalendar()` and update tests.
 
 ---
 
-## 5. Findings — limiti noti (non classificati come bug di regressione)
+## 5. Findings — known limitations (not classified as regressions)
 
-### LIM-001 — Round-trip titoli con punto letterale
+### LIM-001 — Round-trip behavior for literal dots in titles
 
-`filename_to_page_title` applica la regola **legacy Dendron** `.` → `/` (documentata in `ARCHITECTURE.md` § path encoding).
+`filename_to_page_title` applies legacy Dendron rule `.` → `/` (documented in `ARCHITECTURE.md` § path encoding).
 
 ```text
 'Dr. Smith' → back='Dr/ Smith'  (round-trip FAIL)
-'Projects.Secret' → 'Projects/Secret'  (intenzionale legacy)
+'Projects.Secret' → 'Projects/Secret'  (intentional legacy behavior)
 ```
 
-**Status:** comportamento documentato; non è un bug se il vault usa solo namespace `___` o cartelle. È un **trade-off** esplicito tra compatibilità Dendron e titoli con punti letterali.
+**Status:** documented behavior; not a bug when vault uses only `___` namespace or folders. It is an explicit trade-off between Dendron compatibility and literal-dot titles.
 
-### LIM-002 — Titolo pagina vuoto → `untitled.md`
+### LIM-002 — Empty page title maps to `untitled.md`
 
 ```text
 page_title_to_filename('') → ''
 page_title_to_relative_path('') → PosixPath('untitled.md')
-write_logseq_page(page, dest) → scrive su pages/untitled.md (non crash)
+write_logseq_page(page, dest) → writes to pages/untitled.md (no crash)
 ```
 
-Comportamento diverso dalla nota precedente (non più `Errno 21` su path vuoto grazie al fallback `untitled.md`). Resta ambiguo per vault reali. **Copertura:** GFI-04 chiuso in **v1.4.1** (`tests/test_logseq_paths.py`).
+Behavior differs from prior note (no longer `Errno 21` on empty path due to `untitled.md` fallback). Still ambiguous for real vaults. **Coverage:** GFI-04 closed in **v1.4.1** (`tests/test_logseq_paths.py`).
 
 ---
 
-## 6. Debito architetturale (Clean Code / SOLID)
+## 6. Architectural debt (Clean Code / SOLID)
 
-Valutazione secondo i principi di R. C. Martin, senza implicare che il codice sia “sporco” in senso assoluto — il progetto è maturo — ma con margini di miglioramento mirati.
+Evaluation is by Uncle Bob principles and does not imply the code is “dirty”; the project is mature but has precise improvement targets.
 
-| Principio | Osservazione | File / area | Raccomandazione |
+| Principle | Observation | File / area | Recommendation |
 | :--- | :--- | :--- | :--- |
-| **SRP** | `kinetic.py` (~655 righe) orchestra parse, export, stats, agent CLI | `kinetic.py` | Estrarre `export_handlers.py` o visitor registry (già parzialmente fattorizzato con `_export_*`). |
-| **OCP** | Espansione embed in SYNAPSE è un `while` monolitico | `synapse.py` | Strategy per tipo embed (block/page/macro) estendibile senza modificare il loop. |
-| **LSP** | `LogosNode` mutabile vs `LogseqNode` frozen | `logos_core.py` | Mantenere `LogosNode` solo per legacy; evitare nuovi consumer. |
-| **ISP** | Adapter SYNAPSE accede a `graph._page_for_node` (privato) | `synapse.py` L222 | Esporre `graph.page_for_node()` pubblico o protocol `GraphLookup`. |
-| **DIP** | Import lazy `logseq_paths` dentro metodo entity | `logos_core.py` L144 | Accettabile per evitare cicli; alternativa: spostare `resolve_asset_path` in use case layer. |
-| **Boundaries** | `assert bm is not None` in produzione | `synapse.py` L171, L190 | Sostituire con guard espliciti (Clean Code: fail fast leggibile, no assert in `-O`). |
-| **Error handling** | `except ValueError: pass` in normalizzazione timestamp | `logos_parser.py` L500 | Accettabile come fallback chain; **GFI-14 chiuso in v1.4.1** (`tests/test_logos_parser.py`). |
-| **ISP / encapsulation** | Consumer iterano `graph.pages.values()` raw | `kinetic.py`, `graph.py` | `iter_canonical_pages()` — DEBT-001; radice di BUG-002/006/007. |
-| **Use case completeness** | Nessun ramo *delete* in invalidazione incrementale | `graph.py` L641 | BUG-005; watcher senza delete/move — BUG-014 |
+| **SRP** | `kinetic.py` (~655 lines) orchestrates parse, export, stats, agent CLI | `kinetic.py` | Extract `export_handlers.py` or visitor registry (already partially factored with `_export_*`). |
+| **OCP** | SYNAPSE embed expansion is monolithic `while` loop | `synapse.py` | Introduce embed-type strategy (block/page/macro) to extend without changing loop. |
+| **LSP** | Mutable `LogosNode` vs frozen `LogseqNode` | `logos_core.py` | Keep `LogosNode` legacy-only; avoid new consumers. |
+| **ISP** | SYNAPSE adapter reads `graph._page_for_node` (private) | `synapse.py` L222 | Expose public `graph.page_for_node()` or `GraphLookup` protocol. |
+| **DIP** | Lazy import `logseq_paths` inside entity method | `logos_core.py` L144 | Acceptable to avoid cycles; alternative is moving `resolve_asset_path` into use-case layer. |
+| **Boundaries** | `assert bm is not None` in production | `synapse.py` L171, L190 | Replace with explicit guards (Clean Code: readable fail-fast, avoid asserts under `-O`). |
+| **Error handling** | `except ValueError: pass` in timestamp normalization | `logos_parser.py` L500 | Acceptable fallback chain; **GFI-14 closed in v1.4.1** (`tests/test_logos_parser.py`). |
+| **ISP / encapsulation** | Consumers iterate raw `graph.pages.values()` | `kinetic.py`, `graph.py` | `iter_canonical_pages()` — DEBT-001; root of BUG-002/006/007. |
+| **Use case completeness** | No delete branch in incremental invalidation | `graph.py` L641 | BUG-005; watcher without delete/move — BUG-014 |
 
-**Dependency rule:** nessun ciclo di import (analisi statica `check`); la violazione principale è **leaky abstraction** (accesso a membri privati e dizionario `pages` raw).
+**Dependency rule:** no import cycles (static `check`); main violation remains **leaky abstraction** (private member and raw `pages` dict access).
 
 ---
 
-## 7. Gap di copertura test (risk-based)
+## 7. High-risk coverage gap mapping
 
-Linee non coperte con **alto rischio funzionale** (non solo numeri):
+Uncovered lines with **high functional risk** (not just counts):
 
-| Modulo | Miss | Rischio |
+| Module | Miss | Risk |
 | :--- | :--- | :--- |
-| `logos_parser.py` | `_refresh_node` empty bullet + properties | **Critico** — BUG-017 non intercettato |
-| `synapse.py` | embed irrisolti, cicli page | **Alto** — BUG-001 non intercettato |
-| `kinetic.py` | `_export_obsidian`, `_resolve_graph_path` error paths | **Medio** — GFI-01, GFI-19 |
-| `logseq_markdown.py` | round-trip 4-space indent | **Alto** — BUG-021 |
-| `graph.py` | ghost nodes in search/query | **Alto** — BUG-022 (con BUG-010) |
-| `graph.py` | delete invalidate, alias dupes, **pages/journals collision** | **Alto** — BUG-005, BUG-007, **BUG-010** |
-| `agent_writer.py` | **in-memory stale after append**, indent mismatch | **Alto** — BUG-016, BUG-011 |
-| `logseq_markdown.py` | round-trip 4-space indent | **Alto** — BUG-021 |
-| `graph.py` | ghost nodes in search/query/agent-read | **Alto** — BUG-022 (con BUG-010) |
-| `kinetic.py` | `_export_langchain_enriched` alias dupes | **Alto** — BUG-006 |
-| `logseq_paths.py` | titolo vuoto, fallback graph root | **Risolto (v1.4.1)** — GFI-04 |
+| `logos_parser.py` | `_refresh_node` empty bullet + properties | **Critical** — BUG-017 not covered |
+| `synapse.py` | unresolved embeds, page cycles | **High** — BUG-001 not covered |
+| `kinetic.py` | `_export_obsidian`, `_resolve_graph_path` error paths | **Medium** — GFI-01, GFI-19 |
+| `logseq_markdown.py` | round-trip 4-space indentation | **High** — BUG-021 |
+| `graph.py` | ghost nodes in search/query | **High** — BUG-022 (with BUG-010) |
+| `graph.py` | delete invalidate, alias duplicates, **pages/journals collision** | **High** — BUG-005, BUG-007, **BUG-010** |
+| `agent_writer.py` | **in-memory stale after append**, indent mismatch | **High** — BUG-016, BUG-011 |
+| `logseq_markdown.py` | round-trip 4-space indentation | **High** — BUG-021 |
+| `graph.py` | ghost nodes in search/query/agent-read | **High** — BUG-022 (with BUG-010) |
+| `kinetic.py` | `_export_langchain_enriched` alias duplicates | **High** — BUG-006 |
+| `logseq_paths.py` | empty title, fallback graph root | **Fixed (v1.4.1)** — GFI-04 |
 
 ---
 
-## 8. Piano di remediation (ordine suggerito)
+## 8. Remediation plan (suggested order)
 
-| Priorità | ID | Azione | Stima |
+| Priority | ID | Action | Estimate |
 | :--- | :--- | :--- | :--- |
-| P0 | BUG-017 | Guard `first_line` in `_refresh_node` + test outline reale | 1 h |
-| P0 | BUG-001 | Fix loop embed + test synapse | 2–4 h |
-| P0 | BUG-016 | Reload graph dopo `append_child_to_node` | 1–2 h |
-| P0 | BUG-010, BUG-013 | Chiave univoca load_directory + purge ghost registry | 3–4 h |
-| P0 | BUG-005 | Delete-safe `invalidate_and_reload_page` + test watcher | 1–2 h |
-| P1 | BUG-003 | `get_page` in synapse (incluso in P0) | — |
-| P1 | BUG-011, BUG-021 | Indent reale: append + serialize (`tab_size` detection) | 3–4 h |
-| P1 | BUG-022, BUG-023 | Filtro nodi fantasma in search/agent-read/export | con BUG-010 |
-| P1 | BUG-012 | UUID case-normalize in `get_node_by_embed_ref` | 1 h |
-| P1 | DEBT-001 | `iter_canonical_pages()` + usarlo in export/namespace | 2–3 h |
-| P2 | BUG-002, BUG-006, BUG-007 | Deduplica via helper canonico | incluso in P1 |
-| P2 | BUG-026 | Backlink index alias-aware | 2 h |
+| P0 | BUG-017 | Guard `first_line` in `_refresh_node` + real outline test | 1 h |
+| P0 | BUG-001 | Fix embed loop + synapse test | 2–4 h |
+| P0 | BUG-016 | Reload graph after `append_child_to_node` | 1–2 h |
+| P0 | BUG-010, BUG-013 | Unique load_directory key + ghost registry purge | 3–4 h |
+| P0 | BUG-005 | Delete-safe `invalidate_and_reload_page` + watcher test | 1–2 h |
+| P1 | BUG-003 | `get_page` in synapse (included in P0) | — |
+| P1 | BUG-011, BUG-021 | Real indentation handling (`append` + serialize, `tab_size` detection) | 3–4 h |
+| P1 | BUG-022, BUG-023 | Filter ghost nodes in search/agent-read/export | with BUG-010 |
+| P1 | BUG-012 | UUID case normalization in `get_node_by_embed_ref` | 1 h |
+| P1 | DEBT-001 | `iter_canonical_pages()` + use in export/namespace | 2–3 h |
+| P2 | BUG-002, BUG-006, BUG-007 | Canonical dedup via helper | included in P1 |
+| P2 | BUG-026 | Alias-aware backlink index | 2 h |
 | P2 | BUG-014 | Watcher `on_deleted` / `on_moved` | 2 h |
-| P3 | BUG-004 | Decisione ISO vs `%W` + doc/test | 1 h |
-| P4 | BUG-008, BUG-009, BUG-015, BUG-018–020, BUG-024–025, BUG-028–031 | case/`#`/namespace; export dup; asset path | backlog |
-| P5 | Debito | `graph.page_for_node` pubblico; rimuovere `assert` | 2 h |
-| P6 | Coverage | Chiudere GFI-01, GFI-02; wave 2 ([#43](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/43)–[#52](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/52)) | backlog |
+| P3 | BUG-004 | ISO vs `%W` decision + docs/tests | 1 h |
+| P4 | BUG-008, BUG-009, BUG-015, BUG-018–020, BUG-024–025, BUG-028–031 | case/`#`/namespace; export duplicates; asset path | backlog |
+| P5 | Debt | Public `graph.page_for_node`; remove `assert` | 2 h |
+| P6 | Coverage | Close GFI-01, GFI-02; wave 2 ([#43](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/43)–[#52](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/52)) | backlog |
 
-Dopo ogni fix: `make all` + `refresh dell'indice locale` + `impact` sul simbolo modificato.
+After each fix: `make all` + local index refresh + `impact` on changed symbol.
 
 ---
 
-## 9. Script di riproduzione rapida
+## 9. Fast reproduction scripts
 
-Salvare come `scripts/repro_bug_hunt.py` (opzionale) o eseguire inline:
+Save as `scripts/repro_bug_hunt.py` (optional) or execute inline:
 
 ```python
-# BUG-001: hang page embed mancante
+# BUG-001: missing page embed hang
 import signal, tempfile
 from pathlib import Path
 from logseq_matryca_parser.graph import LogseqGraph
@@ -1192,60 +1192,58 @@ with tempfile.TemporaryDirectory() as d:
     print("Alt:", len(g.get_backlinks("Alt")), "P:", len(g.get_backlinks("P")))  # 1, 0
 ```
 
----
+## 10. Full module coverage inventory
 
-## 10. Inventario copertura moduli (mappatura completa)
+Audited all core modules in `src/logseq_matryca_parser/` (waves 1–8). **Status:** no core subsystem without targeted probe.
 
-Audit esauriente su tutti i moduli in `src/logseq_matryca_parser/` (wave 1–8). **Stato:** nessun sotto-sistema core rimasto senza probe mirato.
-
-| Modulo | Probe / analisi statica | Esito |
+| Module | Probe / static analysis | Outcome |
 | :--- | :--- | :--- |
-| `logos_parser.py` | `_refresh_node`, strict_refs, indent, deep nest, properties | BUG-017, BUG-025; altrimenti solido |
-| `logseq_markdown.py` | round-trip 4sp, list props | BUG-021; list props OK |
+| `logos_parser.py` | `_refresh_node`, strict_refs, indent, deep nest, properties | BUG-017, BUG-025; otherwise stable |
+| `logseq_markdown.py` | 4-space round-trip, list props | BUG-021; list props OK |
 | `graph.py` | load, invalidate, query, backlinks, namespace, search | BUG-005,010,013,022,026,028,029,031 |
-| `synapse.py` | embed hang, cycle, enriched | BUG-001,003,018,023 |
-| `kinetic.py` | export `_*`, scan, agent CLI | BUG-002,006,024,027 |
+| `synapse.py` | embed hang, cycles, enriched | BUG-001,003,018,023 |
+| `kinetic.py` | export `_ *`, scan, agent CLI | BUG-002,006,024,027 |
 | `agent_writer.py` | append, indent | BUG-011,016 |
 | `agent_press.py` | X-Ray, alias registry | BUG-009; agent_read path OK (no dup) |
-| `forge.py` | Obsidian suffix, embed resolver | OK (suffix collision non riprodotto) |
+| `forge.py` | Obsidian suffix, embed resolver | OK (suffix collision not reproduced) |
 | `lens.py` | network, stats | BUG-019,020 |
 | `logseq_paths.py` | encode, discover, legacy dot | LIM-001; `.recycle` skip OK |
 | `logos_core.py` | `resolve_asset_path` | BUG-030 |
-| `exceptions.py` | — | Nessun issue (tipi sottili) |
-| `__init__.py` / `__main__.py` | — | Nessun issue |
+| `exceptions.py` | — | No issues (type edge cases) |
+| `__init__.py` / `__main__.py` | — | No issues |
 
-**Comportamenti verificati OK (non bug):** purge UUID su `invalidate_and_reload_page`; catena embed pagina profonda 5 livelli; ciclo A↔B page embed; block backlink registry; `discover_graph_files` esclude `.recycle`; `title::` reload purga vecchia chiave; tab/mixed indent parse; nesting 200 livelli.
+**Verified OK behavior (not bugs):** UUID purge during `invalidate_and_reload_page`; deep page-chain embed of 5 levels; 5-level cyclical embed A↔B; block backlink registry; `discover_graph_files` excludes `.recycle`; `title::` reload purges old key; mixed/tab indentation parse; nesting depth 200.
 
-**Famiglie consolidate (fix unificati):**
+**Consolidated families (unified fixes):**
 
-| Famiglia | Bug ID | Fix unico |
+| Family | Bug ID | Single fix |
 | :--- | :--- | :--- |
 | Ghost registry | 010, 013, 022, 023 | Purge `_node_registry` + `iter_attached_nodes()` |
-| `pages.values()` dup | 002, 006, 019, 024, 027 | `iter_canonical_pages()` (DEBT-001) |
-| Case / `#` tag API | 008, 015, 028, 031 | Normalizzazione unificata in `GraphQuery` / search |
-| Indent / tab_size | 011, 021 | Rilevamento `tab_size` per pagina |
+| `pages.values()` duplicates | 002, 006, 019, 024, 027 | `iter_canonical_pages()` (DEBT-001) |
+| Case / `#` tag API | 008, 015, 028, 031 | Unified normalization in `GraphQuery` / search |
+| Indent / tab_size | 011, 021 | Per-page `tab_size` detection |
 | SYNAPSE embed | 001, 003, 013-block | Fail-safe + `get_page()` |
 
 ---
 
-## 11. Conclusione
+## 11. Conclusion
 
-Il progetto rispetta solidi invarianti deterministici (parser stack-machine, round-trip corpus, assenza cicli di import). I bug più gravi sono:
+The project maintains strong deterministic invariants (stack-machine parser, round-trip corpus, no import cycles). The most serious bugs are:
 
-1. **LOGOS Parser** — crash `IndexError` su bullet vuoto + proprietà (BUG-017); un solo file malformato blocca `load_directory` e `scan`.
-2. **SYNAPSE** — hang su embed irrisolti (BUG-001).
-3. **LOGOS Graph load** — collisioni titolo e nodi fantasma (BUG-010, BUG-013).
-4. **Agent Writer** — disco aggiornato ma AST stale (BUG-016); indent errato (BUG-011).
-5. **LOGOS Graph / Watcher** — crash su delete (BUG-005); eventi delete/move assenti (BUG-014).
-6. **Ghost registry leak** — `search_content`, `agent-read`, SYNAPSE enriched vedono nodi orfani (BUG-022, BUG-023); radice BUG-010/013.
-7. **Serialization** — round-trip 4 spazi → 2 spazi (BUG-021); export markdown duplicato (BUG-024).
-8. **KINETIC export / LENS** — duplicazione con `alias::` (BUG-006, BUG-002, BUG-019, BUG-027) → `iter_canonical_pages()` (DEBT-001).
-9. **API graph incoerenti** — backlinks alias (BUG-026), namespace/tag case (BUG-028, BUG-031).
+1. **LOGOS Parser** — `IndexError` on empty bullet + properties (BUG-017); a single malformed file blocks `load_directory` and `scan`.
+2. **SYNAPSE** — hang on unresolved embeds (BUG-001).
+3. **LOGOS Graph load** — title collisions and ghost nodes (BUG-010, BUG-013).
+4. **Agent Writer** — disk update succeeds but AST remains stale (BUG-016); wrong indentation (BUG-011).
+5. **LOGOS Graph / Watcher** — crash on delete (BUG-005); delete/move events missing (BUG-014).
+6. **Ghost registry leak** — `search_content`, `agent-read`, SYNAPSE enriched see orphan nodes (BUG-022, BUG-023); root cause BUG-010/013.
+7. **Serialization** — round-trip 4-space → 2-space (BUG-021); duplicate markdown export (BUG-024).
+8. **KINETIC export / LENS** — duplication with `alias::` (BUG-006, BUG-002, BUG-019, BUG-027) → `iter_canonical_pages()` (DEBT-001).
+9. **Inconsistent graph API** — alias backlinks (BUG-026), namespace/tag case (BUG-028, BUG-031).
 
-**Mappatura:** 31 bug ID + 2 limitazioni documentate (LIM-001/002) + DEBT-001. Nessun modulo core senza copertura.
+**Coverage:** 31 bug IDs + 2 documented limitations (LIM-001/002) + DEBT-001. No core module lacks coverage.
 
-Prossima fase consigliata: **implementazione fix** — partire da BUG-017 → BUG-010/013 → BUG-001/016 (vedi §8 priorità).
+Next recommended phase: **implement fixes** — start with BUG-017 → BUG-010/013 → BUG-001/016 (see §8 priority).
 
 ---
 
-*Report generato con assistenza da analisi statica locale. Per aggiornare l'indice dopo fix: `refresh dell'indice locale`.*
+*Report generated with local static analysis support. To refresh index after fixes: local index refresh.*

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -1,3 +1,22 @@
+---
+type: ArchitectureGuide
+title: Clean Code and Clean Architecture for Logseq Matryca Parser
+description: Canonical architecture boundaries, SOLID guidance, public graph APIs, and contributor quality contract.
+status: stable
+classification: canonical
+audience: contributors
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2027-02-02
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
 # Clean Code & Clean Architecture — Logseq Matryca Parser
 
 **Version:** documents **v1.6.0** maintainer contracts (v1 structural backlog complete)  

--- a/docs/DOCUMENTATION_SYSTEM.md
+++ b/docs/DOCUMENTATION_SYSTEM.md
@@ -1,0 +1,285 @@
+---
+type: DocumentationGuide
+title: Documentation system and evolution
+description: Canonical guide to documentation authority, structure, metadata, lifecycle, validation, and Matryca Knowledge projection.
+status: stable
+classification: canonical
+audience: contributors
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-08-06
+verified: 2026-08-06
+stale_after: 2027-02-02
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# Documentation system and evolution
+
+This guide explains how documentation in Logseq Matryca Parser is organized,
+maintained, reviewed, and projected into the private Matryca Knowledge registry.
+It is the canonical operating contract for documentation contributors.
+
+The repository uses a federated model: this source repository owns its
+documentation, while Matryca Knowledge owns federation policy, source profiles,
+and reviewed projections. A generated projection or Logseq view is useful for
+discovery, but it never becomes the editing origin.
+
+## 1. Design goals
+
+The documentation system is designed to provide:
+
+1. one stable human portal and one stable machine entry point;
+2. explicit ownership, lifecycle, classification, and freshness;
+3. immutable Git provenance for every federated copy;
+4. deterministic validation before any LLM-assisted interpretation;
+5. preserved historical evidence without treating it as current guidance;
+6. ordinary Markdown links that work both on GitHub and as knowledge-graph
+   edges;
+7. English as the common repository language.
+
+## 2. Authority and projection model
+
+```mermaid
+flowchart LR
+    S["Source repository Markdown"] --> V["Deterministic validation"]
+    V --> P["Content-addressed proposal"]
+    P --> R["Reviewed Matryca Knowledge projection"]
+    R --> L["Generated Logseq navigation"]
+    R --> M["Read-only retrieval surfaces"]
+```
+
+| Surface | Role | May be edited as authority? |
+|---|---|---|
+| This repository | Canonical source for parser documentation | Yes, through reviewed repository changes |
+| Matryca Knowledge source profile | Federation policy and maintained entry-point declaration | Yes, in a separate private-repository change |
+| Matryca Knowledge `knowledge/` | Reviewed, reproducible projection | No; regenerate it from an immutable source commit |
+| Matryca Knowledge `.local/` | Ignored operator inventory, index, and proposals | No |
+| Generated Logseq graph | Disposable navigation view | No |
+| Read-only retrieval interfaces | Cited discovery and retrieval | No |
+
+This separation prevents a projected copy from silently diverging from its
+source. A projection is trustworthy only when repository, commit, path, and
+content hash identify the exact source bytes.
+
+## 3. Documentation surfaces
+
+### 3.1 Maintained bundle
+
+Maintained documents describe current behavior, governance, or decisions. They
+carry the complete metadata contract and are reviewed before their freshness
+date expires.
+
+| Path | Canonical responsibility |
+|---|---|
+| [`index.md`](index.md) | Machine entry point and bundle map |
+| [`README.md`](README.md) | Human navigation by audience and lifecycle |
+| [`DOCUMENTATION_SYSTEM.md`](DOCUMENTATION_SYSTEM.md) | Documentation governance and contributor workflow |
+| [`CLEAN_CODE_ARCHITECTURE.md`](CLEAN_CODE_ARCHITECTURE.md) | Architecture rings, public graph API, and dependency rules |
+| [`REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Current evidence-backed repository roadmap |
+| [`quality/ISSUE_RECONCILIATION_2026-08-06.md`](quality/ISSUE_RECONCILIATION_2026-08-06.md) | Dated GitHub backlog evidence |
+| [`quality/README.md`](quality/README.md) | Quality and architecture navigation |
+| [`decisions/index.md`](decisions/index.md) | Decision registry and ADR gaps |
+| [`reference/index.md`](reference/index.md) | Provenance and ecosystem relations |
+| [`log.md`](log.md) | Chronology of documentation-system changes |
+
+The Matryca Knowledge source profile may select a smaller set of these paths as
+federation entry points. Source maintenance and federation admission are
+related but distinct decisions.
+
+### 3.2 Active supporting documentation
+
+Active supporting documents describe current APIs, operations, contributor
+tasks, or draft proposals. They must be linked from the human portal. They may
+adopt maintained metadata when they enter the profile allowlist, but metadata
+must not be added merely to create the appearance of conformance.
+
+### 3.3 Historical documentation
+
+Historical audits, executed roadmaps, and superseded specifications remain in
+place as evidence. They must be clearly labeled by navigation or metadata and
+must point to their successor when one exists. Do not rewrite historical
+claims, dates, or measured counts as though they described the present.
+
+### 3.4 Generated documentation
+
+Generated artifacts are rebuilt from their source and are never hand-edited.
+They should declare `classification: generated` when they are admitted to a
+maintained profile. A generated view must preserve source links and provenance.
+
+## 4. Metadata contract
+
+Maintained documents use YAML frontmatter. During the transition to an
+official OKF v0.2 parser, the repository retains both the current Matryca field
+`last_verified` and the forward-looking `verified` and `stale_after` fields.
+
+```yaml
+---
+type: ArchitectureGuide
+title: Stable discovery title
+description: Short description of the document's maintained purpose.
+status: draft | stable | deprecated
+classification: canonical | active | historical | generated
+audience: contributors
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: YYYY-MM-DD
+verified: YYYY-MM-DD
+stale_after: YYYY-MM-DD
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+```
+
+### 4.1 Field semantics
+
+| Field | Meaning |
+|---|---|
+| `type` | Stable semantic role used for discovery and canonical-role checks |
+| `title` | Stable human-readable title |
+| `description` | Concise discovery-oriented purpose |
+| `status` | OKF lifecycle only: `draft`, `stable`, or `deprecated` |
+| `classification` | Matryca role: `canonical`, `active`, `historical`, or `generated` |
+| `audience` | Primary reader group |
+| `owner` | Repository or team accountable for review |
+| `authority` | Surface that owns the document; normally `source_repository` |
+| `execution_mode` | How changes become authoritative; normally `reviewed` |
+| `last_verified` | Compatibility date consumed by the current deterministic validator |
+| `verified` | Explicit verification date for the evolving v0.2-aligned profile |
+| `stale_after` | Date after which the content requires review |
+| `okf_profile` | Matryca profile name, distinct from an official specification version |
+| `okf_spec_version` | Official OKF version, or `null` while conformance is not claimed |
+| `supersedes` / `superseded_by` | Explicit lifecycle edges between documents |
+
+`status` must never contain Matryca classifications such as `canonical` or
+`active`. Likewise, `classification` must not be interpreted as an official
+OKF lifecycle result.
+
+## 5. Freshness policy
+
+Freshness is evidence, not a timestamp bump.
+
+| Document kind | Default review window | Verification expectation |
+|---|---:|---|
+| Canonical architecture or documentation policy | 180 days | Compare against current source, public contracts, and policy baseline |
+| Active roadmap or quality index | 90 days | Reconcile live implementation and issue state |
+| Dated issue ledger | 30 days | Recheck GitHub state or mark the ledger historical |
+| Historical document | No recurring refresh | Verify classification and successor links only |
+| Generated document | At every regeneration | Verify generator, source commit, and content hash |
+
+If a document cannot be re-verified, keep its original evidence date and change
+its classification or lifecycle truthfully. Never extend `stale_after` solely
+to satisfy a gate.
+
+## 6. Links, identity, and canonical roles
+
+- Keep maintained Markdown paths stable.
+- Use relative Markdown links for repository-local relations.
+- Validate both target files and heading anchors.
+- Declare only one canonical owner for each semantic `type` within a profile.
+- Use explicit supersession links when replacing a maintained document.
+- Do not use absolute operator paths, runtime logs, secrets, or credentials.
+- Do not copy volatile metrics into several active documents. Link to a dated,
+  reproducible report instead.
+
+Renaming a maintained path is a migration. Update inbound links, preserve a
+redirect or compatibility stub when readers depend on the old path, and record
+the change in [`log.md`](log.md).
+
+## 7. Contribution workflow
+
+### 7.1 Before editing
+
+1. Start at [`README.md`](README.md) and identify whether the target is
+   maintained, active, historical, or generated.
+2. Confirm the canonical document for the topic; avoid creating a parallel
+   source of truth.
+3. Check current implementation, issues, and immutable source references.
+4. Define whether the change affects source documentation only or also requires
+   a separate Matryca Knowledge profile/projection update.
+
+### 7.2 While editing
+
+1. Write in English.
+2. Keep the existing path unless a migration is necessary.
+3. Update metadata only when verification was actually performed.
+4. Add ordinary Markdown links for all important relations.
+5. Update [`log.md`](log.md) for documentation-system or canonical-role changes.
+6. Add an `Unreleased` changelog entry for contributor-visible changes.
+
+### 7.3 Before publication
+
+1. Run `make vendor-name-check` and `make all`.
+2. Confirm the documentation change did not mutate generated snapshots.
+3. Review links, anchors, lifecycle, ownership, and freshness.
+4. Inspect the staged diff and commit only intended files.
+5. Record checks and Matryca/OKF impact in the pull-request description.
+
+The current `make all` gate validates repository quality and vendor-neutral
+documentation. Full MKQ-4 source enforcement remains tracked separately until
+the shared profile and source-local deterministic checks are integrated.
+
+## 8. Federation workflow
+
+After an authoritative parser documentation commit is merged:
+
+1. update the `logseq-matryca-parser` source profile in Matryca Knowledge when
+   entry points or profile rules changed;
+2. operate from clean, immutable source commits;
+3. run the deterministic OKF-inspired audit;
+4. generate a content-addressed proposal without mutating the reviewed tree;
+5. inspect its quality report, source paths, hashes, and removals;
+6. apply the verified proposal atomically;
+7. verify the projection manifest and every projected Markdown hash;
+8. publish the projection through a separate reviewed pull request;
+9. regenerate Logseq and retrieval views from the accepted projection.
+
+This repository must not claim successful federation until the private profile
+includes the entry points and the resulting projection passes its own checks.
+
+## 9. How the documentation evolved
+
+| Stage | Improvement | Remaining limitation at that stage |
+|---|---|---|
+| Original design-driven phase | Detailed architecture blueprints and domain research | Historical and current guidance were difficult to distinguish |
+| Contributor-navigation phase | `docs/README.md`, cookbook, starter issues, and quality indexes | No machine entry point or lifecycle metadata |
+| Clean Architecture phase | Canonical architecture SSOT and vendor-neutral maintainer policy | Documentation quality was mostly prose-enforced |
+| Stellar audit phase | Evidence-backed roadmap, issue reconciliation, entry points, classification, and freshness | Private source profile still lacked parser entry points |
+| English standardization | Repository documentation and maintainer text moved to one shared language | Governance needed a single explanatory contract |
+| Current federated phase | This guide defines authority, metadata, lifecycle, validation, and projection boundaries | MKQ-4 enforcement and private registry activation remain separate gates |
+
+The intended end state is not a mass rewrite. It is a small, clearly owned
+maintained bundle surrounded by discoverable active material and preserved
+historical evidence.
+
+## 10. Current conformance statement
+
+This repository uses the `matryca_okf_inspired_quality` profile. It does not
+claim official OKF v0.1 or v0.2 conformance. The Matryca source-manifest version,
+Matryca quality-profile version, and official OKF specification version are
+separate concepts and must be reported independently.
+
+The source-side documentation structure currently satisfies the intended
+MKQ-1 and MKQ-2 shape and is designed for MKQ-3 validation. MKQ-4 is reached
+only when deterministic source CI enforcement and the private registry profile
+are both active and passing.
+
+## 11. Normative references
+
+- [Documentation portal](README.md)
+- [Knowledge bundle](index.md)
+- [Documentation evolution log](log.md)
+- [Architecture SSOT](CLEAN_CODE_ARCHITECTURE.md)
+- [Reference and provenance index](reference/index.md)
+- [Matryca Knowledge](https://github.com/MarcoPorcellato/matryca-knowledge)
+- [Matryca Plumber](https://github.com/MarcoPorcellato/matryca-plumber)
+
+The Matryca Knowledge policy baseline used for this guide is commit
+[`7a3ebd8`](https://github.com/MarcoPorcellato/matryca-knowledge/commit/7a3ebd8),
+fetched and reviewed on 2026-08-06.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,13 @@ status: stable
 classification: canonical
 audience: contributors
 owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
 last_verified: 2026-08-06
 verified: 2026-08-06
 stale_after: 2027-02-02
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
 supersedes: null
 superseded_by: null
 ---
@@ -17,17 +21,22 @@ superseded_by: null
 
 Use this page to find **active** documentation. Files under [`design-docs/`](design-docs/) are historical blueprints from the Document-Driven Development phase — see [`design-docs/README.md`](design-docs/README.md) before implementing from those specs.
 
-This repository is authoritative for its documentation. Its future projection
+This repository is authoritative for its documentation. Its projection
 into [Matryca Knowledge](https://github.com/MarcoPorcellato/matryca-knowledge)
 must remain reproducible from an immutable source commit; generated Logseq views
 are navigation layers, not the source of truth. The current target is Matryca
 quality level MKQ-4, not a claim of official OKF conformance.
+
+Read the [documentation system and evolution guide](DOCUMENTATION_SYSTEM.md)
+before changing canonical roles, metadata, lifecycle, paths, or federation
+entry points.
 
 ## Active documentation
 
 | Document | Audience | Purpose |
 | :--- | :--- | :--- |
 | [`index.md`](index.md) | Tools, maintainers | Canonical machine entry point for the maintained knowledge bundle |
+| [`DOCUMENTATION_SYSTEM.md`](DOCUMENTATION_SYSTEM.md) | Contributors, maintainers | Canonical documentation governance, metadata, lifecycle, validation, and federation workflow |
 | [`CLEAN_CODE_ARCHITECTURE.md`](CLEAN_CODE_ARCHITECTURE.md) | Contributors, maintainers | Uncle Bob rings, SOLID, module maps, layer CI |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Contributors, integrators | LOGOS, SYNAPSE, `LogseqGraph`, agents, data flow |
 | [`quality/`](quality/) | Maintainers | Architecture backlog (v1 complete), GitHub roadmap, triage |

--- a/docs/REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md
+++ b/docs/REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md
@@ -1,7 +1,7 @@
 ---
 type: RepositoryAudit
-title: Studio approfondito della repository - opportunita di miglioramento
-description: Baseline storica del 2026-07-28, superata dal successivo audit stellare.
+title: Deep repository study - improvement opportunities
+description: Historical baseline as of 2026-07-28, superseded by the subsequent stellar audit.
 status: deprecated
 classification: historical
 audience: maintainers
@@ -13,67 +13,66 @@ supersedes: null
 superseded_by: docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
 ---
 
-# Studio approfondito della repository — opportunità di miglioramento
+# Deep repository study - improvement opportunities
 
-> **Documento storico.** È conservato come baseline del 2026-07-28 ed è
-> sostituito da [`REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md),
-> che include probe aggiuntivi, stato issue aggiornato e piano documentale MKQ-4.
+> **Historical document.** It is kept as a 2026-07-28 baseline and is superseded by [`REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md),
+> which includes additional probes, updated issue status, and an MKQ-4 documentation roadmap.
 
-**Data:** 2026-07-28  
-**Scope:** architettura, correttezza, affidabilità, sicurezza, performance, test, supply chain, release engineering, documentazione e developer experience.  
-**Metodo:** lettura semantica dei flussi, revisione del codice e dei workflow, controlli locali e probe isolati. Non sono state modificate parti del runtime.
+**Date:** 2026-07-28
+**Scope:** architecture, correctness, reliability, security, performance, testing, supply chain, release engineering, documentation, and developer experience.
+**Method:** semantic flow reading, code and workflow review, local checks, and isolated probes. Runtime code was not modified.
 
-## Sintesi esecutiva
+## Executive summary
 
-Il progetto è una libreria Python matura e ben curata per convertire il Markdown spaziale di Logseq in un AST tipizzato, un indice di grafo e formati di esportazione. I suoi punti più forti sono:
+The project is a mature, well-maintained Python library that converts Logseq block Markdown into a typed AST, a graph index, and export formats. Its strongest points are:
 
-- modello di dominio piccolo e tipizzato;
-- parsing deterministico con copertura eccellente dei casi sintattici difficili;
-- invarianti di indice già difesi (niente nodi orfani dopo reload e collisioni);
-- confini architetturali testati e zero cicli di import;
-- pipeline CI, dependency audit e distribuzione PyPI già presenti.
+- a compact, typed domain model;
+- deterministic parsing with excellent coverage of difficult syntax cases;
+- index invariants already enforced (no orphan nodes after reload and collisions);
+- architecture boundaries covered and zero import cycles;
+- CI pipeline, dependency auditing, and PyPI distribution already in place.
 
-La direzione consigliata non è riscrivere la base: è rendere espliciti i contratti che oggi sono impliciti. Le priorità concrete sono: evitare perdita silenziosa nelle collisioni di titolo, rendere atomiche le operazioni concorrenti di writer/watcher, trasformare il lint CI in un vero gate non mutante, e creare un corpus di compatibilità e benchmark ripetibili.
+The advised direction is not a complete rewrite: make contracts that are currently implicit explicit. The concrete priorities are to avoid silent data loss in title collisions, make writer/watcher concurrent operations atomic, turn the CI lint into a non-mutating production gate, and create a reproducible compatibility corpus and benchmark suite.
 
-| Priorità | Tema | Perché ora | Risultato atteso |
+| Priority | Theme | Why now | Expected outcome |
 |---|---|---|---|
-| P0 | Integrità del gate CI | Il lint usato dalla CI corregge anziché rifiutare | Un commit non formattato non può passare senza diff |
-| P1 | Collisioni di pagina | Due file con lo stesso titolo perdono silenziosamente un contenuto | Conflitto diagnosticato o rifiutato in modalità strict |
-| P1 | Concorrenza writer/watcher | Read-modify-write e aggiornamento indici non hanno un contratto di serializzazione | Nessun update perso e snapshot coerenti |
-| P1 | Contratto di compatibilità Logseq | Molti edge case sono testati, ma manca una suite versionata di corpus e metamorphic tests | Regressioni rilevate prima del rilascio |
-| P1 | Hardening release/supply chain | Workflow e artefatti possono avere prove più forti | Release verificabile, riproducibile e attribuibile |
-| P2 | Osservabilità, performance e API | Buon logging, ma mancano SLO, benchmark e contratti macchina | Operatività e diagnosi più rapide |
-| P3 | Modularizzazione parser | Il parser è il grande hub residuo | Cambi locali più sicuri e più leggibili |
+| P0 | CI lint integrity | Lint used in CI currently fixes files instead of rejecting | A formatting violation cannot pass CI without a diff |
+| P1 | Page collisions | Two files with the same title can silently drop content | Report or reject conflicts in strict mode |
+| P1 | Writer/watcher concurrency | Read-modify-write and index refreshes have no serialization contract | No lost updates and consistent snapshots |
+| P1 | Logseq compatibility contract | Many edge cases are tested, but a versioned corpus and metamorphic tests are missing | Regressions detected before release |
+| P1 | Release/supply-chain hardening | Workflow and artifacts can have stronger verification | Verifiable, reproducible, attributable releases |
+| P2 | Observability, performance, and API | Good logging exists, but SLOs, benchmarks, and machine contracts are missing | Faster operations and faster diagnosis |
+| P3 | Parser modularization | The parser remains a large hub | Safer and clearer local changes |
 
-## Evidenze raccolte
+## Collected evidence
 
-| Controllo | Esito |
+| Check | Outcome |
 |---|---:|
-| Test raccolti | 462 |
-| Test eseguiti | 462 passati |
-| Coverage totale | 91,09% |
-| Soglia coverage | 80% |
-| Lint | nessun problema rilevato |
-| Type check | nessun errore rilevato |
-| Cicli di import in `src/` | 0 |
-| Lockfile | coerente con `pyproject.toml` |
-| CLI | `matryca-parse --help` operativo |
-| Artefatti | sdist e wheel di `1.6.0` costruiti correttamente |
-| Audit dipendenze runtime | nessuna vulnerabilità nota al momento della verifica |
+| Tests collected | 462 |
+| Tests run | 462 passed |
+| Total coverage | 91.09% |
+| Coverage threshold | 80% |
+| Lint | no issues found |
+| Type check | no errors found |
+| Import cycles in `src/` | 0 |
+| Lockfile | consistent with `pyproject.toml` |
+| CLI | `matryca-parse --help` is functional |
+| Artifacts | 1.6.0 sdist and wheel built successfully |
+| Runtime dependency audit | no known vulnerabilities at verification time |
 
-Le lacune di coverage più significative non compromettono il gate globale, ma meritano attenzione mirata: `logos_core.py` (75%), `agent_writer.py` (77%) e l'entry point `__main__.py` (0%). La gravità dipende dal flusso: il writer modifica file utente ed è quindi più importante di una semplice percentuale aggregata.
+The most relevant coverage gaps do not invalidate the global gate, but merit focused attention: `logos_core.py` (75%), `agent_writer.py` (77%), and `__main__.py` entrypoint (0%). Severity depends on flow criticality: writer touches user files, so it is more impactful than a plain aggregate percentage.
 
-## Architettura attuale
+## Current architecture
 
 ```mermaid
 flowchart LR
-    Files["Vault Logseq\npages/ + journals/"] --> Paths["logseq_paths\nscoperta e normalizzazione"]
+    Files["Logseq Vault\npages/ + journals/"] --> Paths["logseq_paths\ndiscovery and normalization"]
     Paths --> Parser["logos_parser\nStackMachineParser"]
     Parser --> Domain["logos_core\nLogseqPage / LogseqNode"]
-    Domain --> Graph["graph\nindici, query, watcher"]
-    Graph --> Synapse["synapse + synapse_embed\nRAG e context chunks"]
+    Domain --> Graph["graph\nindexes, query, watcher"]
+    Graph --> Synapse["synapse + synapse_embed\nRAG and context chunks"]
     Domain --> Forge["forge\nJSON / Markdown / Obsidian"]
-    Graph --> Writer["agent_writer\nappend atomico + reload"]
+    Graph --> Writer["agent_writer\nappend atomic + reload"]
     Graph --> Lens["lens\nnetwork visualization"]
     Graph --> CLI["kinetic + kinetic_commands/export\nTyper CLI"]
     Synapse --> CLI
@@ -81,67 +80,67 @@ flowchart LR
     Writer --> CLI
 ```
 
-### Cosa funziona bene nella struttura
+### What works well in the structure
 
-1. **Core separato dalle integrazioni.** `logos_core.py` mantiene le entità; gli adapter di RAG, visualizzazione e formati restano laterali e opzionali.
-2. **Grafo come API applicativa.** `LogseqGraph` offre accessi canonici, backlink, query e reload incrementale, evitando che ogni consumer ricostruisca propri indici.
-3. **Parser deterministico.** Il parser mantiene stack, indentazione, proprietà, drawer, riferimenti e normalizzazione in un singolo percorso coerente.
-4. **Protezione contro regressioni già forte.** I test coprono UUID sintetici, embed ciclici, frontmatter, namespace, backlink, strict references, tab width, watcher e writer.
-5. **Buona disciplina di distribuzione.** Lockfile, test su Python 3.12/3.13, audit dipendenze e pubblicazione con OIDC sono una base affidabile.
+1. **Core separated from integrations.** `logos_core.py` owns entities; optional adapters (RAG, visualization, export formats) remain peripheral.
+2. **Graph as application API.** `LogseqGraph` provides canonical access, backlinks, query, and incremental reload, preventing each consumer from rebuilding indexes.
+3. **Deterministic parser.** The parser keeps stack, indentation, properties, drawers, references, and normalization in one coherent path.
+4. **Strong regression protection already in place.** Tests cover synthetic UUIDs, cyclic embeds, frontmatter, namespace, backlinks, strict references, tab width, watcher, and writer flows.
+5. **Good distribution discipline.** Lockfile, Python 3.12/3.13 testing, dependency audit, and OIDC-based publishing already provide a strong baseline.
 
-### Punto di pressione architetturale
+### Architectural pressure point
 
-`StackMachineParser.parse()` contiene contemporaneamente scansione, gestione stati, costruzione AST, estrazione semantica e recupero da input malformato; è un hub intenzionale, ma lungo circa 400 righe. `_refresh_node()` ricostruisce molte proiezioni derivate del nodo. È corretto preservare il comportamento, ma la prossima evoluzione del parser deve ridurre il costo cognitivo senza spezzarne la determinismo.
+`StackMachineParser.parse()` currently performs scanning, state management, AST construction, semantic extraction, and malformed input recovery in one place; it is intentionally a hub but around 400 lines. `_refresh_node()` also rebuilds many derived projections. Preserving current behavior is correct, but future parser evolution should reduce cognitive load without breaking determinism.
 
 ```text
 Markdown lines
     |
     v
-[classificazione] -> [stato lessicale] -> [evento tipizzato]
+[classification] -> [lexical state] -> [typed event]
                                                    |
                                                    v
-                  [riduttore AST] -> [arricchimento semantico] -> LogseqPage
+                  [AST reducer] -> [semantic enrichment] -> LogseqPage
 ```
 
-Questa separazione non richiede un framework: basta introdurre confini interni e testare ogni passaggio.
+This separation does not require a new framework: add internal boundaries and test each stage.
 
-## Findings e interventi raccomandati
+## Recommended findings and actions
 
-### P0 — Rendere il lint CI non mutante
+### P0 — Make CI lint non-mutating
 
-**Evidenza.** `make lint` esegue `ruff check . --fix`, e la CI invoca `make lint`. Il runner può quindi correggere il checkout e concludere con successo: il gate non prova che il commit ricevuto fosse già conforme.
+**Evidence.** `make lint` runs `ruff check . --fix`, and CI executes `make lint`. The runner can therefore mutate the checkout and still pass, meaning the gate no longer proves the incoming commit was compliant.
 
-**Rischio.** Si perde il ruolo di barriera preventiva; un contributor può ricevere un verde CI ma un working tree locale diverso da quello verificato. In una futura pipeline che riusi lo stesso checkout, file modificati implicitamente possono contaminare step successivi.
+**Risk.** The preventive gate is weakened; a contributor may see a green CI while their working tree differs from the verified state. If the same checkout is reused later, implicit edits can contaminate downstream steps.
 
-**Intervento.** Separare controllo e correzione, rendendo il primo l'unico usato in CI.
+**Action.** Split validation and auto-fix, using only validation in CI.
 
 ```make
 lint:
-	uv run ruff check .
+\tuv run ruff check .
 
 lint-fix:
-	uv run ruff check . --fix
+\tuv run ruff check . --fix
 
 format-check:
-	uv run ruff format --check .
+\tuv run ruff format --check .
 
 format:
-	uv run ruff format .
+\tuv run ruff format .
 ```
 
-**Criteri di accettazione.**
+**Acceptance criteria.**
 
-- un file con import non ordinati fa fallire CI;
-- `make lint-fix` resta ergonomico localmente;
-- CI esegue anche `format-check` oppure verifica esplicitamente che `git diff --exit-code` sia vuoto dopo ogni step mutante.
+- a file with unsorted imports fails CI;
+- `make lint-fix` remains ergonomic for local use;
+- CI also runs `format-check` or explicitly asserts `git diff --exit-code` after mutating steps.
 
-### P1 — Rendere esplicita la policy sulle collisioni di titolo
+### P1 — Make title collision policy explicit
 
-**Evidenza.** `LogseqGraph.load_directory()` inserisce le pagine con `pages[page.title] = page` dopo un ordinamento per path. Un probe con `pages/Daily.md` e `journals/Daily.md` ha prodotto una sola pagina canonica (`pages/Daily.md`); il comportamento è coperto intenzionalmente dai test per evitare nodi fantasma.
+**Evidence.** `LogseqGraph.load_directory()` stores pages with `pages[page.title] = page` after sorting paths. A probe with `pages/Daily.md` and `journals/Daily.md` produced only one canonical page (`pages/Daily.md`); tests currently cover this behavior to avoid orphan nodes.
 
-**Valutazione.** L'invariante attuale è internamente coerente, ma l'esclusione del file perdente è silenziosa: export, ricerca e RAG possono omettere conoscenza senza avviso. È una scelta di prodotto da trasformare in contratto esplicito.
+**Assessment.** The current invariant is internally consistent, but silent exclusion of the losing file is a product behavior issue: export/query/RAG can omit information without warning. This should be turned into an explicit contract.
 
-**Proposta.** Mantenere il default retrocompatibile solo per una release minore, ma raccogliere conflitti strutturati; introdurre `strict_title_collisions=True` e una diagnostica leggibile dalla CLI.
+**Proposal.** Keep the permissive default for one minor release, but collect structured conflicts; add `strict_title_collisions=True` and CLI-readable diagnostics.
 
 ```python
 @dataclass(frozen=True)
@@ -165,15 +164,15 @@ def index_pages(parsed: list[tuple[Path, LogseqPage]], *, strict: bool) -> Index
     return IndexResult(by_title, collisions)
 ```
 
-**Test da aggiungere.** Collisione pages/journals, due `title::` uguali, alias che collide con titolo, CLI `scan --strict-title-collisions`, serializzazione diagnostica JSON. Documentare chiaramente il tie-breaker finché il default rimane permissivo.
+**Tests to add.** Pages/journals collision, two files with identical `title::`, alias colliding with title, `scan --strict-title-collisions` CLI path, JSON diagnostic serialization. Explicitly document tie-breaker while permissive mode remains default.
 
-### P1 — Contratto di concorrenza per watcher, writer e lettori
+### P1 — Concurrency contract for watcher, writer, and readers
 
-**Evidenza.** Il writer effettua un read-modify-write e `os.replace`, poi richiama il reload. Il watcher può aggiornare contemporaneamente gli indici; `invalidate_and_reload_page()` sostituisce `pages`, poi mappa titoli, registro nodi e backlink in passaggi distinti. L'atomic rename protegge dalla scrittura parziale, non da due writer che leggono la stessa versione e sovrascrivono modifiche reciproche.
+**Evidence.** Writer performs read-modify-write and `os.replace`, then calls reload. Watcher can concurrently update indexes; `invalidate_and_reload_page()` mutates `pages`, then title map, node registry, and backlink map in separate passes. Atomic rename protects partial writes only, not two writers reading the same state and overwriting each other.
 
-**Rischio.** In un processo con watcher attivo e richieste simultanee, un lettore può osservare indici transitori; due append possono perdere una modifica. È un rischio di concorrenza da trattare prima di offrire l'API come servizio long-running.
+**Risk.** In a process with active watcher and concurrent requests, a reader can observe transient partial indexes; concurrent appends can drop updates. This is a concurrency risk that should be handled before offering long-running service-style APIs.
 
-**Proposta.** Definire una sola coda di mutazione per vault e pubblicare snapshot immutabili del grafo.
+**Proposal.** Define a single mutation queue per vault and publish immutable graph snapshots.
 
 ```python
 class VaultCoordinator:
@@ -182,7 +181,7 @@ class VaultCoordinator:
         self._snapshot = initial
 
     def read(self) -> GraphSnapshot:
-        return self._snapshot                  # snapshot completo, mai parziale
+        return self._snapshot                  # complete snapshot, never partial
 
     def mutate_file(self, path: Path, transform: Callable[[str], str]) -> None:
         with self._lock:
@@ -193,13 +192,13 @@ class VaultCoordinator:
             emit_change_event(path, self._snapshot.version)
 ```
 
-**Criteri di accettazione.** Test con due append concorrenti, lettura mentre avviene un reload, rename/delete durante debounce, callback che non blocca il thread del watcher, nessuna finestra in cui UUID e backlink appartengono a versioni diverse.
+**Acceptance criteria.** Tests covering two concurrent appends, read during reload, rename/delete during debounce, and a callback that does not block watcher thread; no state window where UUID/backlinks belong to different versions.
 
-### P1 — Corpus di compatibilità e test metamorfici del parser
+### P1 — Compatibility corpus and parser metamorphic tests
 
-**Evidenza.** Il parser ha 95% di coverage e un'eccellente suite di esempi, ma la sintassi Logseq ha edge case quasi illimitati e il comportamento dipende dall'evoluzione dell'editor. La coverage da sola non misura la compatibilità semantica.
+**Evidence.** Parser coverage is strong and the test suite is excellent, but Logseq syntax has many edge cases and editor behavior evolves. Coverage alone does not guarantee semantic compatibility.
 
-**Proposta.** Versionare un corpus di vault minimali e aggiungere proprietà invarianti, senza rendere i test fragili o dipendenti dalla rete.
+**Proposal.** Version a corpus of minimal vault fixtures and add invariant tests without making tests brittle or network-dependent.
 
 ```text
 tests/fixtures/compat/
@@ -208,7 +207,7 @@ tests/fixtures/compat/
   v1/embeds/
   v1/journals/
   v1/recovery/
-  manifest.json  # input, risultato semantico atteso, origine e invariant
+  manifest.json  # input, expected semantic result, origin, and invariant
 ```
 
 ```python
@@ -224,42 +223,42 @@ def test_file_discovery_order_does_not_change_canonical_snapshot(vault: Path) ->
     assert load_with_order(vault, forward) == load_with_order(vault, reverse)
 ```
 
-**Nota.** Per gli input volutamente malformati l'assert non deve essere identità testuale: deve essere terminazione, assenza di crash, AST coerente e diagnostica classificata.
+**Note.** For intentionally malformed inputs, assertions should not require textual equality. They should require termination, no crash, coherent AST, and classified diagnostics.
 
-### P1 — Rafforzare release engineering e supply chain
+### P1 — Strengthen release engineering and supply chain
 
-**Evidenza.** La CI effettua audit dipendenze e la pubblicazione usa OIDC; sono buone basi. I workflow però usano tag mobili delle action e la release GitHub e la pubblicazione PyPI sono workflow indipendenti attivati dal tag. La pubblicazione ricostruisce artefatti in un job separato dal pre-flight.
+**Evidence.** CI already runs dependency checks and publishing uses OIDC; these are good foundations. Workflows still rely on movable action tags, and release creation plus PyPI publish are separate tag-driven jobs. Publishing reconstructs artifacts in a separate job than pre-flight.
 
-**Interventi.**
+**Actions.**
 
-1. Pin delle action a commit SHA, con commento della versione leggibile.
-2. Build una sola volta dopo il gate; caricare wheel e sdist come artifact; pubblicare esattamente quegli artifact.
-3. Verificare prima della pubblicazione: tag `vX.Y.Z` = metadata del package = `__version__`, `twine check`, e changelog con sezione non vuota.
-4. Collegare la release GitHub alla conclusione del publish oppure farle consumare lo stesso artifact attestato.
-5. Generare SBOM e provenance dell'artefatto se la distribuzione diventa un confine di sicurezza significativo.
+1. Pin actions to commit SHA and retain human-readable version comments.
+2. Build once after gate completion; upload wheel and sdist as artifacts; publish exactly those artifacts.
+3. Verify before publish: tag `vX.Y.Z` equals package metadata and `__version__`, `twine check` passes, and changelog has a non-empty section.
+4. Link GitHub release to publish completion, or consume the same attested artifact.
+5. Generate SBOM and provenance when artifact distribution becomes a meaningful security boundary.
 
 ```mermaid
 sequenceDiagram
-    participant Tag as Tag firmato
+    participant Tag as Signed tag
     participant Gate as Quality gate
-    participant Build as Build unico
+    participant Build as Single build
     participant Store as Artifact store
     participant PyPI as PyPI
     participant Release as GitHub release
 
-    Tag->>Gate: verifica versione, test, audit, lint non mutante
-    Gate->>Build: autorizza
+    Tag->>Gate: verify version, tests, audit, non-mutating lint
+    Gate->>Build: authorize
     Build->>Store: wheel + sdist + checksum + SBOM
-    Store->>PyPI: pubblica artifact verificato
-    PyPI-->>Release: publish riuscito
-    Store->>Release: allega stessi artifact e provenance
+    Store->>PyPI: publish verified artifact
+    PyPI-->>Release: publish succeeded
+    Store->>Release: attach same artifact + provenance
 ```
 
-### P2 — Budget prestazionali e scalabilità misurata
+### P2 — Measured performance and scalability
 
-**Evidenza.** Il caricamento concorrente è una buona scelta; mancano però benchmark versionati, dataset di dimensione dichiarata e budget di memoria/tempo. `search_content` e molte query sono scansioni lineari: corrette per vault medi, potenzialmente costose per un server o vault molto grandi.
+**Evidence.** Concurrent loading is a good choice; versioned benchmarks, explicit dataset sizes, and memory/time budgets are still missing. `search_content` and many query paths are linear scans: correct for medium vaults, potentially costly for large-server workloads.
 
-**Proposta.** Aggiungere benchmark separati dal gate veloce e metriche comparabili tra release.
+**Proposal.** Add dedicated benchmarks outside the fast gate and comparable metrics across releases.
 
 ```python
 @benchmark
@@ -272,13 +271,13 @@ def test_incremental_reload(benchmark, loaded_10k_graph, changed_file):
     benchmark(loaded_10k_graph.invalidate_and_reload_page, changed_file)
 ```
 
-Definire budget iniziali realisti (p95 load, p95 reload, RSS) solo dopo una baseline su runner stabile. Se le query diventano un hot path, introdurre indici opzionali per testo/tag con un contratto di invalidazione unico, non ottimizzazioni sparse.
+Set realistic baseline budgets first (p95 load, p95 reload, RSS) after a stable runner baseline. If queries become a hot path, add optional indices with a single invalidation contract, not isolated micro-optimizations.
 
-### P2 — Osservabilità orientata al prodotto
+### P2 — Product-oriented observability
 
-**Evidenza.** Esiste logging utile e dettagliato in tutti i moduli. Manca un modello uniforme per diagnosi di parser, collisioni, riferimenti irrisolti, reload e export: oggi molte informazioni sono solo stringhe di log.
+**Evidence.** Logging is useful and detailed across modules. A uniform serializable model for parser, collision, unresolved reference, reload, and export diagnostics is missing; many states are still logged as ad-hoc text.
 
-**Proposta.** Introdurre un `Diagnostic` serializzabile, mantenendo il logging come sink.
+**Proposal.** Add a serializable `Diagnostic` model and keep logging as sink.
 
 ```python
 @dataclass(frozen=True)
@@ -295,68 +294,68 @@ class ParseResult:
     diagnostics: tuple[Diagnostic, ...]
 ```
 
-La CLI potrebbe offrire `--diagnostics json`, `scan --fail-on warning` e contatori finali. Ciò rende automatizzabili controlli di qualità sui vault senza introdurre telemetria invasiva.
+CLI can then support `--diagnostics json`, `scan --fail-on warning`, and summary counters, enabling automated vault quality checks without intrusive telemetry.
 
-### P2 — API pubblica, typing e compatibilità
+### P2 — Public API, typing, and compatibility
 
-**Evidenza.** `__init__.py` espone esplicitamente molte classi e funzioni, ottimo punto di partenza. Manca il marker `py.typed`, quindi gli integratori potrebbero non ricevere i type hints come package tipizzato. La versione è duplicata tra metadata e modulo, pur essendo coperta da test.
+**Evidence.** `__init__.py` already exports many core classes/functions. `py.typed` is still missing, so downstream consumers may not receive type hints from package metadata. Version is duplicated between metadata and module, though covered by tests.
 
-**Interventi.**
+**Actions.**
 
-- aggiungere `py.typed` al package e verificarne l'inclusione nella wheel;
-- pubblicare una tabella di stabilità API (`stable`, `experimental`, `internal`);
-- usare metadata dinamico o una singola sorgente versione;
-- introdurre test di compatibilità su API pubblica e policy semver; 
-- valutare `mypy --strict` per il core, a ondate, senza imporlo subito agli adapter opzionali.
+- add `py.typed` to package and verify wheel inclusion;
+- publish API stability table (`stable`, `experimental`, `internal`);
+- use dynamic metadata or a single source of version truth;
+- add public API compatibility tests and semver policy;
+- evaluate phased `mypy --strict` for core only, not mandatory for optional adapters.
 
 ```text
 public API -> test import -> test signature/semantic contract -> release note
-internal API -> nessuna promessa di stabilità -> refactor libero con test interni
+internal API -> no stability guarantees -> freer refactor with internal tests
 ```
 
-### P2 — Documentazione viva e onboarding affidabile
+### P2 — Living documentation and onboarding quality
 
-**Evidenza.** La documentazione è ampia e ben organizzata, ma diversi documenti riportano ancora 378 o 456 test, mentre l'evidenza attuale è 462. Alcuni report storici sono dichiaratamente storici, ma la distinzione deve essere visivamente inequivocabile.
+**Evidence.** Documentation is broad and well organized, but several docs still report 378 or 456 tests while current evidence is 462. Some historical docs are marked as historical, yet the distinction should be visually explicit.
 
-**Interventi.**
+**Actions.**
 
-1. Sostituire conteggi volatili con un badge/generatore, oppure aggiornare una singola fonte canonica durante la release.
-2. Aggiungere test per snippet Python dei documenti e controlli link interni.
-3. Etichettare in testa ai report: `Storico`, `Attivo`, `Superseded`, con data e owner.
-4. Creare una pagina "decision records" per scelte come collision policy, UUID sintetici, strict references e writer concurrency.
+1. Replace volatile counts with a generated badge/script, or update a single canonical source during release.
+2. Add tests for documented Python snippets and internal link checks.
+3. Mark report headers with `Historical`, `Active`, `Superseded`, plus date and owner.
+4. Add a "decision records" page for collision policy, synthetic UUIDs, strict references, and writer concurrency.
 
-### P2 — Sicurezza del filesystem e del writer
+### P2 — Filesystem and writer security
 
-**Aspetti già buoni.** Il writer usa file temporaneo nella stessa directory e `os.replace`; la risoluzione asset rifiuta percorsi assoluti e normalizza i path. L'audit runtime delle dipendenze non ha trovato vulnerabilità note.
+**Already solid parts.** Writer uses temporary file plus same-directory `os.replace`; asset resolution rejects absolute paths and normalizes paths. Runtime dependency audit has no known vulnerabilities.
 
-**Miglioramenti.**
+**Improvements.**
 
-- aggiungere test di symlink e confine del vault per tutte le operazioni in scrittura;
-- definire una policy esplicita per permessi e owner preservati dal replace;
-- offrire una modalità `dry-run` che produce patch unificata prima di modificare Markdown;
-- limitare dimensione/depth di input configurabili per usare la libreria su vault non fidati;
-- fare girare l'audit dipendenze anche nel workflow tag, non solo nel percorso pull request.
+- add symlink and vault-boundary tests for all write operations;
+- define explicit policy for permissions/ownership preserved by replace;
+- add `dry-run` mode that outputs unified diffs before writing markdown;
+- bound input size/depth for untrusted vault usage;
+- run dependency audits in tag workflow, not only PR path.
 
-### P3 — Evoluzione incrementale del parser
+### P3 — Incremental parser evolution
 
-Non raccomando un big-bang rewrite. La sequenza sicura è:
+I do not recommend a big-bang parser rewrite. A safer sequence is:
 
 ```mermaid
 flowchart TD
-    A["Congelare corpus e snapshot"] --> B["Estrarre classificatore di linea puro"]
-    B --> C["Estrarre stati lessicali: fence, query, drawer, frontmatter"]
-    C --> D["Estrarre riduttore dello stack AST"]
-    D --> E["Centralizzare arricchimento node e riferimenti"]
-    E --> F["Misurare equivalenza e benchmark"]
+    A["Freeze corpus and snapshot"] --> B["Extract pure line classifier"]
+    B --> C["Extract lexical states: fence, query, drawer, frontmatter"]
+    C --> D["Extract AST stack reducer"]
+    D --> E["Centralize node enrichment and references"]
+    E --> F["Measure semantic equivalence and benchmarks"]
 ```
 
-Ogni slice deve conservare: output semantico, UUID, ordine dei nodi, line range, normalizzazione proprietà e comportamento `strict_refs`. Prima di modificare gli hub del parser o del grafo va rieseguita un'analisi di impatto e vanno aggiornati corpus e benchmark.
+Each slice must preserve semantic output, UUIDs, node ordering, line ranges, property normalization, and `strict_refs` behavior. Before touching parser/graph hubs, rerun impact analysis and update corpus/benchmark.
 
-## Architettura obiettivo
+## Target architecture
 
 ```mermaid
 flowchart TB
-    subgraph Core["Core stabile"]
+    subgraph Core["Stable core"]
         Model["Domain model\nPage, Node, Diagnostic"]
         Events["Parser events\nline classification + state"]
         Reducer["AST reducer\ndeterministic stack"]
@@ -384,55 +383,57 @@ flowchart TB
     end
 ```
 
-Principio guida: il core produce dati e diagnostica deterministici; l'applicazione ne controlla il ciclo di vita; gli adapter non accedono a registri interni né definiscono proprie regole di indicizzazione.
+Design principle: core produces deterministic data and diagnostics; application controls lifecycle; adapters must not access internal registries or define indexing rules themselves.
 
-## Roadmap proposta
+## Proposed roadmap
 
-### Fase 1 — Fiducia nel delivery (1–3 giorni)
+### Phase 1 — Delivery trust (1–3 days)
 
-- Separare lint/check da fix/format.
-- Aggiornare i conteggi test nella documentazione attiva.
-- Creare check `version/tag/changelog` e `twine check` per release.
-- Aggiungere `py.typed` e test della wheel.
+- Separate lint/check from fix/format.
+- Update test counts in active documentation.
+- Add `version/tag/changelog` and `twine check` release checks.
+- Add `py.typed` and wheel inclusion test.
 
-### Fase 2 — Integrità del vault (3–7 giorni)
+### Phase 2 — Vault integrity (3–7 days)
 
-- Introdurre `TitleCollision` e strict mode, senza cambiare il default nella prima release.
-- Pubblicare diagnostica JSON e flag CLI fail-fast.
-- Aggiungere writer dry-run e test su symlink/permessi.
+- Introduce `TitleCollision` and strict mode, with permissive default in the first release.
+- Publish JSON diagnostics and CLI fail-fast flag.
+- Add writer dry-run and symlink/permissions tests.
 
-### Fase 3 — Robustezza operativa (1–2 settimane)
+### Phase 3 — Operational robustness (1–2 weeks)
 
-- Coordinatore/snapshot per reload e writer.
-- Test concorrenti deterministici con barrier e fake watcher.
-- Corpus di compatibilità versionato e prime property-based tests.
+- Snapshot/coordination for reload and writer.
+- Deterministic concurrent watcher/writer tests with barrier and failure injection.
+- Versioned compatibility corpus and first property-based tests.
 
-### Fase 4 — Evoluzione sostenibile (incrementale)
+### Phase 4 — Sustainable evolution (incremental)
 
-- Benchmark e budget per 1k/10k pagine.
-- Estrarre classificatore/stati parser una slice alla volta.
-- Stabilire API stability policy, ADR e release notes generate dai contratti.
+- Benchmark and budget for 1k/10k vaults.
+- Extract parser classifier/states one slice at a time.
+- Establish API stability policy, ADRs, and contract-generated release notes.
 
-## Cosa non cambierei ora
+## What I would not change now
 
-- Non introdurrei una gerarchia di package complessa solo per imitare un'architettura teorica: i moduli piatti sono leggibili e gli import cycle sono già zero.
-- Non aggiungerei un database o un motore di ricerca esterno finché benchmark reali non dimostrano che le scansioni lineari sono il collo di bottiglia.
-- Non sostituirei Pydantic o Typer: il costo della migrazione non è giustificato da un problema concreto.
-- Non renderei il parser "più permissivo" senza diagnostica: per un parser di knowledge graph, un risultato ambiguo ma silenzioso è peggiore di un warning strutturato.
+- I would not add a complex package hierarchy solely to follow a theoretical architecture: flat modules remain readable and import cycles are already zero.
+- I would not add a database or external search engine until measured benchmarks prove linear scans are the bottleneck.
+- I would not replace Pydantic or Typer: migration cost is not justified by a concrete problem.
+- I would not make parser behavior more permissive without diagnostics; for a knowledge graph parser, ambiguous but silent output is worse than structured warnings.
 
-## Definition of Done per le prossime modifiche strutturali
+## Definition of done for future structural changes
 
 ```text
-[ ] analisi di impatto sui simboli hub
-[ ] test mirati del comportamento modificato
-[ ] corpus/regressione per input Logseq rappresentativo
-[ ] lint non mutante, type check, test e coverage
-[ ] check dei cicli di import
-[ ] benchmark se cambia un hot path
-[ ] docs/API/ADR aggiornati se cambia un contratto
-[ ] prova di installazione o artifact build se cambia packaging/release
+[ ] impact analysis on hub symbols
+[ ] targeted tests for changed behavior
+[ ] corpus/regression for representative Logseq input
+[ ] non-mutating lint, type check, tests, and coverage
+[ ] import cycle check
+[ ] benchmark if a hot path changes
+[ ] docs/API/ADR updated when contract changes
+[ ] install or artifact build verification if packaging/release changes
 ```
 
-## Conclusione
+## Conclusion
 
-La repository non necessita di una rifondazione: è già una base di qualità. Il salto successivo è passare da un progetto robusto a una piattaforma affidabile sotto input reali, vault grandi, integrazioni agentiche e release frequenti. Le quattro iniziative con il miglior rapporto valore/rischio sono: gate CI non mutante, collision diagnostics, serializzazione delle mutazioni del vault e corpus di compatibilità. Insieme proteggono le proprietà che rendono il progetto distintivo: determinismo, fedeltà semantica e fiducia nei dati dell'utente.
+The repository does not need a refoundation; it is already a strong foundation. The next step is moving from a robust project to a reliable platform under real inputs, large vaults, agent integrations, and frequent releases. The four best value-to-risk items are:
+CI non-mutating gate, collision diagnostics, vault mutation serialization, and a compatibility corpus.
+Together they protect the qualities that make this project distinctive: determinism, semantic fidelity, and trust in user data.

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -6,9 +6,13 @@ status: stable
 classification: active
 audience: maintainers
 owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
 last_verified: 2026-08-06
 verified: 2026-08-06
-stale_after: 2027-02-02
+stale_after: 2026-11-04
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
 source_commit: 8e90b44
 supersedes: docs/REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md
 superseded_by: null
@@ -337,17 +341,23 @@ The external Matryca Knowledge OKF baseline is Google OKF v0.2 at commit `3fcbb9
 
 Source repository remains the authority for its own documents. Matryca Knowledge can maintain a revised projection only when it is reproducible and traceable to immutable repository path and commit hashes; generated Logseq views are not source of truth.
 
-### 8.2 Current measured state
+### 8.2 Current measured state after documentation adoption
 
-At the analyzed checkout:
+The initial audit findings above were addressed in the documentation adoption
+phase on 2026-08-06:
 
-- 39 markdown files exist under `docs/`, including this report;
-- no maintained document yet uses a uniform true YAML frontmatter;
-- `docs/README.md` is the only explicit documentation portal;
-- missing distinct entry points for machine-readable, historical, decision, and reference surfaces;
-- repository is registered in `matryca-knowledge/sources.toml`, but does not yet expose
-  `okf_entry_points`, so current validator cannot audit the maintained bundle;
-- historical reports and blueprints are semantically distinguishable but this distinction is not yet metadata- or CI-verified.
+- `docs/index.md`, `docs/README.md`, `docs/log.md`, `docs/decisions/index.md`,
+  and `docs/reference/index.md` now provide stable bundle surfaces;
+- maintained entry points use lifecycle, classification, ownership, authority,
+  compatibility freshness, and explicit supersession metadata;
+- [`DOCUMENTATION_SYSTEM.md`](DOCUMENTATION_SYSTEM.md) is the canonical
+  contributor and governance contract;
+- active and historical documents are separated without bulk-normalizing the
+  historical archive;
+- repository documentation and maintainer-facing text use English;
+- the private `matryca-knowledge/sources.toml` still has no parser
+  `okf_entry_points`, so the external validator cannot yet admit or enforce this
+  bundle. That registry change and projection refresh remain separate PRs.
 
 ### 8.3 Current strengths
 
@@ -357,14 +367,17 @@ At the analyzed checkout:
 - Historical roadmaps expose evolution by wave.
 - CONTRIBUTING, issue templates, and Good First Issues offer a real onboarding path.
 
-### 8.4 Current issues
+### 8.4 Remaining issues
 
-- July study is not tracked or indexed.
-- Test counts are hand-maintained and diverge across README/CONTRIBUTING/COOKBOOK/study docs.
-- Historical, active, maintained, and proposal documents do not have uniform metadata and lifecycle tags.
-- There are multiple roadmaps but no single `Now / Next / Later / Rejected` map linked to current issues.
-- No offline gate exists for markdown links, anchors, documented CLI commands, and Python snippets.
-- Asset resolution documentation states a boundary that `file://` handling currently violates.
+- The private source profile must declare parser entry points before the shared
+  validator can audit the bundle.
+- Source CI does not yet enforce maintained links, anchors, lifecycle,
+  canonical roles, documented CLI commands, and Python snippets.
+- Some release-era documents intentionally retain historical metrics; active
+  guidance must avoid copying those values as current claims.
+- Asset resolution documentation states a boundary that `file://` handling
+  currently violates; this remains a product defect, not a documentation-only
+  correction.
 
 ### 8.5 Metadata contract
 
@@ -426,6 +439,9 @@ without shifting source-of-truth authority outside the repository.
 5. Add non-mutating, source-reproducible CI gate.
 6. Declare entry points in Matryca Knowledge registry via a separate PR.
 7. Project only clean immutable commits; verify Logseq-rendered views do not alter source semantics.
+
+Steps 1-3 are complete at source level. Step 4 is partially covered by manual
+review. Steps 5-7 remain the MKQ-4 completion path tracked by issue #109.
 
 ## 9. Product and API strategy
 

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -1,7 +1,7 @@
 ---
 type: RepositoryAudit
-title: Logseq Matryca Parser - Code Audit e roadmap stellare
-description: Audit verificato della repository, finding riproducibili e piano MKQ-4 allineato a Matryca Knowledge.
+title: Logseq Matryca Parser - Code audit and stellar roadmap
+description: Verified audit, reproducible findings, and MKQ-4 roadmap aligned to Matryca Knowledge.
 status: stable
 classification: active
 audience: maintainers
@@ -14,90 +14,90 @@ supersedes: docs/REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md
 superseded_by: null
 ---
 
-# Logseq Matryca Parser — Code Audit e roadmap verso una repository “stellare”
+# Logseq Matryca Parser — Code audit and roadmap to a “stellar” repository
 
-> **Stato:** studio eseguito e verificato il 2026-08-06  
-> **Checkout analizzato:** `main` @ `8e90b44`  
-> **Natura del documento:** decision record e backlog tecnico; non autorizza implementazione, commit, push, PR, merge o release  
-> **Rapporto con lo studio precedente:** integra e corregge `REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md`, che al momento dell'audit era ancora non tracciato
+> **Status:** study executed and verified on 2026-08-06
+> **Analyzed checkout:** `main` @ `8e90b44`
+> **Document nature:** decision record and technical backlog; no implementation, commit, push, PR, merge, or release is authorized from this document.
+> **Relationship to previous study:** supersedes and fixes `REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md`, which was untracked during the previous audit.
 
-## 1. Sintesi esecutiva
+## 1. Executive summary
 
-La repository è già nettamente sopra la media: il quality gate locale passa con **462 test**, **3.233 statement** misurati e **91% di coverage**, Ruff e Mypy puliti, **0 cicli di import**, packaging moderno, API grafo utili, parsing deterministico, writer atomico a livello di singolo file e una buona separazione degli adapter opzionali.
+The repository is already above average: local quality gate passes with **462 tests**, **3,233 statements** measured, and **91% coverage**, Ruff and Mypy are clean, **0 import cycles**, modern packaging, useful graph APIs, deterministic parsing, file-level atomic writer, and good optional-adapter separation.
 
-Il salto successivo non richiede una riscrittura né più feature indiscriminate. Richiede, in quest'ordine:
+The next step is not a rewrite or indiscriminate feature expansion. It is, in order:
 
-1. correggere due difetti P0 confermati su fixture sintetiche;
-2. rendere espliciti e verificabili i confini di sicurezza del vault;
-3. trasformare il grafo mutabile in uno snapshot coerente per writer, watcher e lettori;
-4. congelare la semantica del parser con corpus versionato e test metamorfici;
-5. rendere delivery, API, diagnostica e documentazione meccanicamente affidabili;
-6. misurare la scala prima di introdurre nuovi indici, database o framework.
+1. fix two confirmed P0 defects on synthetic fixtures;
+2. make vault security boundaries explicit and enforceable;
+3. make mutable graph state a coherent snapshot for writer, watcher, and readers;
+4. freeze parser semantics with versioned corpus and metamorphic tests;
+5. make delivery, API, diagnostics, and documentation mechanically reliable;
+6. measure scale before introducing additional indices, databases, or frameworks.
 
-La conclusione più importante è che il backlog aperto **#101–#111 è valido ma non completo**. Copre quasi tutta la maturazione strategica, però il presente audit ha confermato anche:
+The key conclusion is that open backlog **#101–#111 is valid but incomplete**. It covers almost all strategic maturation, but this audit also confirms:
 
-- **P0 — perdita di contenuto su aggiornamenti di nodi annidati oltre il terzo livello**;
-- **P0 — scrittura fuori dal vault attraverso file Markdown symlinkati**;
-- **P1 — risoluzione di URI `file://` senza confinamento al vault**;
-- **P1 — backlink obsoleti dopo una rinomina incrementale di pagina**.
+- **P0 — content loss on updates to nodes nested deeper than level 3**;
+- **P0 — writing outside the vault through symlinked markdown files**;
+- **P1 — `file://` URI resolution without vault confinement**;
+- **P1 — stale backlinks after incremental page rename**.
 
-Il primo difetto merita una issue bug dedicata e una correzione chirurgica prima del refactor del parser. I due difetti di confinamento devono diventare criteri espliciti della #106; il backlink stale deve diventare una slice esplicita della #103 o una issue figlia.
+The first defect needs a dedicated bug issue and a surgical fix before parser refactor. The two confinement defects should become explicit acceptance criteria in #106; the stale-backlink issue should become an explicit slice under #103 or a child issue.
 
-## 2. Piano iniziale
+## 2. Initial plan
 
-Il piano definito prima dell'esplorazione era:
+The pre-exploration plan was:
 
-1. raccogliere baseline live, istruzioni del repository, storico e architettura indicizzata;
-2. delegare audit specialistici a GPT-5.3 Codex Spark e GPT-5.6 Luna;
-3. confrontare i risultati e distinguere difetti correnti, debito già tracciato e idee speculative;
-4. eseguire un round correttivo sui punti contraddittori o non provati;
-5. depositare piano, evidenze, priorità, roadmap e limiti in un Markdown versionabile;
-6. validare il documento con i gate prescritti dal repository.
+1. collect live baseline, repository instructions, history, and indexed architecture;
+2. delegate specialist audits to GPT-5.3 Codex Spark and GPT-5.6 Luna;
+3. reconcile results and distinguish current defects, existing debt, and speculative ideas;
+4. run a correction round on contradictory or unverified points;
+5. place evidence, findings, priorities, roadmap, and limits into a versioned Markdown document;
+6. validate the document with repository-prescribed gates.
 
-### 2.1 Criteri di accettazione dello studio
+### 2.1 Study acceptance criteria
 
-- Le raccomandazioni devono derivare da sorgente live, test, workflow o probe riproducibili.
-- I fatti storici non devono essere presentati come stato corrente.
-- Ogni finding deve indicare impatto, confidenza, verifica minima e relazione con #101–#111.
-- Le modifiche a hub devono essere precedute da impact analysis.
-- Devono restare invariati parsing deterministico, UUID, ordinamento, pagine canoniche, no-ghost-node e `strict_refs`.
-- Nessun commit, push, PR, issue o cambio remoto è autorizzato da questo studio.
+- Recommendations must derive from live sources, tests, workflows, or reproducible probes.
+- Historical facts must not be presented as current state.
+- Each finding should include impact, confidence, minimum verification, and relation to #101–#111.
+- Hub changes must be preceded by impact analysis.
+- Deterministic parsing, UUID behavior, ordering, canonical pages, no-ghost-node guarantees, and `strict_refs` must remain unchanged.
+- This study does not authorize commits, pushes, PRs, issues, or remote changes.
 
-## 3. Delega, raccolta e correzione del tiro
+## 3. Delegation, collection, and plan adjustment
 
-Sono state lanciate cinque attività read-only in worktree separati, partendo dallo stato corrente incluso il documento non tracciato del 28 luglio.
+Five read-only tasks were run in separate worktrees, starting from current state and including the untracked July 28 document.
 
-| Attività | Modello | Motivazione del routing | Esito utile |
+| Task | Model | Routing rationale | Useful outcome |
 |---|---|---|---|
-| Documentazione e contributor experience | GPT-5.3 Codex Spark | Ricerca prevalentemente meccanica: link, numeri, indici, onboarding | Evidenze raccolte; il report finale è fallito per limite del servizio, quindi le conclusioni sono state ricostruite e riverificate localmente |
-| CI, packaging e release engineering | GPT-5.3 Codex Spark | Workflow e manifest hanno controlli deterministici | Confermati lint mutante, action non pin-nate e lineage degli artifact non immutabile |
-| Architettura e manutenibilità | GPT-5.6 Luna | Richiede ragionamento cross-module e blast radius | Confermati i due hub principali, la necessità di slice incrementali e il backlink stale |
-| Correttezza, sicurezza e performance | GPT-5.6 Luna | Area ad alto rischio con probe e giudizio | Ha individuato quattro anomalie riprodotte poi nel checkout principale |
-| Prodotto, API ed ecosistema | GPT-5.6 Luna | Richiede sintesi di posizionamento e sequenziamento | Confermata la strategia contract-first e il rifiuto di plugin/database prematuri |
+| Documentation and contributor experience | GPT-5.3 Codex Spark | Mostly mechanical work: links, counts, indexes, onboarding | Evidence collected; final report failed due to service output limit, so conclusions were rebuilt and locally re-verified |
+| CI, packaging, and release engineering | GPT-5.3 Codex Spark | Workflows and manifests have deterministic checks | Confirmed mutating lint, unpinned actions, and non-immutable artifact lineage |
+| Architecture and maintainability | GPT-5.6 Luna | Requires cross-module reasoning and blast-radius analysis | Confirmed two main hubs, need incremental slices, and stale-backlink risk |
+| Correctness, security, and performance | GPT-5.6 Luna | High-risk area with probes and judgment required | Identified four anomalies later reproduced in primary checkout |
+| Product, API, and ecosystem | GPT-5.6 Luna | Requires sequencing and positioning synthesis | Confirmed contract-first strategy and early rejection of premature plugin/database expansion |
 
-### 3.1 Round correttivo
+### 3.1 Correction round
 
-Le prime esecuzioni lunghe delle attività remote sono state interrotte durante la compattazione. Non sono state accettate come risultati completi. Il secondo round ha:
+The first remote executions were interrupted during compaction. They were not accepted as complete outcomes. The second round:
 
-- ridotto lo scope;
-- vietato nuove scansioni ampie;
-- chiesto una chiusura dai dati già raccolti;
-- ridotto il reasoning dove necessario;
-- imposto output compatti e separazione fra fatti e ipotesi.
+- reduced scope;
+- banned broad re-scans;
+- required closure from already collected data;
+- reduced reasoning where necessary;
+- requested compact outputs and clear separation between facts and assumptions.
 
-Quattro attività hanno poi prodotto report finali. L'attività documentale è fallita nuovamente per limite di output; i suoi dati parziali sono stati confrontati direttamente con `README.md`, `docs/README.md`, `CONTRIBUTING.md`, workflow e studio precedente.
+Four tasks produced final reports. The documentation task failed again due to output limit; partial data were cross-checked directly against `README.md`, `docs/README.md`, `CONTRIBUTING.md`, workflows, and the previous study.
 
-### 3.2 Revisione critica dei risultati delegati
+### 3.2 Critical review of delegated findings
 
-Una prima sintesi concludeva che #101–#111 coprissero tutto il lavoro necessario. Questa conclusione è stata rigettata dopo i probe indipendenti: la perdita di soft-break profondo non è un semplice requisito del corpus, ma un bug corrente riproducibile; il confine symlink e il ramo `file://` sono comportamenti di sicurezza attuali, non solo hardening teorico.
+One early synthesis concluded that #101–#111 covered all required work. This was rejected after independent probes: deep soft-break loss is a reproducible current bug, and symlink boundary and `file://` behavior are current security behavior, not theoretical hardening concerns.
 
-Questo è il motivo per cui la roadmap finale inizia con una **Wave 0 di contenimento e correzione**, prima delle iniziative strategiche già aperte.
+This is why the final roadmap starts with a **Wave 0 containment and correction** before previously opened strategic initiatives.
 
-## 4. Evidenze e baseline live
+## 4. Evidence and live baseline
 
-### 4.1 Stato Git
+### 4.1 Git state
 
-All'inizio dello studio:
+At audit start:
 
 ```text
 * main...origin/main
@@ -105,89 +105,89 @@ All'inizio dello studio:
 ?? docs/REPOSITORY_IMPROVEMENT_STUDY_2026-07-28.md
 ```
 
-Entrambi i path preesistevano e sono stati preservati. L'aggiornamento locale dell'indice di audit code aveva aggiunto automaticamente contenuto a `AGENTS.md` e `CLAUDE.md`; quelle sole aggiunte generate durante lo studio sono state rimosse, riportando i due file senza diff.
+Both paths already existed and were preserved. Local audit index updates automatically added content to `AGENTS.md` and `CLAUDE.md`; those generated additions were removed, restoring both files to no-diff state.
 
 ### 4.2 Quality gate
 
-Comando:
+Command:
 
 ```bash
 rtk make all
 ```
 
-Risultato:
+Result:
 
-- Ruff: `All checks passed!`;
-- Mypy: `Success: no issues found in 34 source files`;
-- controllo documentale vendor-neutral: `OK`;
-- Pytest: **462 passed**;
-- coverage: **3.233 statement, 288 mancanti, 91% totale**.
+- Ruff: `All checks passed!`
+- Mypy: `Success: no issues found in 34 source files`
+- vendor-neutral documentation check: `OK`
+- Pytest: **462 passed**
+- coverage: **3,233 statements, 288 missing, 91% total**
 
-Il target `make all` è verde, ma non è ancora un gate puramente verificativo: `make lint` esegue `ruff check . --fix`. Nel presente run non ha prodotto diff, ma in CI potrebbe correggere il checkout e mascherare una submission non conforme. Questo conferma #101.
+`make all` is green, but it is not yet a purely verificative gate: `make lint` runs `ruff check . --fix`. This run produced no diff, but CI could auto-correct checkout in another run and mask a non-compliant submission. This confirms #101.
 
 ### 4.3 Audit code
 
-L'indice locale è stato aggiornato al commit corrente e ha riportato:
+The local index was updated to the current commit and reported:
 
 ```text
-2.133 nodi | 4.040 relazioni | 57 cluster | 169 flussi
+2,133 nodes | 4,040 relations | 57 clusters | 169 flows
 cycleCount: 0
 ```
 
-Il server di consultazione ha inizialmente mantenuto in cache un contesto vecchio; per questo nessun risultato stale è stato usato come prova sufficiente. I finding critici sono stati confermati con sorgente live, analisi semantica e probe runtime.
+The analysis server initially used stale context cache; therefore stale results were not used as sufficient evidence. Critical findings were confirmed with live source, semantic checks, and runtime probes.
 
-### 4.4 Blast radius degli hub protetti
+### 4.4 Protected hub blast radius
 
-| Simbolo | Rischio | Impatto rilevato | Conseguenza operativa |
+| Symbol | Risk | Observed impact | Operational consequence |
 |---|---:|---|---|
-| `StackMachineParser._refresh_node` | HIGH | 102 simboli, 4 flussi | Modifiche solo con corpus, snapshot semantici e test parser completi |
-| `StackMachineParser._replace_stack_tail_node` | HIGH | 102 simboli, 4 flussi | Il fix P0 deve essere chirurgico e equivalence-tested |
-| `LogseqGraph.load_directory` | CRITICAL | 47 chiamanti diretti, 6 flussi | Nessuna modifica opportunistica; preservare API e determinismo |
-| `LogseqGraph.invalidate_and_reload_page` | LOW locale | 3 chiamanti diretti, 2 flussi | Slice piccola, ma semantica globale degli indici da testare contro cold reload |
-| `_expand_macros_and_embeds_impl` | LOW | 6 simboli, 2 flussi | Seams già sottili; non è un hotspot prioritario |
+| `StackMachineParser._refresh_node` | HIGH | 102 symbols, 4 flows | Changes only with corpus snapshots and parser-level tests |
+| `StackMachineParser._replace_stack_tail_node` | HIGH | 102 symbols, 4 flows | P0 fix must be surgical and equivalence-tested |
+| `LogseqGraph.load_directory` | CRITICAL | 47 direct callers, 6 flows | No opportunistic changes; keep API and determinism |
+| `LogseqGraph.invalidate_and_reload_page` | LOW local | 3 direct callers, 2 flows | Small slice, but global index semantics must be verified against cold reload |
+| `_expand_macros_and_embeds_impl` | LOW | 6 symbols, 2 flows | Seams already narrow; not a top performance hotspot |
 
-## 5. Architettura attuale
+## 5. Current architecture
 
 ```mermaid
 flowchart TD
-    V["Vault: pages/ e journals/"] --> D["Discovery e path policy"]
+    V["Vault: pages/ and journals/"] --> D["Discovery and path policy"]
     D --> P["StackMachineParser"]
-    P --> AST["LogseqPage e LogseqNode immutabili"]
+    P --> AST["Immutable LogseqPage and LogseqNode"]
     AST --> G["LogseqGraph"]
-    G --> IDX["Pagine canoniche, UUID, alias, backlink"]
+    G --> IDX["Canonical pages, UUID, aliases, backlinks"]
     IDX --> Q["Query, namespace, reference checks"]
-    G --> W["Incremental reload e watcher"]
+    G --> W["Incremental reload and watcher"]
     G --> A["CLI, agent read/write"]
-    G --> E["Export, RAG e visualizzazione"]
+    G --> E["Export, RAG, and visualization"]
     W --> G
     A --> W
 ```
 
-La direzione delle dipendenze è buona e il controllo cicli è pulito. I rischi principali non sono cicli o framework sbagliati, ma **coerenza temporale** e **propagazione delle strutture immutabili**:
+Dependency direction is generally good and cycle checks are clean. Primary risks are not cycles or the wrong framework; they are **temporal consistency** and propagation of immutable structures:
 
-- il parser ricostruisce nodi immutabili lungo uno stack;
-- il grafo pubblica più indici derivati dalla stessa collezione di pagine;
-- writer e watcher possono aggiornare file e indici in momenti diversi;
-- alias e titoli trasformano una mappa in un insieme di identità canoniche più proiezioni secondarie.
+- the parser builds immutable nodes through a stack;
+- the graph exposes multiple derived indexes from one page collection;
+- writer and watcher can update files and indexes at different times;
+- aliases and titles convert one map into canonical identities plus secondary projections.
 
-Il design futuro deve rendere questi quattro contratti espliciti.
+The future design must make these four contracts explicit.
 
-## 6. Findings confermati
+## 6. Confirmed findings
 
-### P0.1 — Perdita di contenuto su nodi annidati profondamente
+### P0.1 — Content loss in deeply nested nodes
 
-**Stato:** bug corrente, alta confidenza, non coperto in modo sufficientemente esplicito dalle issue esistenti.
+**Status:** current bug, high confidence, not sufficiently covered by existing issues.
 
-`StackMachineParser._replace_stack_tail_node` aggiorna il nodo, il parent e il grandparent, ma non propaga il nuovo ramo fino alla root per profondità superiori. Il soft-break viene registrato nello stack locale, mentre l'AST restituito conserva una root precedente.
+`StackMachineParser._replace_stack_tail_node` updates the node, parent, and grandparent, but does not propagate the new branch back to the root for depths above the third level. Soft-break text is recorded on local stack state, while the returned AST keeps the previous root.
 
-Probe sintetico:
+Synthetic probe:
 
 ```text
 DEEP_CONTENTS ['a', 'b', 'c', 'd', 'e']
 DEEP_SOFT_BREAK_PRESENT False
 ```
 
-Input protetto:
+Protected input:
 
 ```markdown
 - a
@@ -198,42 +198,42 @@ Input protetto:
           continuation-e
 ```
 
-**Impatto:** perdita silenziosa di contenuto e metadati quando una qualsiasi delle chiamate a `_replace_stack_tail_node` aggiorna un nodo profondo. Il problema non è limitato ai soft-break: lo stesso helper è usato per proprietà, fence, query e finalizzazione delle liste.
+**Impact:** silent loss of content and metadata whenever any call to `_replace_stack_tail_node` updates a deep node. The issue is not limited to soft-breaks; the same helper handles properties, fence, query, and list finalization.
 
-**Perché i test non lo vedono:** i test soft-break correnti proteggono casi poco profondi e la coverage di linea esegue l'helper senza verificare l'invariante “ogni aggiornamento allo stack è osservabile dalla root a qualsiasi profondità”.
+**Why tests miss this:** existing soft-break tests cover shallow depths and line coverage executes helper logic without checking the invariant that every stack update remains observable from root at arbitrary depth.
 
-**Slice minima:** sostituire la propagazione hard-coded a tre livelli con una ricostruzione iterativa dal leaf alla root, senza cambiare classificazione delle linee o semantica del parser.
+**Minimal slice:** replace hardcoded three-level propagation with iterative reconstruction from leaf to root, without changing line classification or parser semantics.
 
-**Test obbligatori:** profondità 1, 2, 3, 4, 8 e 32; soft-break, proprietà, code fence e lista proprietà; `line_end`; parent/left pointers; UUID; serializzazione e reparse; equivalenza fra shallow e deep nesting.
+**Required tests:** depths 1, 2, 3, 4, 8, and 32; soft-break, property, code fence, property-list cases; `line_end`; parent/left pointers; UUID; serialization and re-parse; shallow vs deep nesting equivalence.
 
-**Tracking raccomandato:** nuova issue bug dedicata. Collegarla a #104 e rendere il fix un prerequisito della #108.
+**Recommended tracking:** add a dedicated bug issue. Link it to #104 and make the fix prerequisite for #108.
 
-### P0.2 — Il writer può mutare un file fuori dal vault tramite symlink
+### P0.2 — Writer may write outside vault via symlink
 
-**Stato:** vulnerabilità di confinamento corrente; alta confidenza; sovrapposizione diretta con #106.
+**Status:** current confinement vulnerability, high confidence; directly overlaps #106.
 
-La discovery accetta Markdown symlinkati sotto `pages/` o `journals/`. `parse_page_file` salva nel nodo `path.resolve()`, cioè il target reale. `append_child_to_node` legge e sostituisce quel `source_path` senza verificare che sia contenuto nel `graph.graph_path`.
+Discovery accepts symlinked markdown under `pages/` or `journals/`. `parse_page_file` stores `path.resolve()`, i.e., the real target. `append_child_to_node` reads and rewrites that `source_path` without verifying it is inside `graph.graph_path`.
 
-Probe eseguito esclusivamente in directory temporanee:
+Probe (temp directories only):
 
 ```text
 SYMLINK_SOURCE_OUTSIDE True
 SYMLINK_OUTSIDE_MUTATED True
 ```
 
-**Impatto:** un vault non fidato può indurre un'integrazione con permessi locali a modificare un file Markdown esterno al vault.
+**Impact:** an untrusted vault can cause a local integration with repo permissions to modify an external Markdown file.
 
-**Slice minima:** scegliere e documentare una policy symlink fail-closed per tutte le operazioni di scrittura; verificare il target risolto immediatamente prima di leggere e immediatamente prima di `os.replace`; rifiutare mismatch fra root, source registrato e target corrente.
+**Minimal slice:** define and document a fail-closed symlink policy for all write paths; verify resolved target immediately before read and immediately before `os.replace`; reject mismatches between root, registered source, and current target.
 
-**Test obbligatori:** symlink a file, symlink a directory, cambio symlink fra parse e write, path relativo con traversal, rename race, dry-run senza scrittura, target interno valido.
+**Required tests:** file symlink, directory symlink, symlink changes between parse and write, traversal path, rename race, dry-run without write, valid internal target.
 
-**Tracking raccomandato:** aggiornare #106 con il probe e questi criteri di accettazione; non duplicare la issue salvo decisione del maintainer.
+**Recommended tracking:** update #106 with probe and acceptance criteria; do not duplicate issue unless maintainer decides.
 
-### P1.1 — `file://` bypassa il confinamento degli asset
+### P1.1 — `file://` bypasses asset boundary
 
-**Stato:** difetto di lettura/confinamento corrente; alta confidenza.
+**Status:** current read/confinement defect, high confidence.
 
-`LogseqPage.resolve_asset_path` restituisce immediatamente il path assoluto per URI `file://`, prima del controllo sul `graph_root`. Questo contraddice la documentazione attiva, che dichiara il resolver confinato al vault.
+`LogseqPage.resolve_asset_path` returns an absolute path for `file://` URIs before applying `graph_root` containment checks. This contradicts current docs stating asset resolver is vault-confined.
 
 Probe:
 
@@ -241,17 +241,17 @@ Probe:
 FILE_URI_RESULT /private/etc/passwd
 ```
 
-**Impatto:** un documento non fidato può trasformare un token asset in un path locale arbitrario che un adapter a valle potrebbe leggere o ingerire.
+**Impact:** an untrusted document can convert an asset token into an arbitrary local path, and downstream adapters may ingest/read it.
 
-**Slice minima:** applicare una sola funzione di canonicalizzazione e containment a tutti i rami, inclusi `file://`, percent-decoding, path Windows e fallback asset. Definire se `file://` interno al vault è supportato o sempre vietato.
+**Minimal slice:** apply a single canonicalization and containment function across all branches, including `file://`, percent-decoding, Windows path forms, and asset fallbacks. Define whether in-vault `file://` is supported or always rejected.
 
-**Tracking raccomandato:** nuova issue security separata oppure ampliamento esplicito di #106 da “write boundary” a “filesystem boundary”.
+**Recommended tracking:** either a dedicated security issue or explicit expansion of #106 from “write boundary” to “filesystem boundary.”
 
-### P1.2 — Backlink obsoleti dopo rinomina incrementale
+### P1.2 — Stale backlinks after incremental rename
 
-**Stato:** bug corrente, alta confidenza, vicino a #103 ma non esplicitato nei criteri attuali.
+**Status:** current bug, high confidence, adjacent to #103 but not explicitly stated in current criteria.
 
-Il full load ricostruisce tutti i backlink. `invalidate_and_reload_page` rimuove i nodi della sola pagina modificata e aggiunge i backlink in uscita della pagina fresca; non ricalcola le chiavi dei link provenienti da pagine non modificate quando cambia il titolo o un alias del target.
+Full load reconstructs all backlinks. `invalidate_and_reload_page` removes only nodes for the modified page and adds outgoing backlinks from fresh page data; it does not recalculate keys for incoming links from unchanged pages when a target page title or alias changes.
 
 Probe:
 
@@ -259,131 +259,121 @@ Probe:
 RENAME_BACKLINKS 1 1 0
 ```
 
-Interpretazione: prima della rinomina esiste un backlink; dopo `Target → Renamed`, la vecchia chiave continua a restituire un risultato e la nuova non ne restituisce nessuno.
+Interpretation: before rename there is a backlink; after `Target → Renamed`, the old key still returns a result and the new one returns none.
 
-**Contratto corretto:** dopo ogni incremental reload, lo snapshot osservabile deve essere semanticamente equivalente a un cold load sullo stesso filesystem.
+**Correct contract:** after each incremental reload, the observable snapshot must be semantically equivalent to a cold reload from the same filesystem state.
 
-**Slice minima:** introdurre un risultato di delta che segnali cambi di identità pagina/alias; in quel caso ricostruire gli indici globalmente dipendenti o usare indici reverse-dependency espliciti. Prima ottimizzare la correttezza, poi misurare.
+**Minimal slice:** add a delta signal for identity/alias changes; if triggered, rebuild all globally dependent indexes or add reverse-dependency indices. Prioritize correctness first, then measurement.
 
-**Tracking raccomandato:** issue figlia della #103 o ampliamento esplicito della stessa; collegare #102 e #110.
+**Recommended tracking:** child issue of #103 or explicit expansion of it; also link #102 and #110.
 
-### P1.3 — Collisioni titolo/alias possono nascondere una pagina
+### P1.3 — Title/alias collisions can hide a page
 
-**Stato:** confermato e già correttamente coperto dalla #102.
+**Status:** confirmed and already covered by #102.
 
-Le pagine sono indicizzate in un dizionario title-keyed e gli alias possono rimappare una chiave canonica. Il comportamento è deterministico e il registry evita molti ghost node, ma la perdita di visibilità resta perlopiù un log.
+Pages are stored in a title-keyed dict, and aliases can remap canonical keys. Behavior is deterministic and the registry avoids many ghost nodes, but visibility loss is still primarily a logging concern.
 
-**Azione:** non aprire una nuova iniziativa; implementare diagnostica strutturata, entrambe le path, winner policy stabile e strict mode come già richiesto da #102.
+**Action:** do not open a new initiative. Implement structured diagnostics, both winner paths, stable winner policy, and strict mode as already requested by #102.
 
-### P1.4 — Writer, watcher e lettori non condividono uno snapshot atomico
+### P1.4 — Writer, watcher, and readers do not share an atomic snapshot
 
-**Stato:** rischio architetturale confermato; coperto dalla #103.
+**Status:** confirmed architectural risk; covered by #103.
 
-Il writer offre `mkstemp` + `os.replace`, che protegge dall'osservazione di file parziali, ma non serializza due read-modify-write concorrenti. L'incremental reload assegna e aggiorna più strutture derivate in passi distinti.
+Writer provides `mkstemp` + `os.replace`, which protects against partial file reads, but it does not serialize two concurrent read-modify-write cycles. Incremental reload updates multiple derived structures in multiple passes.
 
-**Azione:** un coordinatore per vault con lock per mutazioni e pubblicazione di un singolo snapshot immutabile. Nessun lock globale di processo.
+**Action:** introduce per-vault coordinator with mutation locks and publish immutable snapshots. Avoid a global process-wide lock.
 
-### P1.5 — Il lint CI è mutante
+### P1.5 — Mutating lint in CI
 
-**Stato:** confermato; coperto dalla #101.
+**Status:** confirmed; covered by #101.
 
-Separare `lint`/`format-check` da `lint-fix`/`format`, aggiungere controllo dirty-tree e mantenere `make all` come gate non mutante.
+Separate `lint`/`format-check` from `lint-fix`/`format`, add dirty-tree checks, and keep `make all` as a non-mutating gate.
 
-### P1.6 — Artifact release non qualificato una sola volta
+### P1.6 — Release artifacts not built once
 
-**Stato:** confermato; coperto dalla #105.
+**Status:** confirmed; covered by #105.
 
-Pre-flight, build PyPI e GitHub Release non consumano necessariamente lo stesso wheel/sdist immutabile. Le action usano tag mobili e il VCS override `nltk` è tag-based anziché commit-based.
+Pre-flight, PyPI build, and GitHub release do not necessarily consume the same immutable wheel/sdist. Workflows use movable tags and the `nltk` VCS override is tag-based instead of commit-based.
 
-**Azione:** build once, checksum, artifact attestato, publish exact bytes, release exact bytes; tag/version/changelog coerenti; action pin-nate a SHA.
+**Action:** build once, checksum, publish attested artifacts, release exact bytes, and align tags, versions, and changelog entries.
 
-### P2 — Debito strategico valido ma non urgente quanto i finding precedenti
+### P2 — Strategic debt valid but not as urgent as current findings
 
-- #104: corpus di compatibilità e proprietà metamorfica;
-- #107: `py.typed`, policy API e fonte versione;
-- #109: lifecycle documentale, link/snippet checks e numeri generati;
-- #110: diagnostica strutturata;
-- #111: benchmark 1k/10k pagine e budget RSS/p95;
-- #108: estrazione incrementale delle fasi parser solo dopo #104 e il fix P0.1.
+- #104: compatibility corpus and metamorphic properties;
+- #107: `py.typed`, API policy, and version source;
+- #109: documentation lifecycle, link/snippet checks, and generated numbers;
+- #110: structured diagnostics;
+- #111: 1k/10k page benchmarks and RSS/p95 budgets;
+- #108: incremental parser phase extraction only after #104 and P0.1 fix.
 
-## 7. Perché 91% di coverage non equivale a 91% di affidabilità
+## 7. Why 91% coverage does not mean 91% reliability
 
-La suite è forte, ma la coverage di linea non esprime quattro dimensioni decisive:
+The suite is strong, but line coverage does not represent four key dimensions:
 
-| Dimensione | Esempio mancante | Tecnica necessaria |
+| Dimension | Missing example | Required technique |
 |---|---|---|
-| Profondità strutturale | aggiornamento leaf a profondità arbitraria | test generativi su alberi e metamorphic depth invariance |
-| Coerenza temporale | incremental reload equivalente al cold load | state-machine test e snapshot oracle |
-| Confine filesystem | symlink, TOCTOU, `file://` | abuse-case fixtures in tmp, path policy centralizzata |
-| Concorrenza | due writer e watcher simultanei | test deterministici con barrier, non sleep casuali |
+| Structural depth | leaf-to-root update at arbitrary depth | tree-generation tests and metamorphic depth invariance |
+| Temporal consistency | incremental reload equivalent to cold load | state-machine tests and snapshot oracle |
+| Filesystem confinement | symlink, TOCTOU, `file://` | temporary fixture abuse cases and centralized path policy |
+| Concurrency | two writers and watcher concurrently | deterministic barrier tests, no timing sleeps |
 
-La metrica target non deve essere “95% coverage” in astratto. Deve essere: **100% degli invarianti critici protetti da oracle semantici**.
+Target metric should not be “95% coverage” in abstract. It should be: **100% of critical invariants protected by semantic oracles**.
 
-## 8. Repository e documentazione — profilo Matryca Knowledge
+## 8. Repository and documentation — Matryca Knowledge profile
 
-### 8.1 Baseline normativa e provenance
+### 8.1 Normative baseline and provenance
 
-Questa parte del piano adotta i parametri correnti di
+This plan section adopts current parameters from
 [`MarcoPorcellato/matryca-knowledge`](https://github.com/MarcoPorcellato/matryca-knowledge)
-alla revisione `7a3ebd8` del 2026-08-06. I riferimenti normativi sono:
+at revision `7a3ebd8` on 2026-08-06. Authoritative references are:
 
-- [`ENGINEERING_PRINCIPLES.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/ENGINEERING_PRINCIPLES.md): determinismo prima dell'automazione, evidenze, baseline, test e rollback;
-- [`OKF_SOURCE_GOVERNANCE.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/OKF_SOURCE_GOVERNANCE.md): identità Markdown stabile, link ordinari, entry point e ownership;
-- [`FOUNDATION_GOVERNANCE_OKF_EXECUTION_PLAN.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/FOUNDATION_GOVERNANCE_OKF_EXECUTION_PLAN.md): separazione fra OKF ufficiale e qualità Matryca, livelli MKQ e Gate G6 dedicato al parser;
-- [`SYNC_POLICY.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/SYNC_POLICY.md): sorgenti autorevoli, projection riproducibile, allowlist e rifiuto delle sorgenti dirty.
+- [`ENGINEERING_PRINCIPLES.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/ENGINEERING_PRINCIPLES.md): determinism before automation, evidence, baseline, testing, rollback;
+- [`OKF_SOURCE_GOVERNANCE.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/OKF_SOURCE_GOVERNANCE.md): stable markdown identity, canonical links, entry points, and ownership;
+- [`FOUNDATION_GOVERNANCE_OKF_EXECUTION_PLAN.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/FOUNDATION_GOVERNANCE_OKF_EXECUTION_PLAN.md): separation of official OKF from Matryca quality, MKQ levels, and Gate G6 dedicated to the parser;
+- [`SYNC_POLICY.md`](https://github.com/MarcoPorcellato/matryca-knowledge/blob/7a3ebd8/docs/SYNC_POLICY.md): trusted sources, reproducible projection, allowlist enforcement, and avoiding dirty sources.
 
-La baseline OKF esterna registrata da Matryca Knowledge è la specifica Google
-OKF v0.2 al commit `3fcbb9f828c2f23d109c855ee403c3a4c81f3a96`, blob
-`a516d50128f5aa1f5746d1464661a39f7143e875`. Questo repository **non dichiara
-conformità OKF ufficiale**: fino all'implementazione e alla verifica del layer
-ufficiale, il profilo corretto è `matryca_okf_inspired_quality`.
+The external Matryca Knowledge OKF baseline is Google OKF v0.2 at commit `3fcbb9f828c2f23d109c855ee403c3a4c81f3a96`, blob
+`a516d50128f5aa1f5746d1464661a39f7143e875`. This repository does **not** declare official OKF compliance: until the official layer is implemented and verified, the correct profile is `matryca_okf_inspired_quality`.
 
-Il repository sorgente resta l'autorità sui propri documenti. Matryca Knowledge
-ne può mantenere una proiezione revisionata e riproducibile, sempre riconducibile
-a repository, commit, path e hash immutabili; la vista Logseq generata non è la
-source of truth.
+Source repository remains the authority for its own documents. Matryca Knowledge can maintain a revised projection only when it is reproducible and traceable to immutable repository path and commit hashes; generated Logseq views are not source of truth.
 
-### 8.2 Stato corrente misurato
+### 8.2 Current measured state
 
-Al checkout analizzato:
+At the analyzed checkout:
 
-- sono presenti 39 file Markdown sotto `docs/`, incluso questo report;
-- nessun documento mantenuto usa ancora un vero frontmatter YAML uniforme;
-- `docs/README.md` è l'unico portale documentale esplicito;
-- mancano entry point distinti per macchina, cronologia, decisioni e reference;
-- il repository è registrato in `matryca-knowledge/sources.toml`, ma non espone
-  ancora `okf_entry_points`, quindi il validator corrente non ne può auditare un
-  bundle mantenuto;
-- i report storici e i blueprint sono già distinguibili semanticamente, ma la
-  distinzione non è ancora verificata da metadata e CI.
+- 39 markdown files exist under `docs/`, including this report;
+- no maintained document yet uses a uniform true YAML frontmatter;
+- `docs/README.md` is the only explicit documentation portal;
+- missing distinct entry points for machine-readable, historical, decision, and reference surfaces;
+- repository is registered in `matryca-knowledge/sources.toml`, but does not yet expose
+  `okf_entry_points`, so current validator cannot audit the maintained bundle;
+- historical reports and blueprints are semantically distinguishable but this distinction is not yet metadata- or CI-verified.
 
-### 8.3 Punti di forza
+### 8.3 Current strengths
 
-- `docs/README.md` separa attivo, storico e design docs.
-- `CLEAN_CODE_ARCHITECTURE.md` esplicita hub, anelli e anti-pattern.
-- `logseq_ast_primer.md` codifica regole di dominio difficili.
-- Le roadmap storiche rendono visibile l'evoluzione per wave.
-- CONTRIBUTING, issue template e Good First Issues offrono un percorso di ingresso reale.
+- `docs/README.md` separates active, historical, and design docs.
+- `CLEAN_CODE_ARCHITECTURE.md` documents hubs, rings, and anti-patterns.
+- `logseq_ast_primer.md` captures difficult domain rules.
+- Historical roadmaps expose evolution by wave.
+- CONTRIBUTING, issue templates, and Good First Issues offer a real onboarding path.
 
-### 8.4 Problemi correnti
+### 8.4 Current issues
 
-- Lo studio del 28 luglio non è tracciato né indicizzato.
-- I numeri test sono hand-maintained e divergono fra README/CONTRIBUTING/COOKBOOK/studi.
-- Documenti “eseguiti”, “attivi”, “storici” e “proposte” non hanno metadata e lifecycle uniformi.
-- Le roadmap sono numerose ma non esiste una sola mappa `Now / Next / Later / Rejected` collegata alle issue correnti.
-- Non esiste un gate offline per link Markdown, anchor, snippet Python e comandi CLI documentati.
-- La documentazione di asset resolution dichiara un confine che il ramo `file://` non rispetta.
+- July study is not tracked or indexed.
+- Test counts are hand-maintained and diverge across README/CONTRIBUTING/COOKBOOK/study docs.
+- Historical, active, maintained, and proposal documents do not have uniform metadata and lifecycle tags.
+- There are multiple roadmaps but no single `Now / Next / Later / Rejected` map linked to current issues.
+- No offline gate exists for markdown links, anchors, documented CLI commands, and Python snippets.
+- Asset resolution documentation states a boundary that `file://` handling currently violates.
 
-### 8.5 Contratto metadata
+### 8.5 Metadata contract
 
-Solo i documenti mantenuti e dichiarati nell'allowlist devono avere metadata
-obbligatori. Gli archivi non vanno riscritti in massa. Il contratto di transizione
-adotta già la separazione prevista dall'ultima evoluzione di Matryca Knowledge:
+Only maintained documents listed in the allowlist must have required metadata. Historical archives should not be rewritten in bulk. Transition contract already follows the latest Matryca Knowledge structure:
 
 ```yaml
 type: ArchitectureGuide
-title: Titolo stabile
-description: Descrizione breve e utile alla discovery
+title: Stable title
+description: Short discovery-focused description
 status: draft | stable | deprecated
 classification: canonical | active | historical | generated
 owner: logseq-matryca-parser
@@ -394,161 +384,151 @@ supersedes: null
 superseded_by: null
 ```
 
-`status` è riservato al lifecycle compatibile con OKF v0.2; `classification`
-esprime invece il ruolo Matryca. `last_verified` resta compatibile con il
-validator corrente, mentre `verified` e `stale_after` preparano il modello di
-freshness esplicito. I numeri volatili — test, coverage, versione, numero moduli
-— non devono essere copiati a mano: una routine deterministica li genera oppure
-il testo evita il valore assoluto.
+`status` is reserved for lifecycle compatible with OKF v0.2. `classification` captures the Matryca role. `last_verified` remains compatible with existing validator, while `verified` and `stale_after` prepare explicit freshness.
+Volatile metrics—tests, coverage, version, module count—must be generated by deterministic tooling or avoided in prose.
 
-### 8.6 Bundle mantenuto target
+### 8.6 Target maintained bundle
 
-| Path | Classificazione | Responsabilità |
+| Path | Classification | Responsibility |
 |---|---|---|
-| `docs/index.md` | canonical | Entry point machine-readable e mappa del bundle |
-| `docs/README.md` | canonical | Portale umano e navigazione per audience |
-| `docs/log.md` | active | Cronologia delle evoluzioni documentali verificabili |
-| `docs/decisions/index.md` | canonical | Registro ADR, stato e supersessioni |
-| `docs/reference/index.md` | canonical | Provenance, sorgenti esterne e contratti pubblici |
-| `docs/quality/README.md` | active | Backlog, gate e roadmap di qualità correnti |
+| `docs/index.md` | canonical | Machine-readable entrypoint and bundle map |
+| `docs/README.md` | canonical | Human portal and navigation surface |
+| `docs/log.md` | active | Verifiable documentation evolution history |
+| `docs/decisions/index.md` | canonical | ADR register, status, and supersession |
+| `docs/reference/index.md` | canonical | Provenance, external sources, and public contracts |
+| `docs/quality/README.md` | active | Current backlog, gates, and quality roadmap |
 
-I path devono restare stabili; rinomine e split richiedono redirect o link di
-supersessione. I link Markdown ordinari costituiscono gli edge della knowledge
-graph. I riferimenti locali e gli anchor devono essere validati offline. Nessun
-documento pubblico può contenere secret, path locali assoluti, dump runtime o
-log non sanitizzati.
+Paths should remain stable; renames or splits require redirects or supersession links. Standard markdown links form the knowledge-graph edges. Local references and anchors should be validated offline. No public document should include secrets, absolute local paths, raw runtime dumps, or unsanitized logs.
 
-### 8.7 Maturità MKQ e Gate G6
+### 8.7 MKQ maturity and Gate G6
 
-| Livello | Evidenza richiesta nel parser |
+| Level | Required evidence for parser |
 |---|---|
-| MKQ-0 | Sorgente registrata con repository e provenance immutabile |
-| MKQ-1 | Entry point stabile e navigazione del bundle |
-| MKQ-2 | Metadata e freshness sui soli documenti mantenuti |
-| MKQ-3 | Link, anchor, lifecycle, owner canonici e classificazioni coerenti |
-| MKQ-4 | Verifica deterministica in CI dalla repository sorgente |
-| MKQ-5 | Federation, storia e relazioni semantiche; fase successiva, non gate immediato |
+| MKQ-0 | Source-anchored repository with immutable provenance |
+| MKQ-1 | Stable entrypoint and bundle navigation |
+| MKQ-2 | Metadata and freshness on maintained documents only |
+| MKQ-3 | Verified links, anchors, lifecycle, owner, and coherent classifications |
+| MKQ-4 | Deterministic CI verification from source repository |
+| MKQ-5 | Federation, history, and semantic relations; next phase, not immediate gate |
 
-Il Gate G6 è raggiunto quando Logseq Matryca Parser arriva a **MKQ-4 senza
-degradare il comportamento Logseq**. La documentazione deve inoltre collegare
-esplicitamente [Matryca Knowledge](https://github.com/MarcoPorcellato/matryca-knowledge)
-e [Matryca Plumber](https://github.com/MarcoPorcellato/matryca-plumber), senza
-trasferire l'autorità dei contenuti fuori dal repository sorgente.
+Gate G6 is reached when Logseq Matryca Parser achieves **MKQ-4 without regressing Logseq behavior**. Documentation must also explicitly link to
+[Matryca Knowledge](https://github.com/MarcoPorcellato/matryca-knowledge)
+and
+[Matryca Plumber](https://github.com/MarcoPorcellato/matryca-plumber),
+without shifting source-of-truth authority outside the repository.
 
-### 8.8 Piano di migrazione documentale
+### 8.8 Documentation migration plan
 
-1. Inventariare e classificare i documenti senza modificarne in massa lo storico.
-2. Stabilizzare `docs/index.md`, il portale umano e gli indici decision/reference.
-3. Applicare metadata e ownership a una allowlist iniziale di documenti mantenuti.
-4. Validare link, anchor, lifecycle, canonical role e freshness offline.
-5. Aggiungere un gate CI non mutante e riproducibile dalla sorgente pulita.
-6. Dichiarare gli entry point nel registro di Matryca Knowledge tramite PR separata.
-7. Proiettare solo commit puliti e immutabili; verificare che la vista Logseq non
-   cambi la semantica dei documenti sorgente.
+1. Inventory and classify documents without bulk editing of historical content.
+2. Stabilize `docs/index.md`, human portal, and decision/reference indices.
+3. Apply metadata and ownership to an initial allowlist of maintained documents.
+4. Validate links, anchors, lifecycle, canonical role, and freshness offline.
+5. Add non-mutating, source-reproducible CI gate.
+6. Declare entry points in Matryca Knowledge registry via a separate PR.
+7. Project only clean immutable commits; verify Logseq-rendered views do not alter source semantics.
 
-## 9. Strategia di prodotto e API
+## 9. Product and API strategy
 
-Posizionamento consigliato:
+Recommended positioning:
 
-> Parser e grafo Logseq local-first, deterministici e model-neutral, con export e adapter opzionali; le scritture agentiche sono operazioni esplicite, confinate e verificabili.
+> Logseq parser and graph should be local-first, deterministic, and model-neutral, with export and optional adapters; agent writes should be explicit, confined, and verifiable.
 
-### 9.1 Contratti da pubblicare
+### 9.1 Public contracts to publish
 
-Separare chiaramente tre compatibilità:
+Separate three compatibility dimensions:
 
-1. **API Python:** import, firme, eccezioni, typing e deprecazioni;
-2. **semantica Logseq:** AST, UUID, gerarchia, proprietà, riferimenti e round-trip;
-3. **CLI:** stdout/stderr, exit code, JSON schema e stabilità dei comandi.
+1. **Python API:** imports, signatures, exceptions, typing, and deprecation policy;
+2. **Logseq semantics:** AST, UUID, hierarchy, properties, references, and round-trip;
+3. **CLI:** stdout/stderr, exit codes, JSON schema, and command stability.
 
-Classificare le superfici come `stable`, `experimental`, `internal`. Gli adapter AI, visualizzazione e watcher restano optional dependencies; il writer resta opt-in.
+Classify surfaces as `stable`, `experimental`, `internal`. AI adapters, visualization, and watcher remain optional dependencies; writer stays opt-in.
 
-### 9.2 Cosa non costruire ora
+### 9.2 What not to build now
 
-- Nessuna riscrittura big-bang del parser.
-- Nessun plugin registry prima di un adapter protocol tipizzato usato da almeno due integrazioni esterne.
-- Nessun database o motore di ricerca prima che #111 dimostri un collo di bottiglia.
-- Nessuna GUI desktop prima di segnali di adozione di library e CLI.
-- Nessuna promessa “10k+ a 60 FPS” senza benchmark riproducibile.
-- Nessuna orchestrazione LLM proprietaria nel core: il parser deve restare model-neutral.
-- Nessuna nuova modalità permissiva senza diagnostica strutturata.
+- No big-bang parser rewrite.
+- No plugin registry before a typed adapter protocol is used by at least two external integrations.
+- No database or search engine until #111 proves bottleneck justification.
+- No desktop GUI until there is adoption signal for library and CLI usage.
+- No “10k+ at 60 FPS” claims without reproducible benchmarks.
+- No proprietary LLM orchestration in core: parser should stay model-neutral.
+- No new permissive mode without structured diagnostics.
 
-## 10. Roadmap proposta
+## 10. Proposed roadmap
 
-### Wave 0 — Contenimento e correttezza (prima di ogni refactor)
+### Wave 0 — Containment and correctness (before any parser refactor)
 
-| Slice | Priorità | Deliverable | Gate |
+| Slice | Priority | Deliverable | Gate |
 |---|---:|---|---|
-| Propagazione leaf-to-root arbitraria | P0 | Fix chirurgico + test depth matrix | Output semantico invariato per fixture esistenti; deep soft-break preservato |
-| Confinamento writer su symlink | P0 | Policy fail-closed + revalidation | Nessuna fixture può mutare path esterni |
-| Confinamento asset URI | P1 | Path policy unica | Nessun resolver restituisce path esterni |
-| Backlink rename correctness | P1 | Delta identity o rebuild corretto | Incremental snapshot = cold-load snapshot |
+| Arbitrary leaf-to-root propagation | P0 | Surgical fix + depth matrix tests | Existing fixture semantics preserved; deep soft-break retained |
+| Writer confinement on symlink | P0 | Fail-closed policy + revalidation | No fixture can mutate external paths |
+| Asset URI confinement | P1 | Single path policy | No resolver returns external paths |
+| Backlink rename correctness | P1 | Delta identity rebuild or correct full rebuild | Incremental snapshot equals cold-load snapshot |
 
 ### Wave 1 — Trust baseline
 
-- #101 lint e format non mutanti;
-- #107 typing metadata e API stability table;
-- #109 bundle MKQ, status/classification separati, freshness, numeri generati,
-  link/anchor/snippet gate e provenance immutabile;
-- aggiornare #106 con i due abuse case filesystem;
-- aggiornare #103 con rename/backlink equivalence.
+- #101: non-mutating lint and format;
+- #107: typing metadata and API stability table;
+- #109: MKQ bundle, separate status/classification, freshness, generated metrics, link/anchor/snippet gates, immutable provenance;
+- update #106 with the two filesystem abuse cases;
+- update #103 with rename/backlink equivalence.
 
 ### Wave 2 — Safe vault semantics
 
-- #110 diagnostica strutturata;
-- #102 collisioni title/alias con strict mode;
-- #106 dry-run e preview patch;
-- codici diagnostici stabili per recovery, collisioni, confini e reload.
+- #110: structured diagnostics;
+- #102: title/alias collisions with strict mode;
+- #106: dry-run and patch preview;
+- stable diagnostic codes for recovery, collisions, boundaries, and reload.
 
 ### Wave 3 — Safe automation
 
-- #103 snapshot atomico per vault e mutazioni serializzate;
-- #104 corpus versionato, semantic projection e test metamorfici;
-- test watcher/writer con barrier e failure injection;
-- equivalenza incremental/cold load come gate universale.
+- #103: atomic snapshot for vault and serialized mutations;
+- #104: versioned corpus, semantic projection, and metamorphic tests;
+- watcher/writer concurrency tests with barrier and failure injection;
+- incremental/cold-load equivalence as universal gate.
 
 ### Wave 4 — Release confidence
 
-- #105 build once / publish exact bytes;
-- action pin-nate a SHA;
-- commit pin per VCS dependency;
-- wheel installato in ambiente pulito, `RECORD` e checksum verificati;
-- changelog/tag/version/artifact unificati.
+- #105: build once / publish exact bytes;
+- pin actions by SHA;
+- pin VCS dependency commits;
+- install typed wheel in clean environment, verify `RECORD` and checksum;
+- align changelog/tag/version and artifact.
 
-### Wave 5 — Scale qualificata
+### Wave 5 — Qualified scale
 
-- #111 generatori offline da 1k e 10k pagine;
-- load, single-page reload, search, backlink, RAG export, RSS e p95;
-- budget registrati per Python 3.12 e 3.13;
-- solo dopo le misure, eventuali indici secondari.
+- #111: offline generators at 1k and 10k pages;
+- load, single-page reload, search, backlink, RAG export, RSS, and p95;
+- budgets recorded for Python 3.12 and 3.13;
+- only after measurement, optional secondary indexes.
 
-### Wave 6 — Evoluzione architetturale
+### Wave 6 — Architectural evolution
 
-- #108: estrarre classifier, lexical state, reducer ed enrichment una fase alla volta;
-- nessun cambio visibile senza decisione di compatibilità;
-- ogni slice deve passare corpus, metamorphic suite, benchmark e impact review.
+- #108: extract classifier, lexical state, reducer, and enrichment one slice at a time;
+- no user-visible change without compatibility decision;
+- each slice must pass corpus, metamorphic suite, benchmarks, and impact review.
 
-## 11. Backlog agent-ready
+## 11. Agent-ready backlog
 
 ### [Issue #113](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/113) — `bug(parser): propagate immutable node refreshes through arbitrary depth`
 
-**Scope:** solo `_replace_stack_tail_node`, test parser e changelog se richiesto.  
-**Non scope:** riscrittura di `parse`, nuovi eventi, package split.  
-**Definition of Done:** depth matrix verde; invarianti UUID/order/line range; round-trip semantico; `make all`; 0 cicli; impact review documentata.
+**Scope:** only `_replace_stack_tail_node`, parser tests, and changelog if needed.
+**Out of scope:** parser rewrite, new events, package split.
+**Definition of Done:** green depth matrix; preserved UUID/order/line-range invariants; semantic round-trip; `make all`; zero cycles; documented impact review.
 
-### Estensione #106 — `security(writer): reject external symlink targets and unify filesystem confinement`
+### Extension #106 — `security(writer): reject external symlink targets and unify filesystem confinement`
 
-**Scope:** discovery/write boundary, `file://`, containment centralizzato, dry-run.  
-**Definition of Done:** nessun path esterno viene letto o scritto dai flussi vault-bound; test POSIX e casi Windows normalizzati; typed error e diagnostic code.
+**Scope:** discovery/write boundary, `file://`, centralized containment, dry-run mode.
+**Definition of Done:** no external path is read or written by vault-bound flows; POSIX and normalized Windows cases; typed errors and diagnostic codes.
 
-### Estensione #103 — `graph: make incremental identity changes cold-load equivalent`
+### Extension #103 — `graph: make incremental identity changes cold-load equivalent`
 
-**Scope:** titolo, alias, backlink, lower-title map e registry derivati.  
-**Definition of Done:** per create/edit/rename/delete, la semantic projection dello snapshot incrementale è identica al reload completo.
+**Scope:** title, alias, backlink, lower-title map, and derived registries.
+**Definition of Done:** for create/edit/rename/delete, observable incremental snapshot is identical to full reload.
 
-### Ordine delle issue esistenti
+### Existing issue order
 
 ```text
-Nuova bug parser P0
+New parser P0 bug
   ├─> #104 compatibility corpus
   └─> #108 parser phase extraction
 
@@ -564,34 +544,34 @@ Nuova bug parser P0
           └─> #108 refactor slices
 ```
 
-## 12. Metriche di successo
+## 12. Success metrics
 
-### 30 giorni
+### 30 days
 
-- 0 P0 noti aperti senza owner e riproduzione;
-- CI non mutante e dirty-tree check;
-- confine filesystem testato su symlink e `file://`;
-- documentazione mantenuta a MKQ-2 con status/classification separati e senza numeri divergenti;
-- issue #101–#111 etichettate per wave e dipendenze.
+- 0 known open P0 issues without owner and repro path;
+- non-mutating CI and dirty-tree check;
+- filesystem boundary tested for symlink and `file://`;
+- maintained documentation at MKQ-2 with separated status/classification and no diverging counts;
+- #101–#111 tagged by wave and dependency.
 
-### 60 giorni
+### 60 days
 
-- incremental reload semanticamente equivalente al cold load;
-- diagnostica JSON stabile per collisioni, riferimenti e filesystem;
-- corpus Logseq versionato con provenance;
-- wheel tipizzato e API stability table pubblica;
-- artifact release costruito una sola volta.
-- bundle documentale a MKQ-3 con link, anchor, lifecycle e canonical role verificati.
+- incremental reload semantically equivalent to cold load;
+- stable JSON diagnostics for collisions, references, and filesystem;
+- versioned Logseq corpus with provenance;
+- typed wheel and published API stability table;
+- release built once.
+- documentation bundle at MKQ-3 with verified links, anchors, lifecycle, and canonical role.
 
-### 90 giorni
+### 90 days
 
-- benchmark 1k/10k pubblicati con RSS e p95;
-- almeno due integrazioni esterne validate contro il contratto API;
-- zero regressioni degli invarianti su corpus e metamorphic suite;
-- prima estrazione parser completata senza semantic drift.
-- Gate G6: MKQ-4 in CI senza regressioni del comportamento Logseq.
+- 1k/10k benchmarks published with RSS and p95;
+- at least two external integrations validated against API contract;
+- zero invariant regressions on corpus and metamorphic suites;
+- first parser extraction slice completed without semantic drift.
+- Gate G6: MKQ-4 in CI without Logseq behavior regressions.
 
-## 13. Comandi di riproduzione e verifica
+## 13. Reproduction and verification commands
 
 Baseline:
 
@@ -606,13 +586,13 @@ rtk git diff --check
 Audit code:
 
 ```text
-status dell'indice al commit corrente
-query/context sui flussi parser, grafo, writer e watcher
-impact upstream sugli hub protetti
+index status at current commit
+query/context across parser, graph, writer, watcher
+impact upstream on protected symbols
 check(cycles) => cycleCount: 0
 ```
 
-I quattro probe runtime sono stati eseguiti su directory temporanee e non su vault reali. Output:
+The four runtime probes were executed in temporary directories only, not live vaults. Output:
 
 ```text
 DEEP_CONTENTS ['a', 'b', 'c', 'd', 'e']
@@ -623,32 +603,29 @@ SYMLINK_OUTSIDE_MUTATED True
 FILE_URI_RESULT /private/etc/passwd
 ```
 
-## 14. Limiti e affermazioni non autorizzate
+## 14. Limits and non-authoritative claims
 
-- Non è stato eseguito un benchmark su vault reale o da 10k pagine.
-- Non è stata qualificata una release pubblica né verificato un wheel installato pulito.
-- La successiva fase di pubblicazione ha aperto la PR #112, creato la issue
-  #113, aggiornato le issue impattate e chiuso solo completati/duplicati
-  documentati nel registro di riconciliazione. Milestone, branch protection e
-  workflow remoti non sono stati modificati.
-- Lo studio non dimostra compatibilità totale con tutte le versioni Logseq.
-- Il probe symlink dimostra il comportamento su macOS/POSIX; la policy deve includere una matrice Windows.
-- Nessuna raccomandazione autorizza refactor di hub senza nuovo impact review al momento dell'implementazione.
+- No benchmark was run against a real or 10k-page vault.
+- No public release was qualified and no clean wheel installation was verified.
+- The follow-up phase opened PR #112, created issue #113, updated impacted issues, and closed only completed/duplicate entries in the reconciliation log. Milestones, branch protection, and remote workflows were not changed.
+- The study does not prove complete compatibility with all Logseq versions.
+- The symlink probe demonstrates macOS/POSIX behavior; the policy must include Windows matrix coverage.
+- No recommendation authorizes hub refactors without fresh impact analysis at implementation time.
 
-## 15. Decisione finale
+## 15. Final decision
 
-La repository non ha bisogno di “più cose”; ha bisogno di rendere **impossibile perdere dati senza segnalarlo**, **impossibile uscire dal vault**, e **misurabile ogni promessa pubblica**.
+The repository does not need “more things”; it needs to make data loss impossible without alerting, make filesystem escape impossible, and make every public promise measurable.
 
-La traiettoria consigliata è quindi:
+Recommended trajectory:
 
 ```text
-correggere i P0
-→ confinare il filesystem
-→ rendere coerente lo snapshot
-→ congelare la semantica
-→ rendere verificabile il delivery
-→ misurare la scala
-→ refactor incrementale
+fix P0 issues
+→ confine vault filesystem operations
+→ make snapshots consistent
+→ freeze semantics
+→ make delivery auditable
+→ measure scale
+→ refactor incrementally
 ```
 
-Se queste wave vengono eseguite nell'ordine indicato, Logseq Matryca Parser può diventare una reference implementation credibile: non perché accumula feature, ma perché offre contratti deterministici, sicurezza locale, regressioni riproducibili e prove di qualità che un integratore può verificare autonomamente.
+If executed in this order, Logseq Matryca Parser can become a credible reference implementation: not by feature volume, but by deterministic contracts, local security, reproducible regressions, and quality evidence an integrator can independently verify.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -6,9 +6,13 @@ status: draft
 classification: canonical
 audience: maintainers
 owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
 last_verified: 2026-08-06
 verified: 2026-08-06
 stale_after: 2027-02-02
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
 supersedes: null
 superseded_by: null
 ---
@@ -26,8 +30,7 @@ introduced incrementally. Do not rewrite historical roadmaps into ADRs.
 | Writer/watcher concurrency | [Issue #103](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/103) | Proposed |
 | Filesystem confinement | [Issue #106](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/106) | Proposed |
 | Public API stability | [Issue #107](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/107) | Proposed |
-| Documentation lifecycle and MKQ | [Issue #109](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/109) | Proposed |
+| Documentation lifecycle and MKQ | [`DOCUMENTATION_SYSTEM.md`](../DOCUMENTATION_SYSTEM.md) | Source contract recorded; MKQ-4 enforcement and private profile activation pending under issue #109 |
 
 Every future ADR must identify owner, status, decision date, supersession links,
 compatibility impact, verification evidence, and rollback.
-

--- a/docs/design-docs/LOGSEQ_ASSET_RESOLUTION_SPEC.md
+++ b/docs/design-docs/LOGSEQ_ASSET_RESOLUTION_SPEC.md
@@ -39,8 +39,8 @@ Because the physical depth of the file on the disk does not change regardless of
 
 Logseq makes a sharp distinction between "Local Assets"—those stored within the graph's own /assets directory—and "Global Assets" or external files. Local assets are treated as internal components of the knowledge graph and are indexed by the Datascript database with specific metadata.11
 
-1. **Local Assets**: These are typically referenced using relative paths (../assets/). They are essential for graph portability. When the graph is moved to another computer, these relative links continue to function because they are resolved against the new graph root.3  
-2. **Absolute Paths**: References using file:/// or absolute Windows/POSIX paths are considered external. These are not portable and will break if the graph is synchronized to a different device or if the external folder structure changes.5  
+1. **Local Assets**: These are typically referenced using relative paths (../assets/). They are essential for graph portability. When the graph is moved to another computer, these relative links continue to function because they are resolved against the new graph root.3
+2. **Absolute Paths**: References using file:/// or absolute Windows/POSIX paths are considered external. These are not portable and will break if the graph is synchronized to a different device or if the external folder structure changes.5
 3. **Zotero and Symbolic Links**: Advanced users often manage large PDF libraries via Zotero. Because Logseq's relative path handling for external directories can be unreliable, the community often employs symbolic links within the /assets folder to trick Logseq into treating external folders as local ones.4
 
 ## **Namespace and Hierarchy Mapping: Filesystem Translation**
@@ -66,7 +66,7 @@ The LOGOS parser must be capable of bidirectional translation: it must be able t
 
 When a user renames a parent namespace, Logseq does not perform a directory-level rename (as there are no actual directories for namespaces). Instead, it performs a bulk rename of all files in the /pages folder that share the affected prefix.12 For example, renaming the namespace Work to Job would trigger the following transformations:
 
-* Work\_\_Tasks.md becomes Job\_\_Tasks.md  
+* Work\_\_Tasks.md becomes Job\_\_Tasks.md
 * Work\_\_Projects\_\_Alpha.md becomes Job\_\_Projects\_\_Alpha.md
 
 Because asset references are relative to the graph root (e.g., ../assets/file.png), they remain functional after the rename. The relative distance between the page file (in /pages) and the asset file (in /assets) is preserved.10 The database maintains the integrity of internal links by updating the :block/content and :block/path-refs attributes in Datascript.11 This mechanism ensures that child page links and their asset references do not break during organizational refactoring.
@@ -94,12 +94,12 @@ The mapping back to the physical PDF is achieved through the file:: property in 
 
 Logseq's strategy for storing annotations is designed to keep them searchable and linkable.
 
-1. **Markdown Annotation Pages**: For every annotated PDF, Logseq generates a Markdown file in the /pages directory named hls\_\_\<pdf\_filename\_without\_extension\>.md.16 This file contains all highlights for that PDF as individual blocks.  
-2. **EDN Metadata**: While the text of the highlight is in Markdown, the technical metadata (coordinates, colors) is often stored in a companion .edn file within the /assets directory or embedded as hidden properties in the annotation blocks.14  
-3. **The Link Chain**: The LOGOS parser can resolve a highlight link by following this chain:  
-   * Identify ((block-ref)) in a user's note.  
-   * Look up the block in Datascript to find its source page (the hls\_\_ page).  
-   * Retrieve the hl-page and ls-pos properties from the block or sidecar file.  
+1. **Markdown Annotation Pages**: For every annotated PDF, Logseq generates a Markdown file in the /pages directory named hls\_\_\<pdf\_filename\_without\_extension\>.md.16 This file contains all highlights for that PDF as individual blocks.
+2. **EDN Metadata**: While the text of the highlight is in Markdown, the technical metadata (coordinates, colors) is often stored in a companion .edn file within the /assets directory or embedded as hidden properties in the annotation blocks.14
+3. **The Link Chain**: The LOGOS parser can resolve a highlight link by following this chain:
+   * Identify ((block-ref)) in a user's note.
+   * Look up the block in Datascript to find its source page (the hls\_\_ page).
+   * Retrieve the hl-page and ls-pos properties from the block or sidecar file.
    * Use the file:: property of the hls\_\_ page to find the absolute path to the PDF asset. 11
 
 ## **Resource Indexing in the Database: Datascript Attributes**
@@ -126,9 +126,9 @@ Logseq's internal classification of assets determines the rendering component us
 
 Logseq classifies resources into several buckets:
 
-* **Images**: Rendered via the frontend.extensions.lightbox and standard \<img\> tags. Supported formats include .png, .jpg, .jpeg, .gif, .svg, and .webp.19  
-* **Videos**: Rendered via an internal player component (e.g., frontend.extensions.video.youtube or a local HTML5 video tag). Supported formats include .mp4, .webm, and .ogv.  
-* **Audio**: Handled via the :audio renderer, which supports .mp3, .wav, and .m4a.5  
+* **Images**: Rendered via the frontend.extensions.lightbox and standard \<img\> tags. Supported formats include .png, .jpg, .jpeg, .gif, .svg, and .webp.19
+* **Videos**: Rendered via an internal player component (e.g., frontend.extensions.video.youtube or a local HTML5 video tag). Supported formats include .mp4, .webm, and .ogv.
+* **Audio**: Handled via the :audio renderer, which supports .mp3, .wav, and .m4a.5
 * **Documents**: Specifically .pdf files, which trigger the specialized frontend.extensions.pdf module.19
 
 The classification logic is crucial for the LOGOS parser's "AI-Ready" objective. For a multimodal RAG system, the parser must identify the MIME type and route the asset to the appropriate model (e.g., a vision model for images or a text extraction pipeline for PDFs).
@@ -145,10 +145,10 @@ Logseq supports both Markdown and Org-mode syntax. The parser must utilize the f
 
 Python
 
-\# Captures:\!\[Label\](../assets/file.png) or \[Label\](../assets/file.pdf)  
+\# Captures:\!\[Label\](../assets/file.png) or \[Label\](../assets/file.pdf)
 MARKDOWN\_ASSET\_REGEX \= r'\!?(?:\\\[.\*?\\\])\\(((?:\\.\\.\\/)\*assets\\/\[^ \\)\]+)\\)'
 
-\# Captures: file::../assets/file.pdf (Page/Block Properties)  
+\# Captures: file::../assets/file.pdf (Page/Block Properties)
 PROPERTY\_ASSET\_REGEX \= r'^\\s\*file::\\s\*((?:\\.\\.\\/)\*assets\\/\[^\\s\]+)'
 
 7
@@ -157,7 +157,7 @@ PROPERTY\_ASSET\_REGEX \= r'^\\s\*file::\\s\*((?:\\.\\.\\/)\*assets\\/\[^\\s\]+)
 
 Python
 
-\# Captures: \[\[../assets/file.png\]\]  
+\# Captures: \[\[../assets/file.png\]\]
 ORG\_ASSET\_REGEX \= r'\\\[\\\[(?:\\.\\.\\/)\*assets\\/(\[^\\\]\]+)\\\]\\\]'
 
 1
@@ -166,7 +166,7 @@ ORG\_ASSET\_REGEX \= r'\\\[\\\[(?:\\.\\.\\/)\*assets\\/(\[^\\\]\]+)\\\]\\\]'
 
 Python
 
-\# Captures: \[\[hls://1698059081568\_0\]\]  
+\# Captures: \[\[hls://1698059081568\_0\]\]
 HLS\_PROTOCOL\_REGEX \= r'\\\[\\\[(hls:\\/\\/\[^\\\]\]+)\\\]\\\]'
 
 14
@@ -177,40 +177,40 @@ The following algorithm provides a step-by-step resolution of a Logseq link to a
 
 Python
 
-def ResolveAssetPath(graphRoot, currentFilePath, linkContent):  
-    """  
-    Standardizes the resolution of a Logseq asset link to an absolute system path.  
-    """  
-    \# 1\. Normalize the link string  
-    normalizedLink \= linkContent.replace('\\\\', '/')  
-      
-    \# 2\. Check for absolute file protocol  
-    if normalizedLink.startswith("file://"):  
-        \# Handle Electron/Windows path inconsistencies  
-        path \= normalizedLink.replace("file://", "")  
-        if path.startswith("/") and os.name \== 'nt':  
-            path \= path\[1:\] \# Strip leading slash for Windows paths like /C:/  
-        return os.path.abspath(path)  
-      
-    \# 3\. Handle Relative Assets (The Logseq Core Logic)  
-    \# Logseq resolves '../assets/' and 'assets/' relative to the graph root.  
-    if normalizedLink.startswith("../assets/") or normalizedLink.startswith("assets/"):  
-        \# Remove any leading '../' to get the root-relative path  
-        rootRelativePath \= normalizedLink.replace("../assets/", "assets/")  
-        absolutePath \= os.path.join(graphRoot, rootRelativePath)  
-        return os.path.normpath(absolutePath)  
-          
-    \# 4\. Handle Namespace-specific resolution (Edge Case)  
-    \# If the current page is a namespace with physical folders (rare/manual)  
-    \# we would look relative to currentFilePath.  
-    localPath \= os.path.join(os.path.dirname(currentFilePath), normalizedLink)  
-    if os.path.exists(localPath):  
-        return os.path.normpath(localPath)  
-          
-    \# 5\. Fallback: Search the entire /assets folder for the filename (Logseq's soft resolution)  
-    filename \= os.path.basename(normalizedLink)  
-    globalAssetPath \= os.path.join(graphRoot, "assets", filename)  
-    if os.path.exists(globalAssetPath):  
+def ResolveAssetPath(graphRoot, currentFilePath, linkContent):
+    """
+    Standardizes the resolution of a Logseq asset link to an absolute system path.
+    """
+    \# 1\. Normalize the link string
+    normalizedLink \= linkContent.replace('\\\\', '/')
+
+    \# 2\. Check for absolute file protocol
+    if normalizedLink.startswith("file://"):
+        \# Handle Electron/Windows path inconsistencies
+        path \= normalizedLink.replace("file://", "")
+        if path.startswith("/") and os.name \== 'nt':
+            path \= path\[1:\] \# Strip leading slash for Windows paths like /C:/
+        return os.path.abspath(path)
+
+    \# 3\. Handle Relative Assets (The Logseq Core Logic)
+    \# Logseq resolves '../assets/' and 'assets/' relative to the graph root.
+    if normalizedLink.startswith("../assets/") or normalizedLink.startswith("assets/"):
+        \# Remove any leading '../' to get the root-relative path
+        rootRelativePath \= normalizedLink.replace("../assets/", "assets/")
+        absolutePath \= os.path.join(graphRoot, rootRelativePath)
+        return os.path.normpath(absolutePath)
+
+    \# 4\. Handle Namespace-specific resolution (Edge Case)
+    \# If the current page is a namespace with physical folders (rare/manual)
+    \# we would look relative to currentFilePath.
+    localPath \= os.path.join(os.path.dirname(currentFilePath), normalizedLink)
+    if os.path.exists(localPath):
+        return os.path.normpath(localPath)
+
+    \# 5\. Fallback: Search the entire /assets folder for the filename (Logseq's soft resolution)
+    filename \= os.path.basename(normalizedLink)
+    globalAssetPath \= os.path.join(graphRoot, "assets", filename)
+    if os.path.exists(globalAssetPath):
         return globalAssetPath
 
     return None \# Link could not be resolved
@@ -225,35 +225,35 @@ The extraction of PDF highlights requires parsing the sidecar .edn files or page
 
 JSON
 
-{  
-  "protocol": "hls://",  
-  "annotation\_id": "1698059081568\_0",  
-  "source\_pdf": {  
-    "logical\_name": "how\_to\_take\_smart\_notes.pdf",  
-    "absolute\_path": "/home/user/graph/assets/how\_to\_take\_smart\_notes.pdf",  
-    "mime\_type": "application/pdf"  
-  },  
-  "highlight\_data": {  
-    "page\_number": 12,  
-    "coordinates": {  
-      "x1": 52.9556,  
-      "y1": 728.343,  
-      "x2": 191.196,  
-      "y2": 743.218  
-    },  
-    "color\_rgb": \[1.0, 1.0, 0.0\],  
-    "text": "Writing is not the outcome of thinking; it is the medium in which thinking takes place."  
-  }  
+{
+  "protocol": "hls://",
+  "annotation\_id": "1698059081568\_0",
+  "source\_pdf": {
+    "logical\_name": "how\_to\_take\_smart\_notes.pdf",
+    "absolute\_path": "/home/user/graph/assets/how\_to\_take\_smart\_notes.pdf",
+    "mime\_type": "application/pdf"
+  },
+  "highlight\_data": {
+    "page\_number": 12,
+    "coordinates": {
+      "x1": 52.9556,
+      "y1": 728.343,
+      "x2": 191.196,
+      "y2": 743.218
+    },
+    "color\_rgb": \[1.0, 1.0, 0.0\],
+    "text": "Writing is not the outcome of thinking; it is the medium in which thinking takes place."
+  }
 }
 
 14
 
 **Technical Mapping Logic**:
 
-1. When the parser encounters \], it queries the database for a block where :block/content or a custom property matches \<ID\>.  
-2. The parser retrieves the parent page (e.g., hls\_\_how\_to\_take\_smart\_notes).  
-3. It resolves the file:: property of that page to locate the physical PDF in /assets.  
-4. It extracts the ls-pos (coordinates) and hl-page (page number) from the annotation block properties.  
+1. When the parser encounters \], it queries the database for a block where :block/content or a custom property matches \<ID\>.
+2. The parser retrieves the parent page (e.g., hls\_\_how\_to\_take\_smart\_notes).
+3. It resolves the file:: property of that page to locate the physical PDF in /assets.
+4. It extracts the ls-pos (coordinates) and hl-page (page number) from the annotation block properties.
 5. These coordinates are passed to the RAG system, allowing a visual processing agent to crop the specific region of the PDF for the LLM to "see." 14
 
 ## **Evolution and Future Trajectory of the Logseq Filesystem**
@@ -268,38 +268,38 @@ There is a long-standing proposal within the Logseq community to move from encod
 
 The primary motivation for the LOGOS parser—making Logseq "AI-Ready"—requires a level of filesystem precision that goes beyond standard note-taking apps. By mastering the Asset Resolution Engine, the LOGOS parser can provide an LLM with a comprehensive context window that includes:
 
-* **Spatial Context**: Exactly where on a PDF page a highlight was made.  
-* **Hierarchical Context**: How a specific asset fits into the larger namespace taxonomy.  
+* **Spatial Context**: Exactly where on a PDF page a highlight was made.
+* **Hierarchical Context**: How a specific asset fits into the larger namespace taxonomy.
 * **Relational Context**: How an image or video is linked across different blocks via block references.
 
 This technical specification provides the roadmap for building a high-fidelity bridge between the unstructured filesystem and the structured data needs of modern artificial intelligence. The ability to resolve any hls:// link or ../assets/ reference to an absolute system path is the final piece of the puzzle for a fully integrated, multimodal knowledge retrieval system.3
 
-#### **Bibliografia**
+#### **Bibliography**
 
-1. Logseq from an Org-mode Point of View \- of Karl Voit, accesso eseguito il giorno aprile 25, 2026, [https://karl-voit.at/2024/01/28/logseq-from-org-pov/](https://karl-voit.at/2024/01/28/logseq-from-org-pov/)  
-2. Just realized the difference between page properties and block properties \- please double check, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/just-realized-the-difference-between-page-properties-and-block-properties-please-double-check/30433](https://discuss.logseq.com/t/just-realized-the-difference-between-page-properties-and-block-properties-please-double-check/30433)  
-3. The relative path for files in "assets" folder · logseq logseq ... \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/discussions/4582](https://github.com/logseq/logseq/discussions/4582)  
-4. Relative Paths in file links don't work (incorrect handling of double-dot ..) \- Bug Reports, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/relative-paths-in-file-links-dont-work-incorrect-handling-of-double-dot/8952](https://discuss.logseq.com/t/relative-paths-in-file-links-dont-work-incorrect-handling-of-double-dot/8952)  
-5. Support relative path in audio component \- Feature Requests \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/support-relative-path-in-audio-component/5518](https://discuss.logseq.com/t/support-relative-path-in-audio-component/5518)  
-6. Understanding the proper way to handle attachements ("assets") \- \#7 by gax, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/understanding-the-proper-way-to-handle-attachements-assets/8910/7](https://discuss.logseq.com/t/understanding-the-proper-way-to-handle-attachements-assets/8910/7)  
-7. logseq/.i18n-lint.toml at master \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/blob/master/.i18n-lint.toml](https://github.com/logseq/logseq/blob/master/.i18n-lint.toml)  
-8. How to use Logseq Namespaces, accesso eseguito il giorno aprile 25, 2026, [https://www.logseqmastery.com/blog/logseq-namespaces](https://www.logseqmastery.com/blog/logseq-namespaces)  
-9. Proposal: Changing How Namespaces Function in Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/proposal-changing-how-namespaces-function-in-logseq/3727](https://discuss.logseq.com/t/proposal-changing-how-namespaces-function-in-logseq/3727)  
-10. Cleaner file names \- Feature Requests \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/cleaner-file-names/11014](https://discuss.logseq.com/t/cleaner-file-names/11014)  
-11. Logseq datascript schema · GitHub, accesso eseguito il giorno aprile 25, 2026, [https://gist.github.com/tiensonqin/9a40575827f8f63eec54432443ecb929](https://gist.github.com/tiensonqin/9a40575827f8f63eec54432443ecb929)  
-12. Support subdirs for namespace hierarchy \- Page 4 \- Feature Requests \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/support-subdirs-for-namespace-hierarchy/9763?page=4](https://discuss.logseq.com/t/support-subdirs-for-namespace-hierarchy/9763?page=4)  
-13. General question about data structures to maximize benefits of datalog db and queries, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063](https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063)  
-14. Export PDF with Highlights / Save highlights to PDF file \- Feature Requests \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/export-pdf-with-highlights-save-highlights-to-pdf-file/6076](https://discuss.logseq.com/t/export-pdf-with-highlights-save-highlights-to-pdf-file/6076)  
-15. PDF annotation in Logseq \- Feature Requests, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/pdf-annotation-in-logseq/1427](https://discuss.logseq.com/t/pdf-annotation-in-logseq/1427)  
-16. Inconsistent behavior when using built-in PDF reader & annotator \- General \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/inconsistent-behavior-when-using-built-in-pdf-reader-annotator/22305](https://discuss.logseq.com/t/inconsistent-behavior-when-using-built-in-pdf-reader-annotator/22305)  
-17. Feature Request: PDF annotations link jumps back to corresponding location in the PDF file, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/feature-request-pdf-annotations-link-jumps-back-to-corresponding-location-in-the-pdf-file/4518](https://discuss.logseq.com/t/feature-request-pdf-annotations-link-jumps-back-to-corresponding-location-in-the-pdf-file/4518)  
-18. HTTP server in cljs.browser.repl doesn't serve files with extensions other than specified in ext-\>mime-type \- Clojure Q\&A, accesso eseguito il giorno aprile 25, 2026, [https://ask.clojure.org/index.php/5893/server-browser-doesnt-serve-files-extensions-other-specified](https://ask.clojure.org/index.php/5893/server-browser-doesnt-serve-files-extensions-other-specified)  
-19. logseq/src/main/frontend/components/block.cljs at master \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/blob/master/src/main/frontend/components/block.cljs](https://github.com/logseq/logseq/blob/master/src/main/frontend/components/block.cljs)  
-20. logseq/src/main/frontend/modules/shortcut/config.cljs at master \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/blob/master/src/main/frontend/modules/shortcut/config.cljs](https://github.com/logseq/logseq/blob/master/src/main/frontend/modules/shortcut/config.cljs)  
-21. Macros to improve assets management \- Look what I built \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/macros-to-improve-assets-management/13606](https://discuss.logseq.com/t/macros-to-improve-assets-management/13606)  
-22. Logseq doesn't seem to support Markdown Reference Links\!? \- Questions & Help, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/logseq-doesnt-seem-to-support-markdown-reference-links/19245](https://discuss.logseq.com/t/logseq-doesnt-seem-to-support-markdown-reference-links/19245)  
-23. Creating Link Aliases in Logseq \- by Preslav Rachev \- Medium, accesso eseguito il giorno aprile 25, 2026, [https://medium.com/@p5v/creating-link-aliases-in-logseq-fe321d38fd7b](https://medium.com/@p5v/creating-link-aliases-in-logseq-fe321d38fd7b)  
-24. Markdown vs Orgmode \- Which format should one choose? : r/logseq \- Reddit, accesso eseguito il giorno aprile 25, 2026, [https://www.reddit.com/r/logseq/comments/1by05ql/markdown\_vs\_orgmode\_which\_format\_should\_one\_choose/](https://www.reddit.com/r/logseq/comments/1by05ql/markdown_vs_orgmode_which_format_should_one_choose/)  
-25. 0.8.18 · Milestone \#12 · logseq/logseq \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/milestone/12?closed=1](https://github.com/logseq/logseq/milestone/12?closed=1)  
-26. Creating Link Aliases in Logseq \- Preslav Rachev, accesso eseguito il giorno aprile 25, 2026, [https://preslav.me/2022/04/10/create-link-aliases-in-logseq/](https://preslav.me/2022/04/10/create-link-aliases-in-logseq/)  
-27. Support subdirs for namespace hierarchy \- Feature Requests \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/support-subdirs-for-namespace-hierarchy/9763](https://discuss.logseq.com/t/support-subdirs-for-namespace-hierarchy/9763)
+1. Logseq from an Org-mode Point of View \- of Karl Voit, accessed on April 25, 2026, [https://karl-voit.at/2024/01/28/logseq-from-org-pov/](https://karl-voit.at/2024/01/28/logseq-from-org-pov/)
+2. Just realized the difference between page properties and block properties \- please double check, accessed on April 25, 2026, [https://discuss.logseq.com/t/just-realized-the-difference-between-page-properties-and-block-properties-please-double-check/30433](https://discuss.logseq.com/t/just-realized-the-difference-between-page-properties-and-block-properties-please-double-check/30433)
+3. The relative path for files in "assets" folder · logseq logseq ... \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/discussions/4582](https://github.com/logseq/logseq/discussions/4582)
+4. Relative Paths in file links don't work (incorrect handling of double-dot ..) \- Bug Reports, accessed on April 25, 2026, [https://discuss.logseq.com/t/relative-paths-in-file-links-dont-work-incorrect-handling-of-double-dot/8952](https://discuss.logseq.com/t/relative-paths-in-file-links-dont-work-incorrect-handling-of-double-dot/8952)
+5. Support relative path in audio component \- Feature Requests \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/support-relative-path-in-audio-component/5518](https://discuss.logseq.com/t/support-relative-path-in-audio-component/5518)
+6. Understanding the proper way to handle attachements ("assets") \- \#7 by gax, accessed on April 25, 2026, [https://discuss.logseq.com/t/understanding-the-proper-way-to-handle-attachements-assets/8910/7](https://discuss.logseq.com/t/understanding-the-proper-way-to-handle-attachements-assets/8910/7)
+7. logseq/.i18n-lint.toml at master \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/blob/master/.i18n-lint.toml](https://github.com/logseq/logseq/blob/master/.i18n-lint.toml)
+8. How to use Logseq Namespaces, accessed on April 25, 2026, [https://www.logseqmastery.com/blog/logseq-namespaces](https://www.logseqmastery.com/blog/logseq-namespaces)
+9. Proposal: Changing How Namespaces Function in Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/proposal-changing-how-namespaces-function-in-logseq/3727](https://discuss.logseq.com/t/proposal-changing-how-namespaces-function-in-logseq/3727)
+10. Cleaner file names \- Feature Requests \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/cleaner-file-names/11014](https://discuss.logseq.com/t/cleaner-file-names/11014)
+11. Logseq datascript schema · GitHub, accessed on April 25, 2026, [https://gist.github.com/tiensonqin/9a40575827f8f63eec54432443ecb929](https://gist.github.com/tiensonqin/9a40575827f8f63eec54432443ecb929)
+12. Support subdirs for namespace hierarchy \- Page 4 \- Feature Requests \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/support-subdirs-for-namespace-hierarchy/9763?page=4](https://discuss.logseq.com/t/support-subdirs-for-namespace-hierarchy/9763?page=4)
+13. General question about data structures to maximize benefits of datalog db and queries, accessed on April 25, 2026, [https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063](https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063)
+14. Export PDF with Highlights / Save highlights to PDF file \- Feature Requests \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/export-pdf-with-highlights-save-highlights-to-pdf-file/6076](https://discuss.logseq.com/t/export-pdf-with-highlights-save-highlights-to-pdf-file/6076)
+15. PDF annotation in Logseq \- Feature Requests, accessed on April 25, 2026, [https://discuss.logseq.com/t/pdf-annotation-in-logseq/1427](https://discuss.logseq.com/t/pdf-annotation-in-logseq/1427)
+16. Inconsistent behavior when using built-in PDF reader & annotator \- General \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/inconsistent-behavior-when-using-built-in-pdf-reader-annotator/22305](https://discuss.logseq.com/t/inconsistent-behavior-when-using-built-in-pdf-reader-annotator/22305)
+17. Feature Request: PDF annotations link jumps back to corresponding location in the PDF file, accessed on April 25, 2026, [https://discuss.logseq.com/t/feature-request-pdf-annotations-link-jumps-back-to-corresponding-location-in-the-pdf-file/4518](https://discuss.logseq.com/t/feature-request-pdf-annotations-link-jumps-back-to-corresponding-location-in-the-pdf-file/4518)
+18. HTTP server in cljs.browser.repl doesn't serve files with extensions other than specified in ext-\>mime-type \- Clojure Q\&A, accessed on April 25, 2026, [https://ask.clojure.org/index.php/5893/server-browser-doesnt-serve-files-extensions-other-specified](https://ask.clojure.org/index.php/5893/server-browser-doesnt-serve-files-extensions-other-specified)
+19. logseq/src/main/frontend/components/block.cljs at master \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/blob/master/src/main/frontend/components/block.cljs](https://github.com/logseq/logseq/blob/master/src/main/frontend/components/block.cljs)
+20. logseq/src/main/frontend/modules/shortcut/config.cljs at master \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/blob/master/src/main/frontend/modules/shortcut/config.cljs](https://github.com/logseq/logseq/blob/master/src/main/frontend/modules/shortcut/config.cljs)
+21. Macros to improve assets management \- Look what I built \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/macros-to-improve-assets-management/13606](https://discuss.logseq.com/t/macros-to-improve-assets-management/13606)
+22. Logseq doesn't seem to support Markdown Reference Links\!? \- Questions & Help, accessed on April 25, 2026, [https://discuss.logseq.com/t/logseq-doesnt-seem-to-support-markdown-reference-links/19245](https://discuss.logseq.com/t/logseq-doesnt-seem-to-support-markdown-reference-links/19245)
+23. Creating Link Aliases in Logseq \- by Preslav Rachev \- Medium, accessed on April 25, 2026, [https://medium.com/@p5v/creating-link-aliases-in-logseq-fe321d38fd7b](https://medium.com/@p5v/creating-link-aliases-in-logseq-fe321d38fd7b)
+24. Markdown vs Orgmode \- Which format should one choose? : r/logseq \- Reddit, accessed on April 25, 2026, [https://www.reddit.com/r/logseq/comments/1by05ql/markdown\_vs\_orgmode\_which\_format\_should\_one\_choose/](https://www.reddit.com/r/logseq/comments/1by05ql/markdown_vs_orgmode_which_format_should_one_choose/)
+25. 0.8.18 · Milestone \#12 · logseq/logseq \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/milestone/12?closed=1](https://github.com/logseq/logseq/milestone/12?closed=1)
+26. Creating Link Aliases in Logseq \- Preslav Rachev, accessed on April 25, 2026, [https://preslav.me/2022/04/10/create-link-aliases-in-logseq/](https://preslav.me/2022/04/10/create-link-aliases-in-logseq/)
+27. Support subdirs for namespace hierarchy \- Feature Requests \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/support-subdirs-for-namespace-hierarchy/9763](https://discuss.logseq.com/t/support-subdirs-for-namespace-hierarchy/9763)

--- a/docs/design-docs/LOGSEQ_DATASCRIPT_MAPPING.md
+++ b/docs/design-docs/LOGSEQ_DATASCRIPT_MAPPING.md
@@ -64,10 +64,10 @@ Task management is a native feature of the Logseq database. When a block starts 
 
 The following markers are hardcoded within the Logseq core logic and recognized by the database:
 
-* TODO, LATER: Representing pending tasks.  
-* DOING, NOW: Representing active tasks.  
-* DONE: Representing completed tasks.  
-* WAITING, WAIT: Representing tasks stalled by external dependencies.  
+* TODO, LATER: Representing pending tasks.
+* DOING, NOW: Representing active tasks.
+* DONE: Representing completed tasks.
+* WAITING, WAIT: Representing tasks stalled by external dependencies.
 * CANCELED, CANCELLED: Representing tasks that have been aborted.19
 
 If a block possesses a marker, it may also have a :block/priority, typically stored as a single character ("A", "B", or "C").10 These are not just part of the content string; they are distinct attributes that enable the sorting and filtering required for high-performance task dashboards.
@@ -80,7 +80,7 @@ One of the most critical aspects of the LOGOS parser is the reconstruction of th
 
 The hierarchy is defined by two primary pointers: :block/parent and :block/left.
 
-* **:block/parent**: This attribute points to the database ID of the entity directly above the current block. If a block is at the root level of a page, its parent is the page entity itself.6  
+* **:block/parent**: This attribute points to the database ID of the entity directly above the current block. If a block is at the root level of a page, its parent is the page entity itself.6
 * **:block/left**: This attribute manages the sequence of blocks at the same level of indentation. It points to the block immediately "to the left" (i.e., preceding it). The first block under a parent will have a :block/left value that is either null or, in some internal transactions, points back to the parent to signal the start of a list.6
 
 This structure is effectively a linked list for siblings, combined with a parent pointer for the tree structure. To reconstruct a page in Python, the LOGOS parser must follow the :block/parent references to establish the tree and then use the :block/left references to sort each level of the tree. This is a departure from standard Markdown parsers that treat indentation as a simple depth integer.
@@ -89,9 +89,9 @@ This structure is effectively a linked list for siblings, combined with a parent
 
 Logseq implements a specialized attribute called :block/path-refs to handle context inheritance in the graph.23 While :block/refs contains only the pages and blocks explicitly mentioned in a block’s content, :block/path-refs is a transitive collection that includes:
 
-1. All direct references in the block.  
-2. All references made by the block's parent.  
-3. All references made by every ancestor up to the page level.  
+1. All direct references in the block.
+2. All references made by the block's parent.
+3. All references made by every ancestor up to the page level.
 4. The ID of the page itself.6
 
 This inheritance logic is the engine behind Logseq’s powerful search capabilities. It allows a query for \#research to return a specific bullet point even if that bullet does not contain the tag, provided that one of its parent blocks or the page itself is tagged with \#research.20 For the LOGOS parser, calculating :block/path-refs is essential for ensuring that Python-serialized objects can support the same level of discoverability as the original Logseq app.
@@ -106,7 +106,7 @@ The :block/properties attribute is a map where keys are stored as keywords. Logs
 
 The storage of values within this map is determined by the content type:
 
-* **Plain Text**: Stored as a simple string.  
+* **Plain Text**: Stored as a simple string.
 * **Page References**: If a value is enclosed in brackets \[\[ref\]\] or prefixed with \#, it is stored in the database as a **Clojure Set** of strings.11 This allows a single property to point to multiple entities. For example, tags:: \[\[work\]\]\[\[urgent\]\] is stored as \#{"work" "urgent"}.
 
 ### **Maintaining Document Order**
@@ -157,61 +157,61 @@ To guide the development of the Python LogseqNode object, the following JSON rep
 
 ### **Markdown Source**
 
-* TODO Deliver the\] technical report \#urgent  
-  id:: 64909c2c-2838-405f-8c02-4a0d53356518  
-  type::\]  
-  priority:: A  
-  scheduled:: 20240520  
+* TODO Deliver the\] technical report \#urgent
+  id:: 64909c2c-2838-405f-8c02-4a0d53356518
+  type::\]
+  priority:: A
+  scheduled:: 20240520
   * Ensure 100% semantic parity with the graph
 
 ### **Datascript JSON Mapping**
 
 JSON
 
-\] technical report \#urgent\\n  type::\]\\n  priority:: A\\n  scheduled:: 20240520",  
-    "block/marker": "TODO",  
-    "block/priority": "A",  
-    "block/scheduled": 20240520,  
-    "block/page": { "db/id": 100 },  
-    "block/parent": { "db/id": 100 },  
-    "block/left": { "db/id": 5000 },  
-    "block/format": "markdown",  
-    "block/properties": {  
-      "type":,  
-      "priority": "A",  
-      "scheduled": 20240520  
-    },  
-    "block/properties-order": \["type", "priority", "scheduled"\],  
-    "block/refs": \[  
-      { "db/id": 101, "block/name": "logos" },  
-      { "db/id": 102, "block/name": "urgent" },  
-      { "db/id": 103, "block/name": "documentation" }  
-    \],  
-    "block/path-refs": \[  
-      { "db/id": 100 },  
-      { "db/id": 101 },  
-      { "db/id": 102 },  
-      { "db/id": 103 }  
-    \],  
-    "block/created-at": 1716200000000,  
-    "block/updated-at": 1716210000000  
-  },  
-  {  
-    "db/id": 5002,  
-    "block/uuid": "9b12c3d4-e567\-890a-bc1d\-2e3f4a5b6c7d",  
-    "block/content": "Ensure 100% semantic parity with the graph",  
-    "block/page": { "db/id": 100 },  
-    "block/parent": { "db/id": 5001 },  
-    "block/left": null,  
-    "block/format": "markdown",  
-    "block/path-refs": \[  
-      { "db/id": 100 },  
-      { "db/id": 5001 },  
-      { "db/id": 101 },  
-      { "db/id": 102 },  
-      { "db/id": 103 }  
-    \]  
-  }  
+\] technical report \#urgent\\n  type::\]\\n  priority:: A\\n  scheduled:: 20240520",
+    "block/marker": "TODO",
+    "block/priority": "A",
+    "block/scheduled": 20240520,
+    "block/page": { "db/id": 100 },
+    "block/parent": { "db/id": 100 },
+    "block/left": { "db/id": 5000 },
+    "block/format": "markdown",
+    "block/properties": {
+      "type":,
+      "priority": "A",
+      "scheduled": 20240520
+    },
+    "block/properties-order": \["type", "priority", "scheduled"\],
+    "block/refs": \[
+      { "db/id": 101, "block/name": "logos" },
+      { "db/id": 102, "block/name": "urgent" },
+      { "db/id": 103, "block/name": "documentation" }
+    \],
+    "block/path-refs": \[
+      { "db/id": 100 },
+      { "db/id": 101 },
+      { "db/id": 102 },
+      { "db/id": 103 }
+    \],
+    "block/created-at": 1716200000000,
+    "block/updated-at": 1716210000000
+  },
+  {
+    "db/id": 5002,
+    "block/uuid": "9b12c3d4-e567\-890a-bc1d\-2e3f4a5b6c7d",
+    "block/content": "Ensure 100% semantic parity with the graph",
+    "block/page": { "db/id": 100 },
+    "block/parent": { "db/id": 5001 },
+    "block/left": null,
+    "block/format": "markdown",
+    "block/path-refs": \[
+      { "db/id": 100 },
+      { "db/id": 5001 },
+      { "db/id": 101 },
+      { "db/id": 102 },
+      { "db/id": 103 }
+    \]
+  }
 \]
 
 ## **Logic for Serializing Python Objects to Datascript**
@@ -234,49 +234,49 @@ The parser must iterate through the :block/content and extract wikilinks, tags, 
 
 The parser must extract the property block (the lines immediately following the first line of content).
 
-1. Keys are converted to keywords (e.g., Type:: \-\> :type).  
-2. Values are inspected for brackets. If present, the value is wrapped in a set.  
+1. Keys are converted to keywords (e.g., Type:: \-\> :type).
+2. Values are inspected for brackets. If present, the value is wrapped in a set.
 3. The original order of keys is recorded in the :block/properties-order vector.
 
 ## **Conclusion**
 
 The mapping between Logseq Markdown and Datascript is a sophisticated transformation that turns a hierarchical text file into a contextual graph. Achieving semantic parity requires the LOGOS parser to meticulously manage normalized page identities, linked-list hierarchy pointers, and set-based property values. By following the schema specifications outlined in this technical document, the LOGOS project can ensure that its Python objects are mathematically equivalent to the data structures used in Logseq, providing a solid foundation for advanced graph-based applications and RAG systems. This specification serves as the authoritative guide for the implementation of the LogseqPage and LogseqNode classes, ensuring that the "sovereign" parser maintains the integrity of the user's graph data.
 
-#### **Bibliografia**
+#### **Bibliography**
 
-1. How advanced queries work \- step-by-step explainer \- Queries \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/how-advanced-queries-work-step-by-step-explainer/30544](https://discuss.logseq.com/t/how-advanced-queries-work-step-by-step-explainer/30544)  
-2. LogSeq: Personal Knowledge Graphs with DB power | by Volodymyr Pavlyshyn \- Medium, accesso eseguito il giorno aprile 25, 2026, [https://volodymyrpavlyshyn.medium.com/logseq-personal-knowledge-graphs-with-db-power-85687d17cc4a](https://volodymyrpavlyshyn.medium.com/logseq-personal-knowledge-graphs-with-db-power-85687d17cc4a)  
-3. How to create page with properties? Page templates? \- Questions & Help \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/how-to-create-page-with-properties-page-templates/26029](https://discuss.logseq.com/t/how-to-create-page-with-properties-page-templates/26029)  
-4. nbb with features enabled for logseq \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/nbb-logseq](https://github.com/logseq/nbb-logseq)  
-5. nbb-logseq/examples/from-js/README.md at main \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/nbb-logseq/blob/main/examples/from-js/README.md](https://github.com/logseq/nbb-logseq/blob/main/examples/from-js/README.md)  
-6. General question about data structures to maximize benefits of ..., accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063](https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063)  
-7. Data structure in logseq \- Questions & Help, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/data-structure-in-logseq/21179](https://discuss.logseq.com/t/data-structure-in-logseq/21179)  
-8. Where I can know the detail schema of logseq db \- Questions & Help, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/where-i-can-know-the-detail-schema-of-logseq-db/6053](https://discuss.logseq.com/t/where-i-can-know-the-detail-schema-of-logseq-db/6053)  
-9. Option to treat specific blocks as pages \- Feature Requests \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/option-to-treat-specific-blocks-as-pages/13203](https://discuss.logseq.com/t/option-to-treat-specific-blocks-as-pages/13203)  
-10. Logseq datascript schema · GitHub, accesso eseguito il giorno aprile 25, 2026, [https://gist.github.com/tiensonqin/9a40575827f8f63eec54432443ecb929](https://gist.github.com/tiensonqin/9a40575827f8f63eec54432443ecb929)  
-11. A Little Guy and His Blog \- Investing and Technical ExcellenceA ..., accesso eseguito il giorno aprile 25, 2026, [https://www.eriksuniverse.com/](https://www.eriksuniverse.com/)  
-12. Advanced query for sorted tasks with custom table view \- Look what I built \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/advanced-query-for-sorted-tasks-with-custom-table-view/29101](https://discuss.logseq.com/t/advanced-query-for-sorted-tasks-with-custom-table-view/29101)  
-13. Official, comprehensive list of \`config.edn\` options \- Archive \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/official-comprehensive-list-of-config-edn-options/4935](https://discuss.logseq.com/t/official-comprehensive-list-of-config-edn-options/4935)  
-14. Different ways to structure data \- Page 4 \- Queries \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/different-ways-to-structure-data/8819?page=4](https://discuss.logseq.com/t/different-ways-to-structure-data/8819?page=4)  
-15. The difference between \[\[page links\]\], \#tags, and properties:: \- Documentation \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/the-difference-between-page-links-tags-and-properties/8393](https://discuss.logseq.com/t/the-difference-between-page-links-tags-and-properties/8393)  
-16. Queries for task management \- Look what I built \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/queries-for-task-management/14937](https://discuss.logseq.com/t/queries-for-task-management/14937)  
-17. Different ways to structure data \- Queries \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/different-ways-to-structure-data/8819](https://discuss.logseq.com/t/different-ways-to-structure-data/8819)  
-18. Pages vs Blocks \- General \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/pages-vs-blocks/205](https://discuss.logseq.com/t/pages-vs-blocks/205)  
-19. Custom workflows/TODO markers via plugins? \- Questions & Help \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/custom-workflows-todo-markers-via-plugins/18630](https://discuss.logseq.com/t/custom-workflows-todo-markers-via-plugins/18630)  
-20. Queries for task management \- Page 6 \- Look what I built \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/queries-for-task-management/14937?page=6](https://discuss.logseq.com/t/queries-for-task-management/14937?page=6)  
-21. Pinning active projects to journal page \- Questions & Help \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/pinning-active-projects-to-journal-page/25374](https://discuss.logseq.com/t/pinning-active-projects-to-journal-page/25374)  
-22. Just realized the difference between page properties and block properties \- please double check, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/just-realized-the-difference-between-page-properties-and-block-properties-please-double-check/30433](https://discuss.logseq.com/t/just-realized-the-difference-between-page-properties-and-block-properties-please-double-check/30433)  
-23. Automatic Query based on the parent block reference, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/automatic-query-based-on-the-parent-block-reference/16023](https://discuss.logseq.com/t/automatic-query-based-on-the-parent-block-reference/16023)  
-24. Advanced Query that pulls all reference AND recursive name spaces \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/advanced-query-that-pulls-all-reference-and-recursive-name-spaces/21275](https://discuss.logseq.com/t/advanced-query-that-pulls-all-reference-and-recursive-name-spaces/21275)  
-25. Tag based task aggregator \- Look what I built \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/tag-based-task-aggregator/21378](https://discuss.logseq.com/t/tag-based-task-aggregator/21378)  
-26. Using 'contains?' on bracketed vs non-bracketed property values \- Queries \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/using-contains-on-bracketed-vs-non-bracketed-property-values/27221](https://discuss.logseq.com/t/using-contains-on-bracketed-vs-non-bracketed-property-values/27221)  
-27. Lesson 5: How to Power Your Workflows Using Properties and Dynamic Variables \- Queries, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/lesson-5-how-to-power-your-workflows-using-properties-and-dynamic-variables/10173](https://discuss.logseq.com/t/lesson-5-how-to-power-your-workflows-using-properties-and-dynamic-variables/10173)  
-28. Logseq makes \#tags and \[\[pages\]\] the same construct. How has that worked for you? \- Reddit, accesso eseguito il giorno aprile 25, 2026, [https://www.reddit.com/r/logseq/comments/1mkhxqz/logseq\_makes\_tags\_and\_pages\_the\_same\_construct/](https://www.reddit.com/r/logseq/comments/1mkhxqz/logseq_makes_tags_and_pages_the_same_construct/)  
-29. Difference between \[\[\]\] and \# : r/logseq \- Reddit, accesso eseguito il giorno aprile 25, 2026, [https://www.reddit.com/r/logseq/comments/t41f6b/difference\_between\_and/](https://www.reddit.com/r/logseq/comments/t41f6b/difference_between_and/)  
-30. Introducing NewTags (with examples) \- Look what I built \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/introducing-newtags-with-examples/32310](https://discuss.logseq.com/t/introducing-newtags-with-examples/32310)  
-31. Tags vs Pages in the New Logseq DB: A Missed Chance for Unification?, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/tags-vs-pages-in-the-new-logseq-db-a-missed-chance-for-unification/33684](https://discuss.logseq.com/t/tags-vs-pages-in-the-new-logseq-db-a-missed-chance-for-unification/33684)  
-32. Help Navigating & Converting Extensive Block References, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/help-navigating-converting-extensive-block-references/32051](https://discuss.logseq.com/t/help-navigating-converting-extensive-block-references/32051)  
-33. Logseq query to find all references to a block \- Hugo Ideler, accesso eseguito il giorno aprile 25, 2026, [https://hugoideler.com/2024/01/logseq-query-to-find-all-references-to-a-block/](https://hugoideler.com/2024/01/logseq-query-to-find-all-references-to-a-block/)
+1. How advanced queries work \- step-by-step explainer \- Queries \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/how-advanced-queries-work-step-by-step-explainer/30544](https://discuss.logseq.com/t/how-advanced-queries-work-step-by-step-explainer/30544)
+2. LogSeq: Personal Knowledge Graphs with DB power | by Volodymyr Pavlyshyn \- Medium, accessed on April 25, 2026, [https://volodymyrpavlyshyn.medium.com/logseq-personal-knowledge-graphs-with-db-power-85687d17cc4a](https://volodymyrpavlyshyn.medium.com/logseq-personal-knowledge-graphs-with-db-power-85687d17cc4a)
+3. How to create page with properties? Page templates? \- Questions & Help \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/how-to-create-page-with-properties-page-templates/26029](https://discuss.logseq.com/t/how-to-create-page-with-properties-page-templates/26029)
+4. nbb with features enabled for logseq \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/nbb-logseq](https://github.com/logseq/nbb-logseq)
+5. nbb-logseq/examples/from-js/README.md at main \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/nbb-logseq/blob/main/examples/from-js/README.md](https://github.com/logseq/nbb-logseq/blob/main/examples/from-js/README.md)
+6. General question about data structures to maximize benefits of ..., accessed on April 25, 2026, [https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063](https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063)
+7. Data structure in logseq \- Questions & Help, accessed on April 25, 2026, [https://discuss.logseq.com/t/data-structure-in-logseq/21179](https://discuss.logseq.com/t/data-structure-in-logseq/21179)
+8. Where I can know the detail schema of logseq db \- Questions & Help, accessed on April 25, 2026, [https://discuss.logseq.com/t/where-i-can-know-the-detail-schema-of-logseq-db/6053](https://discuss.logseq.com/t/where-i-can-know-the-detail-schema-of-logseq-db/6053)
+9. Option to treat specific blocks as pages \- Feature Requests \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/option-to-treat-specific-blocks-as-pages/13203](https://discuss.logseq.com/t/option-to-treat-specific-blocks-as-pages/13203)
+10. Logseq datascript schema · GitHub, accessed on April 25, 2026, [https://gist.github.com/tiensonqin/9a40575827f8f63eec54432443ecb929](https://gist.github.com/tiensonqin/9a40575827f8f63eec54432443ecb929)
+11. A Little Guy and His Blog \- Investing and Technical ExcellenceA ..., accessed on April 25, 2026, [https://www.eriksuniverse.com/](https://www.eriksuniverse.com/)
+12. Advanced query for sorted tasks with custom table view \- Look what I built \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/advanced-query-for-sorted-tasks-with-custom-table-view/29101](https://discuss.logseq.com/t/advanced-query-for-sorted-tasks-with-custom-table-view/29101)
+13. Official, comprehensive list of \`config.edn\` options \- Archive \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/official-comprehensive-list-of-config-edn-options/4935](https://discuss.logseq.com/t/official-comprehensive-list-of-config-edn-options/4935)
+14. Different ways to structure data \- Page 4 \- Queries \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/different-ways-to-structure-data/8819?page=4](https://discuss.logseq.com/t/different-ways-to-structure-data/8819?page=4)
+15. The difference between \[\[page links\]\], \#tags, and properties:: \- Documentation \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/the-difference-between-page-links-tags-and-properties/8393](https://discuss.logseq.com/t/the-difference-between-page-links-tags-and-properties/8393)
+16. Queries for task management \- Look what I built \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/queries-for-task-management/14937](https://discuss.logseq.com/t/queries-for-task-management/14937)
+17. Different ways to structure data \- Queries \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/different-ways-to-structure-data/8819](https://discuss.logseq.com/t/different-ways-to-structure-data/8819)
+18. Pages vs Blocks \- General \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/pages-vs-blocks/205](https://discuss.logseq.com/t/pages-vs-blocks/205)
+19. Custom workflows/TODO markers via plugins? \- Questions & Help \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/custom-workflows-todo-markers-via-plugins/18630](https://discuss.logseq.com/t/custom-workflows-todo-markers-via-plugins/18630)
+20. Queries for task management \- Page 6 \- Look what I built \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/queries-for-task-management/14937?page=6](https://discuss.logseq.com/t/queries-for-task-management/14937?page=6)
+21. Pinning active projects to journal page \- Questions & Help \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/pinning-active-projects-to-journal-page/25374](https://discuss.logseq.com/t/pinning-active-projects-to-journal-page/25374)
+22. Just realized the difference between page properties and block properties \- please double check, accessed on April 25, 2026, [https://discuss.logseq.com/t/just-realized-the-difference-between-page-properties-and-block-properties-please-double-check/30433](https://discuss.logseq.com/t/just-realized-the-difference-between-page-properties-and-block-properties-please-double-check/30433)
+23. Automatic Query based on the parent block reference, accessed on April 25, 2026, [https://discuss.logseq.com/t/automatic-query-based-on-the-parent-block-reference/16023](https://discuss.logseq.com/t/automatic-query-based-on-the-parent-block-reference/16023)
+24. Advanced Query that pulls all reference AND recursive name spaces \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/advanced-query-that-pulls-all-reference-and-recursive-name-spaces/21275](https://discuss.logseq.com/t/advanced-query-that-pulls-all-reference-and-recursive-name-spaces/21275)
+25. Tag based task aggregator \- Look what I built \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/tag-based-task-aggregator/21378](https://discuss.logseq.com/t/tag-based-task-aggregator/21378)
+26. Using 'contains?' on bracketed vs non-bracketed property values \- Queries \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/using-contains-on-bracketed-vs-non-bracketed-property-values/27221](https://discuss.logseq.com/t/using-contains-on-bracketed-vs-non-bracketed-property-values/27221)
+27. Lesson 5: How to Power Your Workflows Using Properties and Dynamic Variables \- Queries, accessed on April 25, 2026, [https://discuss.logseq.com/t/lesson-5-how-to-power-your-workflows-using-properties-and-dynamic-variables/10173](https://discuss.logseq.com/t/lesson-5-how-to-power-your-workflows-using-properties-and-dynamic-variables/10173)
+28. Logseq makes \#tags and \[\[pages\]\] the same construct. How has that worked for you? \- Reddit, accessed on April 25, 2026, [https://www.reddit.com/r/logseq/comments/1mkhxqz/logseq\_makes\_tags\_and\_pages\_the\_same\_construct/](https://www.reddit.com/r/logseq/comments/1mkhxqz/logseq_makes_tags_and_pages_the_same_construct/)
+29. Difference between \[\[\]\] and \# : r/logseq \- Reddit, accessed on April 25, 2026, [https://www.reddit.com/r/logseq/comments/t41f6b/difference\_between\_and/](https://www.reddit.com/r/logseq/comments/t41f6b/difference_between_and/)
+30. Introducing NewTags (with examples) \- Look what I built \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/introducing-newtags-with-examples/32310](https://discuss.logseq.com/t/introducing-newtags-with-examples/32310)
+31. Tags vs Pages in the New Logseq DB: A Missed Chance for Unification?, accessed on April 25, 2026, [https://discuss.logseq.com/t/tags-vs-pages-in-the-new-logseq-db-a-missed-chance-for-unification/33684](https://discuss.logseq.com/t/tags-vs-pages-in-the-new-logseq-db-a-missed-chance-for-unification/33684)
+32. Help Navigating & Converting Extensive Block References, accessed on April 25, 2026, [https://discuss.logseq.com/t/help-navigating-converting-extensive-block-references/32051](https://discuss.logseq.com/t/help-navigating-converting-extensive-block-references/32051)
+33. Logseq query to find all references to a block \- Hugo Ideler, accessed on April 25, 2026, [https://hugoideler.com/2024/01/logseq-query-to-find-all-references-to-a-block/](https://hugoideler.com/2024/01/logseq-query-to-find-all-references-to-a-block/)
 
 [image1]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAE0AAAAXCAYAAABOHMIhAAADKklEQVR4Xu2XS8hNURTHlzcDCX0og6skBkoMPAp9UwYirygTUoYkAykyIV8xMjE1IUUmkpQBKYVEKY9EnqG85RnW/+y1fOv8v73v1R3q/Orf3eu/19lnn3323mdfkYaGhob/l0GqZfbbjlmqJWwSo1XLVaO4okBLdZFNY6qktgZzhTGbDWUCG4b3qxOLVXPYZF6pHqvOqH6rvtSrKyZLqjuoWmTlXMPwL6luWBnqROmex1SnVHNVt1Vv6tUVfo+ot7UMkXHmx35dr2Uktkqq26hao/ophUmEpHkZLz7sJIvjG8Sbh9cbvHeS3mbkh7QfOL8XDxoeiq87kvEQ42VflvSwDB4aObFf08yLbR2iGKzLeBV+cRzRr+bttviaxQy8BxRz3i7zhpMPsCRnSqrnQYP3lDzMbG6fY8YfnPPc837lcgC8DWxiaX4k75mk5H0Wt2sw+idVV0IMNkvK4f0NexVeBkB9HLQh5mH2RMabH+E4B3K4X9537xc/iwPvJZs5vIEWxUzJj9yUfE70UI6D1msell1kqPkRxFh63pct9eoi3HeUP4fY4bws8yUlvQ5e6cKSH0H9AfKwFeAr7CAnDtpq804Hz+H7Ib4X4l+qJyHOcVYG9gsx9mTmX56xSvie8XIXlnznvuTrP1DMg7bKvNKgjQjxjlAG6yXlrCQ/gnp8SdnratCwlGawKeULSz6A73tiBMeBYeTxoE0071zwwEjz2+FLuJQHP3eMgP+NTWnflhyX+gFzrGqblUsXlvxPqrUh3q4aY2W/piQH5VshBlPMdy5Y3Aqef0S67RcD7w6bYKekg2QE036plfdLuUGeDQ9VC8nj5cigndyRA4fLyArzHexfiOPqQBne3eCBTv3yY1YEEwfeAvKrgcHN8fnHZxmHSmysSI5/XRDHfWK6eT3Bw5nnheqqpLbwi5M8d4ZBPS+N3EGW98g90n+WdM5Lyon7HmZk7Bf+FTySelt+nsNMdY6aNwCYJUX2mueDhPKJ/uq/Xkk5/Dzoel6vrmaf/1XbJCkHbz/yXtUn6bx1WFJOXIL+JS4pgr+ScfahHqeJhoaGhoaGhq75A2ztO31XlLFcAAAAAElFTkSuQmCC>
 

--- a/docs/design-docs/LOGSEQ_TEMPORAL_ONTOLOGY.md
+++ b/docs/design-docs/LOGSEQ_TEMPORAL_ONTOLOGY.md
@@ -59,52 +59,52 @@ The following pseudocode represents the logic required for a Journal Name Resolv
 
 Python
 
-def resolve\_journal\_page(input\_string, config\_formats, graph\_database):  
-    """  
-    Resolves a string reference to a Journal Page ID and its ISO-8601 representation.  
-    """  
-    \# Step 1: Normalize input by removing brackets if present  
-    clean\_string \= input\_string.strip("")  
-      
-    \# Step 2: Attempt to parse using the user's preferred formats from config.edn  
-    for fmt in config\_formats:  
-        try:  
-            date\_obj \= parse\_date(clean\_string, fmt)  
-            return map\_to\_entity(date\_obj, graph\_database)  
-        except ParsingError:  
-            continue  
-              
-    \# Step 3: Attempt parsing with common Logseq defaults  
-    defaults \= \["yyyy-MM-dd", "MMM do, yyyy", "yyyy\_MM\_dd", "E, dd-MM-yyyy"\]  
-    for fmt in defaults:  
-        try:  
-            date\_obj \= parse\_date(clean\_string, fmt)  
-            return map\_to\_entity(date\_obj, graph\_database)  
-        except ParsingError:  
-            continue  
-              
-    \# Step 4: If parsing fails, treat as a standard page link (non-journal)  
+def resolve\_journal\_page(input\_string, config\_formats, graph\_database):
+    """
+    Resolves a string reference to a Journal Page ID and its ISO-8601 representation.
+    """
+    \# Step 1: Normalize input by removing brackets if present
+    clean\_string \= input\_string.strip("")
+
+    \# Step 2: Attempt to parse using the user's preferred formats from config.edn
+    for fmt in config\_formats:
+        try:
+            date\_obj \= parse\_date(clean\_string, fmt)
+            return map\_to\_entity(date\_obj, graph\_database)
+        except ParsingError:
+            continue
+
+    \# Step 3: Attempt parsing with common Logseq defaults
+    defaults \= \["yyyy-MM-dd", "MMM do, yyyy", "yyyy\_MM\_dd", "E, dd-MM-yyyy"\]
+    for fmt in defaults:
+        try:
+            date\_obj \= parse\_date(clean\_string, fmt)
+            return map\_to\_entity(date\_obj, graph\_database)
+        except ParsingError:
+            continue
+
+    \# Step 4: If parsing fails, treat as a standard page link (non-journal)
     return resolve\_standard\_page(clean\_string, graph\_database)
 
-def map\_to\_entity(date\_obj, db):  
-    \# Convert date to the YYYYMMDD integer used for indexing  
-    journal\_day \= int(date\_obj.strftime("%Y%m%d"))  
-      
-    \# Query the database for a page with this journal-day  
-    entity \= db.query(f"\[:find?p :where \[?p :block/journal-day {journal\_day}\]\]")  
-      
-    if entity:  
-        return {  
-            "entity\_id": entity,  
-            "iso\_8601": date\_obj.isoformat(),  
-            "journal\_day": journal\_day  
-        }  
-    else:  
-        \# If no entity exists, return the temporal metadata for potential page creation  
-        return {  
-            "entity\_id": None,  
-            "iso\_8601": date\_obj.isoformat(),  
-            "journal\_day": journal\_day  
+def map\_to\_entity(date\_obj, db):
+    \# Convert date to the YYYYMMDD integer used for indexing
+    journal\_day \= int(date\_obj.strftime("%Y%m%d"))
+
+    \# Query the database for a page with this journal-day
+    entity \= db.query(f"\[:find?p :where \[?p :block/journal-day {journal\_day}\]\]")
+
+    if entity:
+        return {
+            "entity\_id": entity,
+            "iso\_8601": date\_obj.isoformat(),
+            "journal\_day": journal\_day
+        }
+    else:
+        \# If no entity exists, return the temporal metadata for potential page creation
+        return {
+            "entity\_id": None,
+            "iso\_8601": date\_obj.isoformat(),
+            "journal\_day": journal\_day
         }
 
 This resolver highlights a key architectural necessity: the parser must maintain a "temporal context" that includes not only the current system time but also the user's specific config.edn environment. Without this context, a string like "01-02-2024" is ambiguous, as it could represent January 2nd or February 1st depending on the user's locale.13
@@ -159,19 +159,19 @@ The following logic illustrates how the parser should calculate the next date fo
 
 Python
 
-def calculate\_next\_repeat(last\_scheduled, completion\_date, interval\_str):  
-    \# interval\_str example: "+1d", "++1w", ".+1m"  
-    kind \= identify\_kind(interval\_str) \# Simple, Double, Dotted  
-    delta \= parse\_interval(interval\_str) \# e.g., Timedelta(days=1)  
-      
-    if kind \== "SimplePlus":  
-        return last\_scheduled \+ delta  
-    elif kind \== "DoublePlus":  
-        next\_date \= last\_scheduled \+ delta  
-        while next\_date \<= completion\_date:  
-            next\_date \+= delta  
-        return next\_date  
-    elif kind \== "DottedPlus":  
+def calculate\_next\_repeat(last\_scheduled, completion\_date, interval\_str):
+    \# interval\_str example: "+1d", "++1w", ".+1m"
+    kind \= identify\_kind(interval\_str) \# Simple, Double, Dotted
+    delta \= parse\_interval(interval\_str) \# e.g., Timedelta(days=1)
+
+    if kind \== "SimplePlus":
+        return last\_scheduled \+ delta
+    elif kind \== "DoublePlus":
+        next\_date \= last\_scheduled \+ delta
+        while next\_date \<= completion\_date:
+            next\_date \+= delta
+        return next\_date
+    elif kind \== "DottedPlus":
         return completion\_date \+ delta
 
 The Sovereign AI must look at the :logbook history to see if the user consistently completes tasks late, which might suggest a need to adjust the interval or identify patterns of procrastination.27
@@ -184,11 +184,11 @@ The ultimate utility of the temporal ontology is realized through Datalog querie
 
 The DataScript schema contains several attributes that are essential for chronological reconstruction 1:
 
-* :block/journal-day: The date of the journal page the block resides on (Integer: YYYYMMDD).5  
-* :block/journal?: A boolean flag indicating if the page is a journal.6  
-* :block/scheduled: The scheduled date of a task (Integer: YYYYMMDD).21  
-* :block/deadline: The deadline of a task (Integer: YYYYMMDD).21  
-* :block/created-at: System timestamp of block creation (Epoch ms).1  
+* :block/journal-day: The date of the journal page the block resides on (Integer: YYYYMMDD).5
+* :block/journal?: A boolean flag indicating if the page is a journal.6
+* :block/scheduled: The scheduled date of a task (Integer: YYYYMMDD).21
+* :block/deadline: The deadline of a task (Integer: YYYYMMDD).21
+* :block/created-at: System timestamp of block creation (Epoch ms).1
 * :block/updated-at: System timestamp of the last modification (Epoch ms).33
 
 ### **Executing Range Queries**
@@ -197,12 +197,12 @@ Range queries are the most frequent temporal operations. A query to find all blo
 
 Clojure
 
-\[:find (pull?b \[\*\])  
- :in $?start?today  
- :where  
- \[?b :block/page?p\]  
- \[?p :block/journal-day?d\]  
- \[(\>=?d?start)\]  
+\[:find (pull?b \[\*\])
+ :in $?start?today
+ :where
+ \[?b :block/page?p\]
+ \[?p :block/journal-day?d\]
+ \[(\>=?d?start)\]
  \[(\<=?d?today)\]\]
 
 In this context, :inputs like :-7d and :today are provided to the query engine.7 The engine resolves :-7d by taking the current system date and subtracting 7 days, then formatting the result as a YYYYMMDD integer.8 This demonstrates why the parser must maintain a real-time clock to resolve relative references during the AI Inference phase.
@@ -217,19 +217,19 @@ The primary objective of the LOGOS parser is to create a "Sovereign AI" capable 
 
 The parser should implement a multi-stage normalization pipeline:
 
-1. **Extraction**: Use the regex patterns identified for links, markers, and clock entries to pull raw strings from the Markdown content.16  
-2. **Contextualization**: Identify the parent page’s date. If the block is on a journal page, its base date is the :block/journal-day of that page.1  
-3. **Resolution**: Apply the Resolver Algorithm using the user's config.edn to turn localized strings into YYYYMMDD integers.10  
-4. **Enrichment**: For tasks with times (e.g., 17:00), combine the date from the marker with the time to create a full ISO-8601 timestamp (e.g., 2024-04-25T17:00:00).23  
+1. **Extraction**: Use the regex patterns identified for links, markers, and clock entries to pull raw strings from the Markdown content.16
+2. **Contextualization**: Identify the parent page’s date. If the block is on a journal page, its base date is the :block/journal-day of that page.1
+3. **Resolution**: Apply the Resolver Algorithm using the user's config.edn to turn localized strings into YYYYMMDD integers.10
+4. **Enrichment**: For tasks with times (e.g., 17:00), combine the date from the marker with the time to create a full ISO-8601 timestamp (e.g., 2024-04-25T17:00:00).23
 5. **Reconstruction**: Use the :logbook data to track the actual completion times, providing a ground-truth timeline of when actions were performed versus when they were scheduled.22
 
 ### **Chronicling Personal Focus Areas**
 
 By normalizing all references to ISO-8601, the AI can perform longitudinal analysis. For example, to answer "What were my focus areas last October?", the AI does not just search for the word "October." Instead, it:
 
-* Identifies the date range for October of the target year.  
-* Converts this range to YYYYMMDD integers (e.g., 20231001 to 20231031).  
-* Queries the graph for all blocks where :block/journal-day falls within this range.  
+* Identifies the date range for October of the target year.
+* Converts this range to YYYYMMDD integers (e.g., 20231001 to 20231031).
+* Queries the graph for all blocks where :block/journal-day falls within this range.
 * Analyzes the content of those blocks and their linked pages (tags) to identify themes.
 
 This approach transforms Logseq from a collection of text files into a structured database of human experience. The Sovereign AI thus gains the ability to "remember" with chronological precision, providing the user with an ordered, searchable, and insightful history of their digital life. The rigor of the temporal ontology is what enables this transition from a mere note-taking application to a true personal knowledge graph.
@@ -322,42 +322,42 @@ The technical investigation into Logseq's temporal ontology reveals a system tha
 
 The LOGOS parser must address these challenges by mastering the mldoc parser's date detection logic, the sophisticated Journal Name Resolver algorithm, and the complex rules governing task repeaters and metadata markers. By normalizing every temporal reference into a standard ISO-8601 string or Unix Epoch timestamp, LOGOS provides the essential foundation for a Sovereign AI. This AI can then move beyond mere text searching to achieve a true "World Model" of the user's data, answering chronological questions with precision and reconstructing a perfectly ordered timeline of the user's life. The mastery of this temporal ontology is not just a technical requirement; it is the key to unlocking the full potential of personal knowledge graphs for human-AI collaboration.
 
-#### **Bibliografia**
+#### **Bibliography**
 
-1. General question about data structures to maximize benefits of datalog db and queries, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063](https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063)  
-2. How advanced queries work \- step-by-step explainer \- Queries \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/how-advanced-queries-work-step-by-step-explainer/30544](https://discuss.logseq.com/t/how-advanced-queries-work-step-by-step-explainer/30544)  
-3. logseq/CODEBASE\_OVERVIEW.md at master \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/blob/master/CODEBASE\_OVERVIEW.md](https://github.com/logseq/logseq/blob/master/CODEBASE_OVERVIEW.md)  
-4. Logseq from an Org-mode Point of View \- of Karl Voit, accesso eseguito il giorno aprile 25, 2026, [https://karl-voit.at/2024/01/28/logseq-from-org-pov/](https://karl-voit.at/2024/01/28/logseq-from-org-pov/)  
-5. Logseq journal: On this day, accesso eseguito il giorno aprile 25, 2026, [https://manhtai.github.io/posts/logseq-journal-on-this-day/](https://manhtai.github.io/posts/logseq-journal-on-this-day/)  
-6. Query to find blocks created today \- Questions & Help \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/query-to-find-blocks-created-today/15812](https://discuss.logseq.com/t/query-to-find-blocks-created-today/15812)  
-7. How to query block property with a date? \- Questions & Help \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/how-to-query-block-property-with-a-date/11825](https://discuss.logseq.com/t/how-to-query-block-property-with-a-date/11825)  
-8. How to show task's status, priority & deadlines in Table view mode \- Look what I built, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/how-to-show-tasks-status-priority-deadlines-in-table-view-mode/26924](https://discuss.logseq.com/t/how-to-show-tasks-status-priority-deadlines-in-table-view-mode/26924)  
-9. A logseq plugin which counts how many days left until the deadline. \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/xxchan/logseq-deadline-countdown](https://github.com/xxchan/logseq-deadline-countdown)  
-10. How to Change Logseq Journal File Name to YYYY-DD-MM Format \- Nesin.io, accesso eseguito il giorno aprile 25, 2026, [https://nesin.io/blog/change-logseq-journal-file-name-format](https://nesin.io/blog/change-logseq-journal-file-name-format)  
-11. Journal file name format \- Questions & Help \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/journal-file-name-format/1590](https://discuss.logseq.com/t/journal-file-name-format/1590)  
-12. Going back in time through Calendar creates and opens a page called Journal instead \#9923 \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/issues/9923](https://github.com/logseq/logseq/issues/9923)  
-13. Looking for Customizing Date Formats in Logseq\! \- Customization ..., accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/looking-for-customizing-date-formats-in-logseq/28352](https://discuss.logseq.com/t/looking-for-customizing-date-formats-in-logseq/28352)  
-14. cljs-time — com.andrewmcveigh/cljs-time 0.5.2 \- cljdoc, accesso eseguito il giorno aprile 25, 2026, [https://cljdoc.org/d/com.andrewmcveigh/cljs-time/0.5.2/api/cljs-time](https://cljdoc.org/d/com.andrewmcveigh/cljs-time/0.5.2/api/cljs-time)  
-15. clj-time.format documentation, accesso eseguito il giorno aprile 25, 2026, [https://clj-time.github.io/clj-time/doc/clj-time.format.html](https://clj-time.github.io/clj-time/doc/clj-time.format.html)  
-16. Modify date format in all existing docs \- Questions & Help \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/modify-date-format-in-all-existing-docs/30686](https://discuss.logseq.com/t/modify-date-format-in-all-existing-docs/30686)  
-17. Proper way to specify block creation date? : r/logseq \- Reddit, accesso eseguito il giorno aprile 25, 2026, [https://www.reddit.com/r/logseq/comments/1k4suhe/proper\_way\_to\_specify\_block\_creation\_date/](https://www.reddit.com/r/logseq/comments/1k4suhe/proper_way_to_specify_block_creation_date/)  
-18. Can I use a custom "date"/title format for journals and their titles? \- Questions & Help, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/can-i-use-a-custom-date-title-format-for-journals-and-their-titles/25983](https://discuss.logseq.com/t/can-i-use-a-custom-date-title-format-for-journals-and-their-titles/25983)  
-19. Formatting date formats : r/logseq \- Reddit, accesso eseguito il giorno aprile 25, 2026, [https://www.reddit.com/r/logseq/comments/19cle0c/formatting\_date\_formats/](https://www.reddit.com/r/logseq/comments/19cle0c/formatting_date_formats/)  
-20. What's the best practice for markers on recurring tasks? \- Questions & Help \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/whats-the-best-practice-for-markers-on-recurring-tasks/27455](https://discuss.logseq.com/t/whats-the-best-practice-for-markers-on-recurring-tasks/27455)  
-21. Sorting by minimum of scheduled and deadline? \- Queries \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/sorting-by-minimum-of-scheduled-and-deadline/23613](https://discuss.logseq.com/t/sorting-by-minimum-of-scheduled-and-deadline/23613)  
-22. How can I create a time-spent-on-tasks report for a tree of tasks or single page of tasks?, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/how-can-i-create-a-time-spent-on-tasks-report-for-a-tree-of-tasks-or-single-page-of-tasks/29541](https://discuss.logseq.com/t/how-can-i-create-a-time-spent-on-tasks-report-for-a-tree-of-tasks-or-single-page-of-tasks/29541)  
-23. benjypng/logseq-dateutils \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/benjypng/logseq-dateutils](https://github.com/benjypng/logseq-dateutils)  
-24. How do I get LogSeq page creation date to equal creation date of actual .md file?, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/how-do-i-get-logseq-page-creation-date-to-equal-creation-date-of-actual-md-file/13939](https://discuss.logseq.com/t/how-do-i-get-logseq-page-creation-date-to-equal-creation-date-of-actual-md-file/13939)  
-25. How do I get the simplified block content as in regular logseq.table.version 1 of Advanced Queries in custom :view, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/how-do-i-get-the-simplified-block-content-as-in-regular-logseq-table-version-1-of-advanced-queries-in-custom-view/25192](https://discuss.logseq.com/t/how-do-i-get-the-simplified-block-content-as-in-regular-logseq-table-version-1-of-advanced-queries-in-custom-view/25192)  
-26. Scheduled tasks on day of journal \- Queries \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/scheduled-tasks-on-day-of-journal/22441](https://discuss.logseq.com/t/scheduled-tasks-on-day-of-journal/22441)  
-27. r/logseq \- Reddit, accesso eseguito il giorno aprile 25, 2026, [https://www.reddit.com/r/logseq/](https://www.reddit.com/r/logseq/)  
-28. Home Report home for your next assignment Training Practice Complete challenging Kata to earn honor and ranks. Re-train to hone, accesso eseguito il giorno aprile 25, 2026, [https://www.terceiro.com.br/resolucoes-exercicios-codewars.pdf](https://www.terceiro.com.br/resolucoes-exercicios-codewars.pdf)  
-29. Repeat tasks don't repeat as documented · Issue \#11260 \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/issues/11260](https://github.com/logseq/logseq/issues/11260)  
-30. habits/repeating tasks scheduling reference date · Issue \#5645 ..., accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/issues/5645](https://github.com/logseq/logseq/issues/5645)  
-31. Repeating tasks don't behave as documented \- Bug Reports \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/repeating-tasks-dont-behave-as-documented/26631](https://discuss.logseq.com/t/repeating-tasks-dont-behave-as-documented/26631)  
-32. Official, comprehensive list of \`config.edn\` options \- Archive \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/official-comprehensive-list-of-config-edn-options/4935](https://discuss.logseq.com/t/official-comprehensive-list-of-config-edn-options/4935)  
-33. My GTD and slip box-ish workflow within logseq \- Look what I built, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/my-gtd-and-slip-box-ish-workflow-within-logseq/4626](https://discuss.logseq.com/t/my-gtd-and-slip-box-ish-workflow-within-logseq/4626)  
-34. Use journal day instead of :today in advanced queries \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/use-journal-day-instead-of-today-in-advanced-queries/28121](https://discuss.logseq.com/t/use-journal-day-instead-of-today-in-advanced-queries/28121)  
-35. Advanced queries for Logseq.md \- GitHub Gist, accesso eseguito il giorno aprile 25, 2026, [https://gist.github.com/jumski/ad9d9f952a263af35a06a7c6cfff0d04](https://gist.github.com/jumski/ad9d9f952a263af35a06a7c6cfff0d04)  
-36. Sorting by journal-day and hiding the page name in advanced queries, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/sorting-by-journal-day-and-hiding-the-page-name-in-advanced-queries/24543](https://discuss.logseq.com/t/sorting-by-journal-day-and-hiding-the-page-name-in-advanced-queries/24543)  
-37. Advanced Query that pulls all reference AND recursive name spaces \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/advanced-query-that-pulls-all-reference-and-recursive-name-spaces/21275](https://discuss.logseq.com/t/advanced-query-that-pulls-all-reference-and-recursive-name-spaces/21275)
+1. General question about data structures to maximize benefits of datalog db and queries, accessed on April 25, 2026, [https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063](https://discuss.logseq.com/t/general-question-about-data-structures-to-maximize-benefits-of-datalog-db-and-queries/20063)
+2. How advanced queries work \- step-by-step explainer \- Queries \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/how-advanced-queries-work-step-by-step-explainer/30544](https://discuss.logseq.com/t/how-advanced-queries-work-step-by-step-explainer/30544)
+3. logseq/CODEBASE\_OVERVIEW.md at master \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/blob/master/CODEBASE\_OVERVIEW.md](https://github.com/logseq/logseq/blob/master/CODEBASE_OVERVIEW.md)
+4. Logseq from an Org-mode Point of View \- of Karl Voit, accessed on April 25, 2026, [https://karl-voit.at/2024/01/28/logseq-from-org-pov/](https://karl-voit.at/2024/01/28/logseq-from-org-pov/)
+5. Logseq journal: On this day, accessed on April 25, 2026, [https://manhtai.github.io/posts/logseq-journal-on-this-day/](https://manhtai.github.io/posts/logseq-journal-on-this-day/)
+6. Query to find blocks created today \- Questions & Help \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/query-to-find-blocks-created-today/15812](https://discuss.logseq.com/t/query-to-find-blocks-created-today/15812)
+7. How to query block property with a date? \- Questions & Help \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/how-to-query-block-property-with-a-date/11825](https://discuss.logseq.com/t/how-to-query-block-property-with-a-date/11825)
+8. How to show task's status, priority & deadlines in Table view mode \- Look what I built, accessed on April 25, 2026, [https://discuss.logseq.com/t/how-to-show-tasks-status-priority-deadlines-in-table-view-mode/26924](https://discuss.logseq.com/t/how-to-show-tasks-status-priority-deadlines-in-table-view-mode/26924)
+9. A logseq plugin which counts how many days left until the deadline. \- GitHub, accessed on April 25, 2026, [https://github.com/xxchan/logseq-deadline-countdown](https://github.com/xxchan/logseq-deadline-countdown)
+10. How to Change Logseq Journal File Name to YYYY-DD-MM Format \- Nesin.io, accessed on April 25, 2026, [https://nesin.io/blog/change-logseq-journal-file-name-format](https://nesin.io/blog/change-logseq-journal-file-name-format)
+11. Journal file name format \- Questions & Help \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/journal-file-name-format/1590](https://discuss.logseq.com/t/journal-file-name-format/1590)
+12. Going back in time through Calendar creates and opens a page called Journal instead \#9923 \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/issues/9923](https://github.com/logseq/logseq/issues/9923)
+13. Looking for Customizing Date Formats in Logseq\! \- Customization ..., accessed on April 25, 2026, [https://discuss.logseq.com/t/looking-for-customizing-date-formats-in-logseq/28352](https://discuss.logseq.com/t/looking-for-customizing-date-formats-in-logseq/28352)
+14. cljs-time — com.andrewmcveigh/cljs-time 0.5.2 \- cljdoc, accessed on April 25, 2026, [https://cljdoc.org/d/com.andrewmcveigh/cljs-time/0.5.2/api/cljs-time](https://cljdoc.org/d/com.andrewmcveigh/cljs-time/0.5.2/api/cljs-time)
+15. clj-time.format documentation, accessed on April 25, 2026, [https://clj-time.github.io/clj-time/doc/clj-time.format.html](https://clj-time.github.io/clj-time/doc/clj-time.format.html)
+16. Modify date format in all existing docs \- Questions & Help \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/modify-date-format-in-all-existing-docs/30686](https://discuss.logseq.com/t/modify-date-format-in-all-existing-docs/30686)
+17. Proper way to specify block creation date? : r/logseq \- Reddit, accessed on April 25, 2026, [https://www.reddit.com/r/logseq/comments/1k4suhe/proper\_way\_to\_specify\_block\_creation\_date/](https://www.reddit.com/r/logseq/comments/1k4suhe/proper_way_to_specify_block_creation_date/)
+18. Can I use a custom "date"/title format for journals and their titles? \- Questions & Help, accessed on April 25, 2026, [https://discuss.logseq.com/t/can-i-use-a-custom-date-title-format-for-journals-and-their-titles/25983](https://discuss.logseq.com/t/can-i-use-a-custom-date-title-format-for-journals-and-their-titles/25983)
+19. Formatting date formats : r/logseq \- Reddit, accessed on April 25, 2026, [https://www.reddit.com/r/logseq/comments/19cle0c/formatting\_date\_formats/](https://www.reddit.com/r/logseq/comments/19cle0c/formatting_date_formats/)
+20. What's the best practice for markers on recurring tasks? \- Questions & Help \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/whats-the-best-practice-for-markers-on-recurring-tasks/27455](https://discuss.logseq.com/t/whats-the-best-practice-for-markers-on-recurring-tasks/27455)
+21. Sorting by minimum of scheduled and deadline? \- Queries \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/sorting-by-minimum-of-scheduled-and-deadline/23613](https://discuss.logseq.com/t/sorting-by-minimum-of-scheduled-and-deadline/23613)
+22. How can I create a time-spent-on-tasks report for a tree of tasks or single page of tasks?, accessed on April 25, 2026, [https://discuss.logseq.com/t/how-can-i-create-a-time-spent-on-tasks-report-for-a-tree-of-tasks-or-single-page-of-tasks/29541](https://discuss.logseq.com/t/how-can-i-create-a-time-spent-on-tasks-report-for-a-tree-of-tasks-or-single-page-of-tasks/29541)
+23. benjypng/logseq-dateutils \- GitHub, accessed on April 25, 2026, [https://github.com/benjypng/logseq-dateutils](https://github.com/benjypng/logseq-dateutils)
+24. How do I get LogSeq page creation date to equal creation date of actual .md file?, accessed on April 25, 2026, [https://discuss.logseq.com/t/how-do-i-get-logseq-page-creation-date-to-equal-creation-date-of-actual-md-file/13939](https://discuss.logseq.com/t/how-do-i-get-logseq-page-creation-date-to-equal-creation-date-of-actual-md-file/13939)
+25. How do I get the simplified block content as in regular logseq.table.version 1 of Advanced Queries in custom :view, accessed on April 25, 2026, [https://discuss.logseq.com/t/how-do-i-get-the-simplified-block-content-as-in-regular-logseq-table-version-1-of-advanced-queries-in-custom-view/25192](https://discuss.logseq.com/t/how-do-i-get-the-simplified-block-content-as-in-regular-logseq-table-version-1-of-advanced-queries-in-custom-view/25192)
+26. Scheduled tasks on day of journal \- Queries \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/scheduled-tasks-on-day-of-journal/22441](https://discuss.logseq.com/t/scheduled-tasks-on-day-of-journal/22441)
+27. r/logseq \- Reddit, accessed on April 25, 2026, [https://www.reddit.com/r/logseq/](https://www.reddit.com/r/logseq/)
+28. Home Report home for your next assignment Training Practice Complete challenging Kata to earn honor and ranks. Re-train to hone, accessed on April 25, 2026, [https://www.terceiro.com.br/resolucoes-exercicios-codewars.pdf](https://www.terceiro.com.br/resolucoes-exercicios-codewars.pdf)
+29. Repeat tasks don't repeat as documented · Issue \#11260 \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/issues/11260](https://github.com/logseq/logseq/issues/11260)
+30. habits/repeating tasks scheduling reference date · Issue \#5645 ..., accessed on April 25, 2026, [https://github.com/logseq/logseq/issues/5645](https://github.com/logseq/logseq/issues/5645)
+31. Repeating tasks don't behave as documented \- Bug Reports \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/repeating-tasks-dont-behave-as-documented/26631](https://discuss.logseq.com/t/repeating-tasks-dont-behave-as-documented/26631)
+32. Official, comprehensive list of \`config.edn\` options \- Archive \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/official-comprehensive-list-of-config-edn-options/4935](https://discuss.logseq.com/t/official-comprehensive-list-of-config-edn-options/4935)
+33. My GTD and slip box-ish workflow within logseq \- Look what I built, accessed on April 25, 2026, [https://discuss.logseq.com/t/my-gtd-and-slip-box-ish-workflow-within-logseq/4626](https://discuss.logseq.com/t/my-gtd-and-slip-box-ish-workflow-within-logseq/4626)
+34. Use journal day instead of :today in advanced queries \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/use-journal-day-instead-of-today-in-advanced-queries/28121](https://discuss.logseq.com/t/use-journal-day-instead-of-today-in-advanced-queries/28121)
+35. Advanced queries for Logseq.md \- GitHub Gist, accessed on April 25, 2026, [https://gist.github.com/jumski/ad9d9f952a263af35a06a7c6cfff0d04](https://gist.github.com/jumski/ad9d9f952a263af35a06a7c6cfff0d04)
+36. Sorting by journal-day and hiding the page name in advanced queries, accessed on April 25, 2026, [https://discuss.logseq.com/t/sorting-by-journal-day-and-hiding-the-page-name-in-advanced-queries/24543](https://discuss.logseq.com/t/sorting-by-journal-day-and-hiding-the-page-name-in-advanced-queries/24543)
+37. Advanced Query that pulls all reference AND recursive name spaces \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/advanced-query-that-pulls-all-reference-and-recursive-name-spaces/21275](https://discuss.logseq.com/t/advanced-query-that-pulls-all-reference-and-recursive-name-spaces/21275)

--- a/docs/design-docs/OFFICIAL_MLDOC_SPECS.md
+++ b/docs/design-docs/OFFICIAL_MLDOC_SPECS.md
@@ -32,8 +32,8 @@ This absolute indentation rule introduces profound complexities during the lexin
 
 ### **Root Level H3**
 
-\- Level 1 Bullet  
-	\# Level 2 H1  
+\- Level 1 Bullet
+	\# Level 2 H1
 		\- Level 3 Bullet
 
 **Expected Output / AST Behavior:** The Abstract Syntax Tree deterministically ignores the conventional semantic meaning of the hash markers for hierarchy construction. The Angstrom parser initializes its indentation tracking stack at column zero. The initial string \#\#\# Root Level H3 is parsed with zero indentation, resulting in its assignment as a root node of type Heading with a metadata parameter of :level 3\.6 As the scanner proceeds to the next line, it detects a single tab character, which introduces a positive indentation delta. The parser emits a virtual indentation token, and the text Level 1 Bullet is instantiated as the first child of the root node.
@@ -44,10 +44,10 @@ Subsequently, the parser encounters \\t\\t\# Level 2 H1. This introduces a secon
 
 **Context:** A critical failure point in standard markdown parsers occurs when text contains broken indentation sequences—specifically, a sudden geometric jump from a zero-space prefix directly to a four-space prefix, entirely bypassing an intermediate two-space or single-tab level. The mldoc engine must decide whether to treat the heavily indented text as a grandchild (which would necessitate the creation of a phantom, empty intermediate child node), a direct child with a non-standard spatial baseline, or an indented code block as dictated by standard CommonMark specifications.3 **Input Markdown:**
 
-* Root Node  
-  * Sudden Four Space Node  
-    * Normal Two Space Delta  
-      **Expected Output / AST Behavior:**  
+* Root Node
+  * Sudden Four Space Node
+    * Normal Two Space Delta
+      **Expected Output / AST Behavior:**
       To resolve this anomaly, the mldoc lexer employs a specialized whitespace unification pass designed to preserve user intent within the context of an outliner database. The parser initially reads the Root Node string at column zero. Upon scanning the subsequent line, it detects four consecutive spaces. While a strict standard Markdown parser might interpret four spaces following a list item as either a block continuation or an erroneously formatted string, the Logseq outliner paradigm mandates that this represents a nested level.
 
 Because the intermediate two-space level is entirely missing from the character stream, mldoc does not generate a phantom or empty intermediate node to bridge the gap. Instead, it dynamically binds the Sudden Four Space Node as a direct child of the Root Node, internally recording the new spatial baseline delta for this specific subtree as four spaces. When the parser moves to the third line and encounters six spaces, it calculates a delta of two spaces relative to the parent node. The parser seamlessly accepts this as a valid child of the Sudden Four Space Node. When the AST normalizes these relationships into JSON or EDN formats, the inconsistent visual spacing is entirely stripped. The final hierarchical array transforms the physical character variations into purely logical datalog relationships, linking the blocks cleanly without retaining the spatial anomalies.3
@@ -56,9 +56,9 @@ Because the intermediate two-space level is entirely missing from the character 
 
 **Context:** Within the layout state machine, sibling nodes are structurally mandated to share the exact same indentation prefix string. If siblings present with mismatched white spaces—for instance, one node utilizing a physical tab character while another utilizes four individual space characters—the mldoc parser's scanner must execute character reconciliation heuristics to prevent the layout stack from prematurely issuing a block termination command.3 **Input Markdown:**
 
-* Parent Block  
-  * Sibling One (1 Tab)  
-  * Sibling Two (4 Spaces)  
+* Parent Block
+  * Sibling One (1 Tab)
+  * Sibling Two (4 Spaces)
   * Sibling Three (2 Spaces) **Expected Output / AST Behavior:** The OCaml parsing logic applies an aggressive character-equivalence heuristic during the layout scanning phase. In the Logseq ecosystem, a physical tab is generally mapped to equivalent space geometry depending on the user's overarching graph configuration, though the internal mldoc engine frequently defaults to a rigid two-space parity for Markdown lists.3 The Sibling One string establishes the first child indentation baseline utilizing a \\t character. When the scanner evaluates the subsequent string, Sibling Two, it processes the four space characters.
 
 If the internal parity configuration equates one tab to two spaces, the four-space prefix dictates that Sibling Two is actually a child of Sibling One, pushing it to a grandchild depth. However, if the parity equates a tab to four spaces, the layout state machine recognizes Sibling Two as a direct sibling of Sibling One. The standard fallback behavior isolates the relative delta. Because Sibling Three uses only two spaces, the layout tracker determines that the spatial column is less than the active stack depth for Sibling Two, forcing the emission of a DEDENT token. The AST dynamically flattens these misalignments into the closest logical levels, grouping the siblings beneath the Parent Block if their calculated column depths fall within the bounds of a single logical level. This strict spatial alignment is crucial for preventing graph corruption during real-time collaborative editing sessions, where disparate client environments may inject conflicting whitespace characters into the shared sequence.3
@@ -85,10 +85,10 @@ This sequestration mechanism is absolutely critical for database integrity. The 
 
 **Context:** This scenario strictly evaluates the parser's capacity to enter and exit the Org-mode drawer state without corrupting adjacent block structures. It validates the foundational requirement that the CLOCK: tracking sequence and state change strings nested inside a :LOGBOOK: drawer are mapped directly to metadata AST structures rather than rendered text blocks, ensuring that the parent block's textual output remains pristine.2 **Input Markdown:**
 
-* TODO Implement the new AST parser  
-  :LOGBOOK:  
-  CLOCK:-- \=\> 01:00  
-  :END:  
+* TODO Implement the new AST parser
+  :LOGBOOK:
+  CLOCK:-- \=\> 01:00
+  :END:
   * Sub-task continuing after the drawer **Expected Output / AST Behavior:** The AST generation sequence begins with the parser identifying the TODO keyword at the start of the block, which immediately flags the node for task state formatting. As the scanner transitions to the next line, which is spatially indented to become a child or property of the root TODO block, it encounters the string :LOGBOOK:. The Angstrom combinator consumes this specific token and forces the lexer into drawer mode.14 The subsequent CLOCK: line is read as raw string data by the base parser, knowing that downstream logic (specifically frontend.util.clock) will translate these temporal boundaries into the database.15
 
 The scanner continues until it matches the :END: token, which successfully terminates the drawer mode and releases the lock. In the resulting JSON AST structure, the primary node representing the TODO block contains only the textual string Implement the new AST parser within its title array. All LOGBOOK data is completely sequestered into a non-rendered :meta or :drawer object attached to the block's programmatic definition. Crucially, the string \- Sub-task continuing after the drawer is parsed normally and nested as a standard child block of the TODO block. This structural outcome proves that the drawer parser successfully and cleanly returned control to the main block-level combinator stack without consuming adjacent siblings.6
@@ -97,10 +97,10 @@ The scanner continues until it matches the :END: token, which successfully termi
 
 **Context:** Software regression reports, specifically GitHub Pull Request \#138 and Issue \#3823, explicitly highlight the parser's failure state when encountering an initialized but immediately terminated :LOGBOOK: drawer.14 Historically, if a drawer was completely empty, the lexer failed to recognize the state change, leading to severe synchronization issues where the underlying markdown file updated its state but the user interface did not accurately reflect the database modification.14 **Input Markdown:**
 
-* TODO Clean SCHEDULED: \<2022-01-08 Sat.+2d\>  
-  :LOGBOOK:  
-  :END:  
-  **Expected Output / AST Behavior:**  
+* TODO Clean SCHEDULED: \<2022-01-08 Sat.+2d\>
+  :LOGBOOK:
+  :END:
+  **Expected Output / AST Behavior:**
   The OCaml combinator responsible for executing the take\_until ":END:" directive must exhibit high tolerance for zero-length payloads. The parser matches the opening :LOGBOOK: token and prepares for sequential reading. However, as it peeks at the very next token in the stream, it encounters :END:, resulting in a payload length of absolute zero.
 
 To maintain database integrity, the AST must construct a valid but empty logbook meta-object for the block rather than faulting. The parser strictly forbids throwing a fatal exception or swallowing the subsequent document structure due to the empty array. The expected AST behavior yields an output array containing the block text TODO Clean SCHEDULED... alongside a structural :meta dictionary where the :logbook key maps directly to an empty array \`\` or nil.6 This deliberate handling ensures that the application frontend can safely clear task timers and reconcile the graph database without experiencing a desynchronization event.
@@ -109,9 +109,9 @@ To maintain database integrity, the AST must construct a valid but empty logbook
 
 **Context:** Logseq heavily leverages a double-colon syntax (e.g., collapsed:: true) inline within the Markdown stream to persist user interface state variables or block behavior toggles across distinct sessions. Because these variables do not utilize standard property blocks or drawer encapsulation, the parser must rely on localized geometric scanning to recognize these specifically defined reserved keys and dynamically strip them from the visible paragraph text.13 **Input Markdown:**
 
-* A massive block of text that the user wants to hide.  
-  collapsed:: true  
-  **Expected Output / AST Behavior:**  
+* A massive block of text that the user wants to hide.
+  collapsed:: true
+  **Expected Output / AST Behavior:**
   As the lexer evaluates the block lines, it scans for trailing directive strings appended to the paragraph nodes. The string collapsed:: true is identified against an internal dictionary of reserved noise directives. When the AST object is constructed for the string A massive block of text..., the parsing logic actively mutates the textual payload by stripping the collapsed:: true line entirely from the visible inline text tuple.
 
 In its place, the AST generation sequence injects a boolean flag directly into the block's root property definition or metadata dictionary, establishing the key-value pair :collapsed true. This guarantees that the front-end rendering engine automatically folds the block upon initialization. Conversely, if a non-reserved or user-defined keyword is utilized with the double-colon syntax in this exact same geometric position, the parser automatically routes the character stream to the secondary Properties parser instead, treating it as user-defined metadata.6
@@ -145,10 +145,10 @@ The serialization output structure—whether JSON or EDN—takes the isolated id
 
 **Context:** Advanced users frequently nest active graph links, index tags, or rich formatting within the property values to create dynamic dashboards. Consequently, the property value parser must not treat the extracted value as an opaque literal string; it must recursively tokenize the value payload for active links to ensure the Datalog database registers the backlink and updates the node graph accordingly.16 **Input Markdown:**
 
-* Primary research statement.  
-  source::\]  
-  related-tags:: \#theory, \[\[physics\]\]  
-  **Expected Output / AST Behavior:**  
+* Primary research statement.
+  source::\]
+  related-tags:: \#theory, \[\[physics\]\]
+  **Expected Output / AST Behavior:**
   The initial parsing phase for the double-colon properties splits the input string precisely at the first valid occurrence of ::. The extracted keys, source and related-tags, are converted into sanitized, machine-readable dictionary keys. Rather than halting execution, the extracted values are passed back into the inline combinator engine. The string \] is successfully parsed and converted into a PageReference AST node.
 
 The related-tags string is far more complex, requiring tokenization into two distinct reference nodes: a Tag node representing \#theory and a secondary PageReference node representing \[\[physics\]\].6 The final AST architecture populates the :meta {:properties...} object with complex arrays of these parsed inline nodes rather than basic raw strings. By representing properties as nested AST tuples, the graph database engine can flawlessly traverse the bidirectional relationships implicitly defined within the metadata schema, enabling complex queries against nested properties.6
@@ -157,9 +157,9 @@ The related-tags string is far more complex, requiring tokenization into two dis
 
 **Context:** If the double-colon syntax appears inadvertently in the middle of a continuous text paragraph rather than at the geometric beginning of a line or as a distinct, trailing metadata block, the parser must deploy spatial heuristics to determine if it is a genuine property declaration or merely standard text (such as a code snippet demonstrating the syntax).13 **Input Markdown:**
 
-* This is a standard sentence that contains a weird string like key:: value inside it.  
-  actual-prop:: true  
-  **Expected Output / AST Behavior:**  
+* This is a standard sentence that contains a weird string like key:: value inside it.
+  actual-prop:: true
+  **Expected Output / AST Behavior:**
   To prevent catastrophic false positives, the parser rigidly restricts property recognition to specific geometric bounds within the spatial block—typically localized to the end of the block and strictly delimited by line breaks. As the scanner evaluates the first sentence, the internal string key:: value is bypassed by the property engine and treated entirely as a literal inline text tuple \["Plain" "key:: value"\] because it does not follow a mandatory line break.
 
 Conversely, the string actual-prop:: true resides on a discrete new line at the terminus of the block, perfectly conforming to the spatial property boundary rules. This line is aggressively stripped from the visible text output and injected into the :properties AST map as a boolean or string pair. This strict boundary enforcement is the primary defense mechanism preventing arbitrary prose from inadvertently corrupting the block's hidden metadata schema during unstructured journaling.6
@@ -186,8 +186,8 @@ Furthermore, standard hashing utilizing the \# symbol is deployed for inline tag
 
 **Context:** The parsing engine must successfully isolate the double-parenthesis syntax indicating a hard block reference. It is required to strip the wrapping parenthesis, validate the internal string payload as an active identifier string, and separate it cleanly from any surrounding punctuation or inline text strings.9 **Input Markdown:**
 
-* The foundational argument is presented here: ((64c752b0-d33b-4448-a261-e4dc2bbe12d3)).  
-  **Expected Output / AST Behavior:**  
+* The foundational argument is presented here: ((64c752b0-d33b-4448-a261-e4dc2bbe12d3)).
+  **Expected Output / AST Behavior:**
   The inline scanner marches across the string until it matches the (( sequence, which immediately initiates a specialized take\_until "))" sequence combinator. The internal payload, 64c752b0-d33b-4448-a261-e4dc2bbe12d3, is extracted and passed to the validation engine. Upon success, the AST generation sequence constructs a highly structured tuple array representing the block's entire text geometry.
 
 The resulting structure is defined as: \["Plain" "."\]\].6 The ability of the parser to successfully isolate the trailing period and capture it as an entirely separate Plain node proves that the block reference combinator successfully and cleanly yielded execution control back to the standard text scanner after consuming the exact boundaries of the reference.6
@@ -202,8 +202,8 @@ The resulting structure is defined as: \["Plain" "."\]\].6 The ability of the pa
 
 **Context:** Users frequently require the aliasing of links using standard Markdown URL syntax combined recursively with graph references, resulting in complex geometrical arrays such as (((uuid))).17 The AST must recursively build a node hierarchy where the link target is recognized as an internal graphical entity rather than a standard HTTP URL. **Input Markdown:**
 
-* Check out this crucial definition related to the subject.  
-  **Expected Output / AST Behavior:**  
+* Check out this crucial definition related to the subject.
+  **Expected Output / AST Behavior:**
   This string introduces severe stress to the depth-first recursive tokenizer within the Angstrom library. The scanner encounters the \`
 
 ## **Scenario: Complex Lexical Precedence \- Headings vs. Tags**
@@ -244,51 +244,51 @@ The parser generates a \["Plain" "1 "\] node, followed independently by the supe
 
 **Context:** When a user wishes to document precisely how to write a code block within their notes, they must geometrically wrap a standard three-backtick string entirely inside a four-backtick string.24 This scenario rigorously tests the greedy nature of the Angstrom take\_until combinator assigned to verbatim syntax parsing. **Input Markdown:** \-\`
 
-Snippet di codice
+Code snippet
 
 code
 
-\`\`\`  
-\*\*Expected Output / AST Behavior:\*\*  
-The lexer matches the initial \`\`\`\`\` string as the opening marker sequence for a \`CodeBlock\` or \`Verbatim\` node.\[2, 24\] Critically, it must store the mathematical length of this opening delimiter (which is 4\) into its active state tracking buffer. As the scanner consumes the internal payload, it encounters \`\`\`\`lang\`. 
+\`\`\`
+\*\*Expected Output / AST Behavior:\*\*
+The lexer matches the initial \`\`\`\`\` string as the opening marker sequence for a \`CodeBlock\` or \`Verbatim\` node.\[2, 24\] Critically, it must store the mathematical length of this opening delimiter (which is 4\) into its active state tracking buffer. As the scanner consumes the internal payload, it encounters \`\`\`\`lang\`.
 
 Because the delimiter length of the internal string is 3 (which is strictly less than the state-tracked delimiter of 4), the parser engine treats it entirely as a literal string payload rather than a termination sequence. The parser only halts when it encounters the closing \`\`\`\`\` sequence matching the exact length of 4, successfully terminating the block. The AST output is a highly clean \`CodeBlock\` node containing the exact internal string \`\`\`\`lang\\ncode\\n\`\`\`\` without prematurely closing, thus mathematically verifying the dynamic delimiter-length tracking integrity within the OCaml lexer state.
 
-\#\# Scenario: Anki Cloze and LaTeX Math Boundaries  
-\*\*Context:\*\* The Logseq user base heavily integrates spaced repetition study methodologies and advanced mathematical documentation. Therefore, the parser must cleanly and flawlessly distinguish between standard curly braces, LaTeX math boundary markers (\`$\`), and specific Anki spaced-repetition cloze structures such as \`{{c1...}}\` when they are interleaved within the exact same geometric string.  
-\*\*Input Markdown:\*\*  
-\- test anki cloze 1 {{c1 $\\mathrm{K}$}}  
-\*\*Expected Output / AST Behavior:\*\*  
-The inline parser reads the initial string sequence \`test anki cloze 1 \`. Upon encountering the sequence \`{{c1 \`, it triggers a hard transition into the specialized Cloze node combinator pipeline. Deep inside the cloze execution state, it encounters the \`$\` symbol, which immediately triggers a sub-transition into the LaTeX inline math combinator. 
+\#\# Scenario: Anki Cloze and LaTeX Math Boundaries
+\*\*Context:\*\* The Logseq user base heavily integrates spaced repetition study methodologies and advanced mathematical documentation. Therefore, the parser must cleanly and flawlessly distinguish between standard curly braces, LaTeX math boundary markers (\`$\`), and specific Anki spaced-repetition cloze structures such as \`{{c1...}}\` when they are interleaved within the exact same geometric string.
+\*\*Input Markdown:\*\*
+\- test anki cloze 1 {{c1 $\\mathrm{K}$}}
+\*\*Expected Output / AST Behavior:\*\*
+The inline parser reads the initial string sequence \`test anki cloze 1 \`. Upon encountering the sequence \`{{c1 \`, it triggers a hard transition into the specialized Cloze node combinator pipeline. Deep inside the cloze execution state, it encounters the \`$\` symbol, which immediately triggers a sub-transition into the LaTeX inline math combinator.
 
 The Math combinator consumes the internal string \`\\mathrm{K}\` and elegantly closes its state upon encountering the secondary \`$\`. Subsequently, the Cloze combinator resumes and closes successfully at the \`}}\` delimiter sequence. The resulting AST array is highly nested but geometrically perfect: \`\["Cloze" {:id "c1", :content \[\["Math" "\\\\mathrm{K}"\]\]}\]\`. The parser correctly proves its deep recursive descent capabilities, allowing complex LaTeX AST nodes to exist dynamically inside spaced-repetition Cloze nodes without the \`{}\` structural braces of the LaTeX syntax maliciously confusing the closing \`}}\` sequence of the overarching Cloze tag.
 
-#### **Bibliografia**
+#### **Bibliography**
 
-1. mldoc/mlorg at master \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/mldoc/blob/master/mlorg](https://github.com/logseq/mldoc/blob/master/mlorg)  
-2. Mldoc \- Another Emacs Org-mode and Markdown parser. \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/mldoc](https://github.com/logseq/mldoc)  
-3. Allow non-outline (freeform) text \- \#45 by cannibalox \- Feature Requests \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/allow-non-outline-freeform-text/172/45](https://discuss.logseq.com/t/allow-non-outline-freeform-text/172/45)  
-4. logseq/logseq: A privacy-first, open-source platform for knowledge management and collaboration. Download link: http://github.com/logseq/logseq/releases. roadmap: https://logseq.io/p/NX4mc\_ggEV · GitHub \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq](https://github.com/logseq/logseq)  
-5. logseq/.i18n-lint.toml at master \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/blob/master/.i18n-lint.toml](https://github.com/logseq/logseq/blob/master/.i18n-lint.toml)  
-6. GitHub \- cldwalker/logseq-clis, accesso eseguito il giorno aprile 25, 2026, [https://github.com/cldwalker/logseq-clis](https://github.com/cldwalker/logseq-clis)  
-7. Use a proper markdown Standard such as GFM or Commonmark. · Issue \#9266 \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/issues/9266](https://github.com/logseq/logseq/issues/9266)  
-8. updating page name doesn't update tags prefixed with ... \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/issues/6611](https://github.com/logseq/logseq/issues/6611)  
-9. The basics of Logseq block references \- Documentation, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/the-basics-of-logseq-block-references/8458](https://discuss.logseq.com/t/the-basics-of-logseq-block-references/8458)  
-10. Different ways to structure data \- Queries \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/different-ways-to-structure-data/8819](https://discuss.logseq.com/t/different-ways-to-structure-data/8819)  
-11. Option to Make Parser Respect Standard Markdown \- General \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/option-to-make-parser-respect-standard-markdown/640](https://discuss.logseq.com/t/option-to-make-parser-respect-standard-markdown/640)  
-12. References with specific tag or task \- Queries \- Logseq forum, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/references-with-specific-tag-or-task/27734](https://discuss.logseq.com/t/references-with-specific-tag-or-task/27734)  
-13. List of special properties and tags \- Documentation \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/list-of-special-properties-and-tags/25821](https://discuss.logseq.com/t/list-of-special-properties-and-tags/25821)  
-14. LOGBOOK doesn't display state changes of repeating tasks · Issue \#3823 \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/issues/3823](https://github.com/logseq/logseq/issues/3823)  
-15. logseq/src/main/frontend/components/block.cljs at master \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/blob/master/src/main/frontend/components/block.cljs](https://github.com/logseq/logseq/blob/master/src/main/frontend/components/block.cljs)  
-16. Logseq's Export Formats \- Random Geekery, accesso eseguito il giorno aprile 25, 2026, [https://randomgeekery.org/post/2022/03/logseqs-export-formats/](https://randomgeekery.org/post/2022/03/logseqs-export-formats/)  
-17. An idea for a more standard-Markdown property syntax \- General \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/an-idea-for-a-more-standard-markdown-property-syntax/20073](https://discuss.logseq.com/t/an-idea-for-a-more-standard-markdown-property-syntax/20073)  
-18. Help Navigating & Converting Extensive Block References, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/help-navigating-converting-extensive-block-references/32051](https://discuss.logseq.com/t/help-navigating-converting-extensive-block-references/32051)  
-19. Query to format structured blocks into table, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/query-to-format-structured-blocks-into-table/26733](https://discuss.logseq.com/t/query-to-format-structured-blocks-into-table/26733)  
-20. cloze with latex doesn't work · Issue \#5087 \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/issues/5087](https://github.com/logseq/logseq/issues/5087)  
-21. Why You Should Use Block References in Logseq: A Beginner's Introduction \- YouTube, accesso eseguito il giorno aprile 25, 2026, [https://www.youtube.com/watch?v=g66G2ThmC7M](https://www.youtube.com/watch?v=g66G2ThmC7M)  
-22. Block References Issues and Ideas for Improvements \- Feature Requests, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/block-references-issues-and-ideas-for-improvements/15784](https://discuss.logseq.com/t/block-references-issues-and-ideas-for-improvements/15784)  
-23. How can I get a folder hierachy on logseq? Pics of what I mean \- Reddit, accesso eseguito il giorno aprile 25, 2026, [https://www.reddit.com/r/logseq/comments/wibfz6/how\_can\_i\_get\_a\_folder\_hierachy\_on\_logseq\_pics\_of/](https://www.reddit.com/r/logseq/comments/wibfz6/how_can_i_get_a_folder_hierachy_on_logseq_pics_of/)  
-24. Option to Make Parser Respect Standard Markdown \- \#9 by lewisia \- General \- Logseq, accesso eseguito il giorno aprile 25, 2026, [https://discuss.logseq.com/t/option-to-make-parser-respect-standard-markdown/640/9](https://discuss.logseq.com/t/option-to-make-parser-respect-standard-markdown/640/9)  
-25. Markdown: cannot put bold words inside italic sentence · Issue \#8790 \- GitHub, accesso eseguito il giorno aprile 25, 2026, [https://github.com/logseq/logseq/issues/8790](https://github.com/logseq/logseq/issues/8790)
+1. mldoc/mlorg at master \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/mldoc/blob/master/mlorg](https://github.com/logseq/mldoc/blob/master/mlorg)
+2. Mldoc \- Another Emacs Org-mode and Markdown parser. \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/mldoc](https://github.com/logseq/mldoc)
+3. Allow non-outline (freeform) text \- \#45 by cannibalox \- Feature Requests \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/allow-non-outline-freeform-text/172/45](https://discuss.logseq.com/t/allow-non-outline-freeform-text/172/45)
+4. logseq/logseq: A privacy-first, open-source platform for knowledge management and collaboration. Download link: http://github.com/logseq/logseq/releases. roadmap: https://logseq.io/p/NX4mc\_ggEV · GitHub \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq](https://github.com/logseq/logseq)
+5. logseq/.i18n-lint.toml at master \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/blob/master/.i18n-lint.toml](https://github.com/logseq/logseq/blob/master/.i18n-lint.toml)
+6. GitHub \- cldwalker/logseq-clis, accessed on April 25, 2026, [https://github.com/cldwalker/logseq-clis](https://github.com/cldwalker/logseq-clis)
+7. Use a proper markdown Standard such as GFM or Commonmark. · Issue \#9266 \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/issues/9266](https://github.com/logseq/logseq/issues/9266)
+8. updating page name doesn't update tags prefixed with ... \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/issues/6611](https://github.com/logseq/logseq/issues/6611)
+9. The basics of Logseq block references \- Documentation, accessed on April 25, 2026, [https://discuss.logseq.com/t/the-basics-of-logseq-block-references/8458](https://discuss.logseq.com/t/the-basics-of-logseq-block-references/8458)
+10. Different ways to structure data \- Queries \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/different-ways-to-structure-data/8819](https://discuss.logseq.com/t/different-ways-to-structure-data/8819)
+11. Option to Make Parser Respect Standard Markdown \- General \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/option-to-make-parser-respect-standard-markdown/640](https://discuss.logseq.com/t/option-to-make-parser-respect-standard-markdown/640)
+12. References with specific tag or task \- Queries \- Logseq forum, accessed on April 25, 2026, [https://discuss.logseq.com/t/references-with-specific-tag-or-task/27734](https://discuss.logseq.com/t/references-with-specific-tag-or-task/27734)
+13. List of special properties and tags \- Documentation \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/list-of-special-properties-and-tags/25821](https://discuss.logseq.com/t/list-of-special-properties-and-tags/25821)
+14. LOGBOOK doesn't display state changes of repeating tasks · Issue \#3823 \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/issues/3823](https://github.com/logseq/logseq/issues/3823)
+15. logseq/src/main/frontend/components/block.cljs at master \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/blob/master/src/main/frontend/components/block.cljs](https://github.com/logseq/logseq/blob/master/src/main/frontend/components/block.cljs)
+16. Logseq's Export Formats \- Random Geekery, accessed on April 25, 2026, [https://randomgeekery.org/post/2022/03/logseqs-export-formats/](https://randomgeekery.org/post/2022/03/logseqs-export-formats/)
+17. An idea for a more standard-Markdown property syntax \- General \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/an-idea-for-a-more-standard-markdown-property-syntax/20073](https://discuss.logseq.com/t/an-idea-for-a-more-standard-markdown-property-syntax/20073)
+18. Help Navigating & Converting Extensive Block References, accessed on April 25, 2026, [https://discuss.logseq.com/t/help-navigating-converting-extensive-block-references/32051](https://discuss.logseq.com/t/help-navigating-converting-extensive-block-references/32051)
+19. Query to format structured blocks into table, accessed on April 25, 2026, [https://discuss.logseq.com/t/query-to-format-structured-blocks-into-table/26733](https://discuss.logseq.com/t/query-to-format-structured-blocks-into-table/26733)
+20. cloze with latex doesn't work · Issue \#5087 \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/issues/5087](https://github.com/logseq/logseq/issues/5087)
+21. Why You Should Use Block References in Logseq: A Beginner's Introduction \- YouTube, accessed on April 25, 2026, [https://www.youtube.com/watch?v=g66G2ThmC7M](https://www.youtube.com/watch?v=g66G2ThmC7M)
+22. Block References Issues and Ideas for Improvements \- Feature Requests, accessed on April 25, 2026, [https://discuss.logseq.com/t/block-references-issues-and-ideas-for-improvements/15784](https://discuss.logseq.com/t/block-references-issues-and-ideas-for-improvements/15784)
+23. How can I get a folder hierachy on logseq? Pics of what I mean \- Reddit, accessed on April 25, 2026, [https://www.reddit.com/r/logseq/comments/wibfz6/how\_can\_i\_get\_a\_folder\_hierachy\_on\_logseq\_pics\_of/](https://www.reddit.com/r/logseq/comments/wibfz6/how_can_i_get_a_folder_hierachy_on_logseq_pics_of/)
+24. Option to Make Parser Respect Standard Markdown \- \#9 by lewisia \- General \- Logseq, accessed on April 25, 2026, [https://discuss.logseq.com/t/option-to-make-parser-respect-standard-markdown/640/9](https://discuss.logseq.com/t/option-to-make-parser-respect-standard-markdown/640/9)
+25. Markdown: cannot put bold words inside italic sentence · Issue \#8790 \- GitHub, accessed on April 25, 2026, [https://github.com/logseq/logseq/issues/8790](https://github.com/logseq/logseq/issues/8790)
 
 [image1]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAXCAYAAAAV1F8QAAAA9ElEQVR4XmNgGAVDDXAA8XMg/o+E3wFxKJKaY2jyRUhyJAOYIdiAGANEzhJdghyAy6JMIL6NLkgJAFmyD03sIhCXoYlRBJQYIBaxQPmiUD7VwRIGhMG5UDZNLIKltKtAnA3E96BiVAcwH4hA+YJQPkXJGB3Aggod7GfALk42eM+A3UBQwgCJT0GXgAJDIOaBsjmBmAlJDivAF/G45EAZF2Q4SO48EIsD8S8gtkNWBAJhQPyGAWEQCD8BYjYkNQ/R5F8iyekAMTNUHAZAbJA41QEoI99H4mPzOVXAZyCOReLfhdJULUlAAN0HeUB8EE1sFAxyAAAvTEOc/K2MwAAAAABJRU5ErkJggg==>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,10 +6,13 @@ status: stable
 classification: canonical
 audience: maintainers
 owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
 last_verified: 2026-08-06
 verified: 2026-08-06
 stale_after: 2027-02-02
 okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
 supersedes: null
 superseded_by: null
 ---
@@ -25,6 +28,7 @@ navigation layers only.
 | Resource | Role |
 |---|---|
 | [Documentation portal](README.md) | Human navigation by audience |
+| [Documentation system](DOCUMENTATION_SYSTEM.md) | Canonical governance, lifecycle, metadata, and federation guide |
 | [Architecture](CLEAN_CODE_ARCHITECTURE.md) | Canonical architecture and public graph API |
 | [Repository roadmap](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Current evidence-backed improvement plan |
 | [Issue reconciliation](quality/ISSUE_RECONCILIATION_2026-08-06.md) | Current GitHub backlog decisions |
@@ -36,5 +40,6 @@ navigation layers only.
 
 The current target is Matryca quality level **MKQ-4**. This bundle does not
 claim official OKF conformance. Validation must remain offline, deterministic,
-non-mutating, and reproducible from a clean source commit.
-
+non-mutating, and reproducible from a clean source commit. The private source
+profile does not yet declare this repository's entry points, so federation
+activation remains a separate review gate.

--- a/docs/log.md
+++ b/docs/log.md
@@ -6,9 +6,13 @@ status: stable
 classification: active
 audience: maintainers
 owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
 last_verified: 2026-08-06
 verified: 2026-08-06
 stale_after: 2027-02-02
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
 supersedes: null
 superseded_by: null
 ---
@@ -17,6 +21,14 @@ superseded_by: null
 
 ## 2026-08-06
 
+- Published the canonical
+  [documentation system and evolution guide](DOCUMENTATION_SYSTEM.md).
+- Reconciled the maintained bundle with Matryca Knowledge `origin/main` at
+  commit `7a3ebd8`, including authority, execution mode, lifecycle,
+  classification, freshness, and honest conformance boundaries.
+- Recorded that the private source registry still requires a separate parser
+  entry-point change before projection-level conformance can be claimed.
+- Standardized repository documentation and maintainer-facing text in English.
 - Added the canonical [knowledge bundle entry point](index.md).
 - Published the [stellar repository audit](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md).
 - Classified the 2026-07-28 study as a superseded historical baseline.

--- a/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
+++ b/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
@@ -6,9 +6,13 @@ status: stable
 classification: active
 audience: maintainers
 owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
 last_verified: 2026-08-06
 verified: 2026-08-06
 stale_after: 2026-09-05
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
 supersedes: docs/quality/ISSUE_TRIAGE_2026-07.md
 superseded_by: null
 publication_pr: 112
@@ -94,3 +98,13 @@ deep parser P0 + #106 filesystem boundary
 
 Product RFCs and contributor issues may proceed in parallel only when they do
 not touch protected parser/graph hubs or weaken these gates.
+
+## Post-baseline documentation progress
+
+- Draft [PR #114](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/114)
+  standardizes repository documentation and maintainer-facing text in English;
+  it closes #69 when merged.
+- The same documentation adoption phase records the source-side lifecycle,
+  classification, authority, freshness, and federation contract requested by
+  #109. Deterministic source CI, private profile activation, and projection
+  verification remain open before MKQ-4 can be claimed.

--- a/docs/quality/README.md
+++ b/docs/quality/README.md
@@ -6,9 +6,13 @@ status: stable
 classification: canonical
 audience: maintainers
 owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
 last_verified: 2026-08-06
 verified: 2026-08-06
 stale_after: 2027-02-02
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
 supersedes: null
 superseded_by: null
 ---
@@ -21,6 +25,7 @@ Maintainer-facing triage and backlog for Clean Architecture / Clean Code work.
 |----------|---------|
 | [`ISSUE_RECONCILIATION_2026-08-06.md`](ISSUE_RECONCILIATION_2026-08-06.md) | Current disposition of every open GitHub issue and stellar-roadmap integration |
 | [`../REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](../REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Current repository-wide evidence, priorities and MKQ-4 plan |
+| [`../DOCUMENTATION_SYSTEM.md`](../DOCUMENTATION_SYSTEM.md) | Canonical documentation authority, metadata, lifecycle, and federation contract |
 | [`GITHUB_CLEAN_ARCH_ROADMAP.md`](GITHUB_CLEAN_ARCH_ROADMAP.md) | Milestone, project board, epic + phase issues (v1.6) |
 | [`ISSUE_TRIAGE_2026-07.md`](ISSUE_TRIAGE_2026-07.md) | Superseded July 2026 backlog baseline |
 | [`CLEAN_ARCH_BACKLOG.md`](CLEAN_ARCH_BACKLOG.md) | v1 structural debt **complete** — v2 epic (`logos_parser` split) |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,9 +6,13 @@ status: stable
 classification: canonical
 audience: maintainers
 owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
 last_verified: 2026-08-06
 verified: 2026-08-06
 stale_after: 2027-02-02
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
 supersedes: null
 superseded_by: null
 ---
@@ -33,6 +37,11 @@ The official OKF v0.2 baseline recorded there is pinned to commit
 This repository currently declares `matryca_okf_inspired_quality`, not official
 OKF conformance.
 
+The private `sources.toml` profile at this baseline registers the repository
+but does not yet declare its maintained entry points. The source bundle and the
+private registry/projection change therefore remain independently reviewed
+artifacts.
+
 ## Local contracts
 
 - [Architecture](../CLEAN_CODE_ARCHITECTURE.md)
@@ -40,4 +49,4 @@ OKF conformance.
 - [Release process](../RELEASE_PROCESS.md)
 - [Security policy](../../SECURITY.md)
 - [Current roadmap](../REPOSITORY_STELLAR_ROADMAP_2026-08-06.md)
-
+- [Documentation system](../DOCUMENTATION_SYSTEM.md)

--- a/src/logseq_matryca_parser/agent_writer.py
+++ b/src/logseq_matryca_parser/agent_writer.py
@@ -249,7 +249,7 @@ def _demo() -> None:
         datetime(2026, 5, 11),
         datetime(2026, 5, 22),
     ]
-    print(f"{'Data Originale':<20} | {'Formato Logseq':<15} | {'Output Finale'}")
+    print(f"{'Original Date':<20} | {'Logseq Format':<15} | {'Final Output'}")
     print("-" * 60)
     for dt in test_dates:
         fmt = reader.load_journal_format()

--- a/src/logseq_matryca_parser/logos_parser.py
+++ b/src/logseq_matryca_parser/logos_parser.py
@@ -1063,7 +1063,7 @@ class StackMachineParser:
         content = path.read_text(encoding="utf-8-sig")
         detected_tab = detect_tab_size_from_markdown(content)
         if not content.strip():
-            logger.warning("Il file %s è vuoto.", path)
+            logger.warning("File %s is empty.", path)
             page_title = derive_page_title_from_source_path(path)
             title_segments = [segment for segment in page_title.split("/") if segment]
             namespace_chain = title_segments[:-1] if len(title_segments) > 1 else []

--- a/src/logseq_matryca_parser/synapse.py
+++ b/src/logseq_matryca_parser/synapse.py
@@ -289,7 +289,7 @@ class SynapseAdapter:
     def to_langchain_documents(nodes: list[LogseqNode], source_name: str) -> list[Any]:
         """Convert AST nodes to LangChain documents using `LangChainVisitor`."""
         if Document is None:
-            raise ImportError("LangChain non rilevato. Installa 'langchain-core' per usare Synapse.")
+            raise ImportError("LangChain was not detected. Install 'langchain-core' to use Synapse.")
         visitor = LangChainVisitor(source_name=source_name, document_cls=Document)
         for node in nodes:
             node.accept(visitor)
@@ -304,7 +304,7 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Convert AST nodes to LlamaIndex nodes preserving topology links."""
         if TextNode is None or NodeRelationship is None or RelatedNodeInfo is None:
-            raise ImportError("LlamaIndex non rilevato. Installa 'llama-index' per usare Synapse.")
+            raise ImportError("LlamaIndex was not detected. Install 'llama-index' to use Synapse.")
         flat = _flatten_nodes_for_export(nodes)
         unique_paths = {node.source_path for node in flat if node.source_path}
         use_per_node_source = len(unique_paths) > 1
@@ -341,7 +341,7 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Flatten ``nodes`` and emit LangChain ``Document``s with breadcrumb-enriched ``page_content``."""
         if Document is None:
-            raise ImportError("LangChain non rilevato. Installa 'langchain-core' per usare Synapse.")
+            raise ImportError("LangChain was not detected. Install 'langchain-core' to use Synapse.")
         documents: list[Any] = []
         flat = _flatten_nodes_for_export(nodes)
         for node in flat:

--- a/tests/test_logos_parser.py
+++ b/tests/test_logos_parser.py
@@ -343,7 +343,7 @@ def test_parse_file_empty_returns_no_nodes(tmp_path: Path, caplog: pytest.LogCap
 
     assert page.root_nodes == []
     assert page.title == "ghost"
-    assert "vuoto" in caplog.text
+    assert "is empty" in caplog.text
 
 
 def test_parse_page_file_zero_byte_returns_empty_page(tmp_path: Path) -> None:


### PR DESCRIPTION
## Objective

Make English the repository-wide documentation language and align the maintained documentation bundle with the current private Matryca Knowledge governance model.

## What changed

### Phase 1 — English standardization

- translated historical audit reports, mixed-language design references, the Logseq Read skill, maintainer configuration, CLI/help text, demo labels, parser warnings, and optional SYNAPSE dependency errors
- added an explicit English-language policy to `CONTRIBUTING.md`
- preserved findings, metrics, links, URLs, code fences, embedded images, and intentional localized test fixtures

### Phase 2 — documentation governance

- added `docs/DOCUMENTATION_SYSTEM.md`, the canonical English guide to authority, taxonomy, metadata, lifecycle, freshness, validation, contribution, and federation
- aligned the maintained bundle with Matryca Knowledge `origin/main` at immutable commit `7a3ebd8`
- separated OKF lifecycle (`draft`, `stable`, `deprecated`) from Matryca classification (`canonical`, `active`, `historical`, `generated`)
- recorded source authority, review mode, compatibility freshness, profile identity, and honest conformance boundaries
- updated the documentation portal, machine entry point, architecture SSOT, decision/reference/quality indexes, evolution log, roadmap, issue ledger, README, CONTRIBUTING, and CHANGELOG
- documented that the private parser profile still lacks `okf_entry_points`; private registry activation and projection refresh remain separate review gates

## Scope and non-goals

- source repository documentation remains authoritative
- historical documents are preserved rather than mass-normalized
- generated repository packs remain untouched
- this PR does not claim official OKF v0.1/v0.2 conformance or completed MKQ-4
- this PR does not modify the private Matryca Knowledge repository, CI behavior, runtime code, releases, or repository settings
- the pre-existing untracked `.serena/` directory is excluded

## Provenance and execution

- base: `main` at `f8982bb`
- Matryca Knowledge policy baseline: `origin/main` at `7a3ebd8`
- commits:
  - `5cd98a8` — English documentation standardization
  - `e105402` — remaining English maintainer text
  - `7c98acb` — Matryca Knowledge documentation alignment
- deterministic evidence was collected before model review
- local advisory review failed with zero confidence and was rejected
- GPT-5.3 Codex Spark performed a bounded read-only documentation review; its one freshness-policy finding was corrected and all checks were rerun

## Validation

- [x] `make all` — 462 passed, 91.09% coverage; Ruff and Mypy clean
- [x] `make vendor-name-check`
- [x] maintained-bundle audit with the current Matryca Knowledge validator — conformant, 0 findings
- [x] `check(cycles)` — 0 import cycles
- [x] `git diff --check`
- [x] focused translation residue and preservation checks from phase 1
- [x] independent bounded documentation-policy review and correction

## OKF and Matryca impact

The source-side bundle now follows the transitional `matryca_okf_inspired_quality` metadata model and is structured for MKQ-3 validation. MKQ-4 remains pending until deterministic source CI enforcement and private `okf_entry_points`/projection verification are active. Manifest version, Matryca profile version, and official OKF specification version remain distinct.

## Security, privacy, cost, and rollback

- no secrets, credentials, operator paths, or runtime logs were added
- no runtime or dependency behavior changed
- LLM use was limited to a bounded review after deterministic checks; acceptance evidence is deterministic
- rollback is a normal revert of the three documentation commits; no migration or external data mutation is required

## Remaining risks

- the private source profile and reviewed projection still need their own PRs
- source CI does not yet enforce all maintained links, anchors, snippets, freshness, and canonical-role rules
- GitHub checks triggered by the latest push must complete before merge

Closes #69.
Advances #109 without closing it.
