### PR TITLE
feat(docs): enforce maintained documentation profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,6 @@ jobs:
 
     - name: Test
       run: make test
+
+    - name: Documentation check (non-mutating)
+      run: make docs-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Federated documentation profile** — aligned the maintained bundle with Matryca Knowledge `origin/main` at `7a3ebd8`, separating OKF lifecycle from Matryca classification and recording authority, freshness, provenance, and the still-pending private registry activation.
 - **Ghost Tooling** — removed remaining vendor indexer blocks from `AGENTS.md` / `CLAUDE.md`; maintainer guidance now uses **audit code** terminology only.
 - **Repository language** — translated the historical audit reports, design references, Logseq Read skill, maintainer configuration comments, parser warning, demo labels, and optional SYNAPSE dependency errors into English; contributor guidance now makes English the repository default ([#69](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/69)).
+- **Documentation quality tranche** — added `scripts/check_documentation.py`, source `docs/maintained.toml`, and focused tests; wired the deterministic, non-mutating `docs-check` into `make all` and CI. This implements the source-side MKQ-3 gate; MKQ-4 remains pending until private `okf_entry_points` and projection activation pass against the merged source commit.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ git checkout -b feat/add-html-exporter
 
 ### 4. Code Quality & Linting (Mandatory)
 
-CI runs the same commands as your local environment: `uv sync --all-extras`, then `make lint`, `make check`, and `make test`. Before committing, run the full gate:
+CI runs the same commands as your local environment: `uv sync --all-extras`, then `make lint`, `make check`, `make test`, and `make docs-check`. Before committing, run the full gate:
 
 ```bash
 make all
@@ -171,7 +171,7 @@ Or run each step individually:
 
 ```bash
 make lint   # Ruff (with auto-fix)
-make check  # Mypy on src/, tests/, examples/
+make check  # Mypy on src/, tests/, examples/, and the documentation checker
 make test   # Pytest on tests/
 ```
 
@@ -179,7 +179,7 @@ Equivalent `uv run` invocations:
 
 ```bash
 uv run ruff check . --fix
-uv run mypy src/ tests/ examples/
+uv run mypy src/ tests/ examples/ scripts/check_documentation.py
 uv run pytest -v tests/
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
-.PHONY: all lint check test build vendor-name-check
+.PHONY: all lint check test build vendor-name-check docs-check
 
-all: lint check vendor-name-check test
+all: lint check vendor-name-check docs-check test
 
 lint:
 	uv run ruff check . --fix
 
 check:
-	uv run mypy src/ tests/ examples/
+	uv run mypy src/ tests/ examples/ scripts/check_documentation.py
 
 vendor-name-check:
 	bash scripts/check_vendor_free_docs.sh
 
 test:
 	uv run pytest --cov=src/logseq_matryca_parser --cov-report=term-missing --cov-fail-under=80 -v tests/
+
+docs-check:
+	uv run python scripts/check_documentation.py --root . --profile docs/maintained.toml --as-of-date $$(date -u +%F)
 
 build:
 	uv run python -m nuitka --standalone --onefile src/logseq_matryca_parser/kinetic.py

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -317,4 +317,6 @@ make test
 
 Full gate: `make all`.
 
-Cursor agents: load [`.cursor/rules/08-clean-code-architecture.mdc`](../.cursor/rules/08-clean-code-architecture.mdc) when editing `src/`. Bug-hunt SOP: [`.cursor/rules/07-clean-architecture-audit.mdc`](../.cursor/rules/07-clean-architecture-audit.mdc).
+Maintainer agents must follow this canonical architecture contract when editing
+`src/` and use the versioned [local code-audit runbook](internal/LOCAL_CODE_STUDY.md)
+for bug-hunt and impact-analysis workflows.

--- a/docs/DOCUMENTATION_SYSTEM.md
+++ b/docs/DOCUMENTATION_SYSTEM.md
@@ -221,9 +221,16 @@ the change in [`log.md`](log.md).
 4. Inspect the staged diff and commit only intended files.
 5. Record checks and Matryca/OKF impact in the pull-request description.
 
-The current `make all` gate validates repository quality and vendor-neutral
-documentation. Full MKQ-4 source enforcement remains tracked separately until
-the shared profile and source-local deterministic checks are integrated.
+The source-owned [`maintained.toml`](maintained.toml) profile is the executable
+inventory for this bundle. `make docs-check` validates its paths, flat scalar
+frontmatter, lifecycle and classification values, verification dates, freshness,
+canonical-type uniqueness, and local links and anchors. Findings are sorted and
+use repository-relative paths; the explicit UTC audit date makes repeated runs
+against the same checkout reproducible. The check never rewrites documentation.
+
+`make all` and CI both execute this source gate. Full MKQ-4 status remains
+pending until the private `okf_entry_points` profile and projection are active
+and passing in the separate registry.
 
 ## 8. Federation workflow
 
@@ -252,7 +259,7 @@ includes the entry points and the resulting projection passes its own checks.
 | Clean Architecture phase | Canonical architecture SSOT and vendor-neutral maintainer policy | Documentation quality was mostly prose-enforced |
 | Stellar audit phase | Evidence-backed roadmap, issue reconciliation, entry points, classification, and freshness | Private source profile still lacked parser entry points |
 | English standardization | Repository documentation and maintainer text moved to one shared language | Governance needed a single explanatory contract |
-| Current federated phase | This guide defines authority, metadata, lifecycle, validation, and projection boundaries | MKQ-4 enforcement and private registry activation remain separate gates |
+| Source-enforcement phase | `docs/maintained.toml` and `make docs-check` enforce the maintained bundle in local and remote CI | Private registry admission and projection remain a separate gate |
 
 The intended end state is not a mass rewrite. It is a small, clearly owned
 maintained bundle surrounded by discoverable active material and preserved
@@ -265,10 +272,10 @@ claim official OKF v0.1 or v0.2 conformance. The Matryca source-manifest version
 Matryca quality-profile version, and official OKF specification version are
 separate concepts and must be reported independently.
 
-The source-side documentation structure currently satisfies the intended
-MKQ-1 and MKQ-2 shape and is designed for MKQ-3 validation. MKQ-4 is reached
-only when deterministic source CI enforcement and the private registry profile
-are both active and passing.
+The source-side documentation structure and deterministic CI gate implement the
+intended MKQ-1 through MKQ-3 controls. MKQ-4 is reached only when the private
+registry profile and projection are also active and passing against an immutable
+merged source commit.
 
 ## 11. Normative references
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -19,6 +19,23 @@ superseded_by: null
 
 # Documentation evolution log
 
+## 2026-08-07
+
+- Added a source-owned maintained-document profile in
+  [`docs/maintained.toml`](maintained.toml) and implemented
+  [`scripts/check_documentation.py`](../scripts/check_documentation.py) with deterministic
+  reporting, required frontmatter and link/anchor validation, duplicate canonical
+  detection, and non-zero exit on findings.
+- Added [`tests/test_check_documentation.py`](../tests/test_check_documentation.py) for valid-bundle checks, failure families,
+  deterministic ordering, fenced-code exclusion, duplicate heading anchors, and
+  CLI exit codes.
+- Added a dedicated `docs-check` target to `Makefile` and a non-mutating CI step
+  in `.github/workflows/ci.yml`.
+- Activated source-side documentation CI in `make all` and recorded the result in
+  this log.
+- Did not claim MKQ-4 conformance because private `okf_entry_points` and
+  projection activation remain pending.
+
 ## 2026-08-06
 
 - Published the canonical

--- a/docs/log.md
+++ b/docs/log.md
@@ -31,6 +31,9 @@ superseded_by: null
   CLI exit codes.
 - Added a dedicated `docs-check` target to `Makefile` and a non-mutating CI step
   in `.github/workflows/ci.yml`.
+- Replaced two links from the canonical architecture guide to unversioned local
+  editor rules with the versioned maintainer audit-code runbook after clean-checkout
+  CI exposed the hidden local dependency.
 - Activated source-side documentation CI in `make all` and recorded the result in
   this log.
 - Did not claim MKQ-4 conformance because private `okf_entry_points` and

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -1,0 +1,31 @@
+required_frontmatter_fields = [
+  "type",
+  "title",
+  "description",
+  "status",
+  "classification",
+  "audience",
+  "owner",
+  "authority",
+  "execution_mode",
+  "last_verified",
+  "verified",
+  "stale_after",
+  "okf_profile",
+  "okf_spec_version",
+  "supersedes",
+  "superseded_by",
+]
+
+maintained_documents = [
+  "docs/index.md",
+  "docs/README.md",
+  "docs/DOCUMENTATION_SYSTEM.md",
+  "docs/CLEAN_CODE_ARCHITECTURE.md",
+  "docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md",
+  "docs/quality/ISSUE_RECONCILIATION_2026-08-06.md",
+  "docs/quality/README.md",
+  "docs/decisions/index.md",
+  "docs/reference/index.md",
+  "docs/log.md",
+]

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Deterministically validate the maintained documentation bundle."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import tomllib
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+STATUSES = {"draft", "stable", "deprecated"}
+CLASSIFICATIONS = {"canonical", "active", "historical", "generated"}
+DATE_FIELDS = ("last_verified", "verified", "stale_after")
+HEADING = re.compile(r"^#{1,6}\s+(.+?)\s*#*\s*$")
+MARKDOWN_LINK = re.compile(r"(?<!!)\[[^]]*\]\(([^)]+)\)")
+
+
+class ProfileError(ValueError):
+    """A fatal maintained-profile configuration error."""
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    """One stable, machine-readable validation finding."""
+
+    source: str
+    line: int
+    code: str
+    message: str
+
+    def render(self) -> str:
+        return f"{self.source}:{self.line}: {self.code}: {self.message}"
+
+
+def _relative(path: Path, root: Path) -> str:
+    """Return a checkout-independent path for diagnostics."""
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _fenced_lines(lines: list[str]) -> set[int]:
+    skipped: set[int] = set()
+    fence: str | None = None
+    for number, line in enumerate(lines, start=1):
+        stripped = line.lstrip()
+        marker = stripped[:3]
+        if marker in {"```", "~~~"}:
+            if fence is None:
+                fence = marker
+            elif marker == fence:
+                fence = None
+            skipped.add(number)
+        elif fence is not None:
+            skipped.add(number)
+    return skipped
+
+
+def _heading_anchors(text: str) -> set[str]:
+    """Match the current Matryca Knowledge anchor algorithm."""
+    anchors: set[str] = set()
+    counts: dict[str, int] = {}
+    lines = text.splitlines()
+    skipped = _fenced_lines(lines)
+    for number, line in enumerate(lines, start=1):
+        if number in skipped or not (match := HEADING.match(line)):
+            continue
+        heading = re.sub(r"\[([^]]+)\]\([^)]+\)", r"\1", match.group(1))
+        slug = re.sub(r"[^\w\- ]", "", heading.lower(), flags=re.UNICODE)
+        slug = slug.strip().replace(" ", "-")
+        occurrence = counts.get(slug, 0)
+        counts[slug] = occurrence + 1
+        anchors.add(slug if occurrence == 0 else f"{slug}-{occurrence}")
+    return anchors
+
+
+def _frontmatter(path: Path, root: Path, findings: list[Finding]) -> dict[str, str] | None:
+    source = _relative(path, root)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != "---":
+        findings.append(Finding(source, 1, "DOC_FRONTMATTER_MISSING", "missing opening ---"))
+        return None
+    try:
+        end = next(index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration:
+        findings.append(Finding(source, 1, "DOC_FRONTMATTER_UNCLOSED", "missing closing ---"))
+        return None
+
+    metadata: dict[str, str] = {}
+    for line_number, raw in enumerate(lines[1:end], start=2):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        if raw.startswith((" ", "\t")) or ":" not in raw:
+            findings.append(
+                Finding(source, line_number, "DOC_FRONTMATTER_NON_SCALAR", "expected a flat key: value field")
+            )
+            continue
+        key, value = (part.strip() for part in raw.split(":", 1))
+        if not key or value.startswith(("[", "{")):
+            findings.append(
+                Finding(source, line_number, "DOC_FRONTMATTER_NON_SCALAR", "expected a flat scalar field")
+            )
+            continue
+        if key in metadata:
+            findings.append(Finding(source, line_number, "DOC_FRONTMATTER_DUPLICATE", f"duplicate field: {key}"))
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        metadata[key] = value
+    return metadata
+
+
+def _profile(path: Path) -> tuple[list[str], list[str]]:
+    if not path.is_file():
+        raise ProfileError(f"profile not found: {path}")
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ProfileError(f"invalid TOML profile: {exc}") from exc
+    documents = data.get("maintained_documents")
+    fields = data.get("required_frontmatter_fields")
+    if not isinstance(documents, list) or not documents or not all(isinstance(item, str) for item in documents):
+        raise ProfileError("maintained_documents must be a non-empty string array")
+    if len(documents) != len(set(documents)):
+        raise ProfileError("maintained_documents contains duplicate paths")
+    if not isinstance(fields, list) or not fields or not all(isinstance(item, str) for item in fields):
+        raise ProfileError("required_frontmatter_fields must be a non-empty string array")
+    if len(fields) != len(set(fields)):
+        raise ProfileError("required_frontmatter_fields contains duplicates")
+    return documents, fields
+
+
+def _validate_metadata(
+    metadata: dict[str, str], source: str, required: list[str], as_of: date, findings: list[Finding]
+) -> None:
+    for field in required:
+        if not metadata.get(field):
+            findings.append(Finding(source, 1, "DOC_FIELD_MISSING", f"required field missing or empty: {field}"))
+
+    status = metadata.get("status")
+    if status not in STATUSES:
+        findings.append(Finding(source, 1, "DOC_STATUS_INVALID", f"invalid lifecycle status: {status!r}"))
+    classification = metadata.get("classification")
+    if classification not in CLASSIFICATIONS:
+        findings.append(
+            Finding(source, 1, "DOC_CLASSIFICATION_INVALID", f"invalid Matryca classification: {classification!r}")
+        )
+
+    parsed: dict[str, date] = {}
+    for field in DATE_FIELDS:
+        raw = metadata.get(field)
+        if not raw:
+            continue
+        try:
+            parsed[field] = date.fromisoformat(raw)
+        except ValueError:
+            findings.append(Finding(source, 1, "DOC_DATE_INVALID", f"{field} is not YYYY-MM-DD: {raw!r}"))
+    if parsed.get("last_verified") != parsed.get("verified") and {"last_verified", "verified"} <= parsed.keys():
+        findings.append(Finding(source, 1, "DOC_DATE_MISMATCH", "last_verified must equal verified"))
+    verified = parsed.get("verified")
+    stale_after = parsed.get("stale_after")
+    if verified is not None and verified > as_of:
+        findings.append(Finding(source, 1, "DOC_VERIFIED_FUTURE", f"verified {verified} is after {as_of}"))
+    if verified is not None and stale_after is not None and stale_after < verified:
+        findings.append(Finding(source, 1, "DOC_STALE_ORDER", "stale_after must not precede verified"))
+    if stale_after is not None and stale_after < as_of:
+        findings.append(Finding(source, 1, "DOC_STALE", f"stale_after {stale_after} is before {as_of}"))
+
+
+def _markdown_links(text: str) -> list[tuple[int, str]]:
+    links: list[tuple[int, str]] = []
+    lines = text.splitlines()
+    skipped = _fenced_lines(lines)
+    for line_number, line in enumerate(lines, start=1):
+        if line_number not in skipped:
+            links.extend((line_number, match.group(1).strip()) for match in MARKDOWN_LINK.finditer(line))
+    return links
+
+
+def _validate_links(path: Path, root: Path, text: str, findings: list[Finding], cache: dict[Path, set[str]]) -> None:
+    source = _relative(path, root)
+    for line_number, raw in _markdown_links(text):
+        target = raw[1:-1] if raw.startswith("<") and raw.endswith(">") else raw
+        parsed = urlsplit(target)
+        if parsed.scheme or parsed.netloc:
+            continue
+        relative = unquote(parsed.path)
+        destination = (path.parent / relative if relative else path).resolve()
+        try:
+            destination.relative_to(root)
+        except ValueError:
+            findings.append(Finding(source, line_number, "DOC_LINK_ESCAPE", f"local link escapes root: {raw}"))
+            continue
+        if not destination.exists():
+            findings.append(Finding(source, line_number, "DOC_LINK_MISSING", f"local target does not exist: {raw}"))
+            continue
+        anchor = unquote(parsed.fragment)
+        if anchor and destination.is_file():
+            anchors = cache.setdefault(destination, _heading_anchors(destination.read_text(encoding="utf-8")))
+            if anchor not in anchors:
+                findings.append(Finding(source, line_number, "DOC_ANCHOR_MISSING", f"local anchor does not exist: {raw}"))
+
+
+def check(root: Path, profile: Path, as_of: date) -> list[Finding]:
+    root = root.resolve()
+    documents, required = _profile(profile)
+    findings: list[Finding] = []
+    canonical: dict[str, list[str]] = {}
+    anchor_cache: dict[Path, set[str]] = {}
+    for relative in documents:
+        path = (root / relative).resolve()
+        try:
+            path.relative_to(root)
+        except ValueError:
+            findings.append(Finding(relative, 1, "DOC_PATH_ESCAPE", "maintained path escapes repository root"))
+            continue
+        if not path.is_file():
+            findings.append(Finding(relative, 1, "DOC_PATH_MISSING", "maintained document is not a file"))
+            continue
+        metadata = _frontmatter(path, root, findings)
+        if metadata is None:
+            continue
+        source = _relative(path, root)
+        _validate_metadata(metadata, source, required, as_of, findings)
+        text = path.read_text(encoding="utf-8")
+        _validate_links(path, root, text, findings, anchor_cache)
+        if metadata.get("classification") == "canonical" and (doc_type := metadata.get("type")):
+            canonical.setdefault(doc_type, []).append(source)
+    for doc_type, sources in canonical.items():
+        if len(sources) > 1:
+            findings.append(
+                Finding(sources[0], 1, "DOC_CANONICAL_DUPLICATE", f"type {doc_type!r} is canonical in: {', '.join(sources)}")
+            )
+    return sorted(findings)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--profile", type=Path, default=ROOT / "docs" / "maintained.toml")
+    parser.add_argument("--as-of-date", required=True, help="deterministic audit date (YYYY-MM-DD)")
+    args = parser.parse_args(argv)
+    try:
+        as_of = date.fromisoformat(args.as_of_date)
+        findings = check(args.root, args.profile, as_of)
+    except (ValueError, ProfileError) as exc:
+        print(f"configuration error: {exc}")
+        return 2
+    for finding in findings:
+        print(finding.render())
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_documentation.py
+++ b/tests/test_check_documentation.py
@@ -1,0 +1,176 @@
+"""Tests for the deterministic maintained-documentation gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_documentation.py"
+SPEC = importlib.util.spec_from_file_location("check_documentation", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+FIELDS = {
+    "type": "Guide",
+    "title": "Guide",
+    "description": "Maintained guide.",
+    "status": "stable",
+    "classification": "active",
+    "audience": "maintainers",
+    "owner": "repository",
+    "authority": "source_repository",
+    "execution_mode": "reviewed",
+    "last_verified": "2026-08-06",
+    "verified": "2026-08-06",
+    "stale_after": "2026-08-20",
+    "okf_profile": "matryca_okf_inspired_quality",
+    "okf_spec_version": "null",
+    "supersedes": "null",
+    "superseded_by": "null",
+}
+
+
+def _profile(root: Path, documents: tuple[str, ...] = ("docs/a.md", "docs/b.md")) -> Path:
+    path = root / "docs" / "maintained.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = ", ".join(f'"{field}"' for field in FIELDS)
+    paths = ", ".join(f'"{document}"' for document in documents)
+    path.write_text(
+        f"required_frontmatter_fields = [{fields}]\nmaintained_documents = [{paths}]\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _document(path: Path, *, body: str = "", **overrides: str | None) -> None:
+    values = FIELDS | {key: value for key, value in overrides.items() if value is not None}
+    for key, value in overrides.items():
+        if value is None:
+            values.pop(key, None)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frontmatter = "\n".join(f"{key}: {value}" for key, value in values.items())
+    path.write_text(f"---\n{frontmatter}\n---\n\n# Guide\n{body}", encoding="utf-8")
+
+
+def _run(root: Path, profile: Path, capsys: pytest.CaptureFixture[str], as_of: str = "2026-08-07") -> tuple[int, str]:
+    code = checker.main(["--root", str(root), "--profile", str(profile), "--as-of-date", as_of])
+    return code, capsys.readouterr().out
+
+
+def test_valid_bundle_and_matryca_anchor_semantics(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    profile = _profile(tmp_path)
+    _document(tmp_path / "docs/a.md", classification="canonical", body="[target](b.md#linked-heading)\n")
+    _document(
+        tmp_path / "docs/b.md",
+        type="Reference",
+        title="Reference",
+        body="# [Linked](elsewhere.md) Heading\n# Linked Heading\n",
+    )
+    (tmp_path / "docs/elsewhere.md").write_text("# Elsewhere\n", encoding="utf-8")
+    code, output = _run(tmp_path, profile, capsys)
+    assert (code, output) == (0, "")
+
+
+def test_missing_file_frontmatter_and_field(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    profile = _profile(tmp_path, ("docs/a.md", "docs/b.md", "docs/missing.md"))
+    _document(tmp_path / "docs/a.md", description=None)
+    (tmp_path / "docs/b.md").write_text("# No metadata\n", encoding="utf-8")
+    code, output = _run(tmp_path, profile, capsys)
+    assert code == 1
+    assert "DOC_FIELD_MISSING" in output
+    assert "DOC_FRONTMATTER_MISSING" in output
+    assert "DOC_PATH_MISSING" in output
+
+
+def test_metadata_lifecycle_and_freshness_failures(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    profile = _profile(tmp_path, ("docs/a.md",))
+    _document(
+        tmp_path / "docs/a.md",
+        status="active",
+        classification="stable",
+        last_verified="2026-08-05",
+        verified="2026-08-08",
+        stale_after="2026-08-04",
+    )
+    code, output = _run(tmp_path, profile, capsys)
+    assert code == 1
+    for finding in (
+        "DOC_STATUS_INVALID",
+        "DOC_CLASSIFICATION_INVALID",
+        "DOC_DATE_MISMATCH",
+        "DOC_VERIFIED_FUTURE",
+        "DOC_STALE_ORDER",
+        "DOC_STALE",
+    ):
+        assert finding in output
+
+
+def test_each_invalid_date_is_reported(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    profile = _profile(tmp_path, ("docs/a.md",))
+    _document(tmp_path / "docs/a.md", last_verified="bad", verified="also-bad", stale_after="never")
+    code, output = _run(tmp_path, profile, capsys)
+    assert code == 1
+    assert output.count("DOC_DATE_INVALID") == 3
+
+
+def test_link_missing_anchor_escape_and_fenced_code(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    profile = _profile(tmp_path)
+    _document(
+        tmp_path / "docs/a.md",
+        classification="canonical",
+        body=(
+            "[missing](missing.md) [anchor](b.md#absent) [escape](../../outside.md)\n"
+            "```md\n[ignored](also-missing.md)\n```\n"
+            "[external](https://example.com)\n"
+        ),
+    )
+    _document(tmp_path / "docs/b.md", type="Reference")
+    code, output = _run(tmp_path, profile, capsys)
+    assert code == 1
+    assert "DOC_LINK_MISSING" in output
+    assert "DOC_ANCHOR_MISSING" in output
+    assert "DOC_LINK_ESCAPE" in output
+    assert "also-missing" not in output
+
+
+def test_duplicate_frontmatter_and_canonical_type(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    profile = _profile(tmp_path)
+    _document(tmp_path / "docs/a.md", classification="canonical")
+    _document(tmp_path / "docs/b.md", classification="canonical")
+    with (tmp_path / "docs/a.md").open("a", encoding="utf-8") as stream:
+        stream.write("\n")
+    text = (tmp_path / "docs/a.md").read_text(encoding="utf-8")
+    (tmp_path / "docs/a.md").write_text(text.replace("title: Guide", "title: Guide\ntitle: Duplicate"), encoding="utf-8")
+    code, output = _run(tmp_path, profile, capsys)
+    assert code == 1
+    assert "DOC_FRONTMATTER_DUPLICATE" in output
+    assert "DOC_CANONICAL_DUPLICATE" in output
+
+
+def test_diagnostics_are_relative_and_sorted(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    profile = _profile(tmp_path)
+    _document(tmp_path / "docs/a.md", status="invalid")
+    _document(tmp_path / "docs/b.md", status="invalid", type="Reference")
+    code, output = _run(tmp_path, profile, capsys)
+    lines = output.splitlines()
+    assert code == 1
+    assert lines == sorted(lines)
+    assert str(tmp_path) not in output
+
+
+@pytest.mark.parametrize(
+    ("as_of", "expected"),
+    [("2026-08-07", 0), ("invalid", 2)],
+)
+def test_cli_exit_codes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], as_of: str, expected: int
+) -> None:
+    profile = _profile(tmp_path, ("docs/a.md",))
+    _document(tmp_path / "docs/a.md")
+    code, _ = _run(tmp_path, profile, capsys, as_of)
+    assert code == expected


### PR DESCRIPTION
## Summary

- add a source-owned `docs/maintained.toml` inventory for the maintained documentation bundle
- add a stdlib-only, deterministic, non-mutating documentation checker
- validate flat scalar frontmatter, lifecycle and Matryca classification, dates and freshness, canonical type uniqueness, safe local links, and heading anchors
- integrate `docs-check` with `make all`, Mypy, contributor guidance, and CI
- document the transition from prose governance to source-side MKQ-3 enforcement

## Matryca / OKF boundary

The checker mirrors the current Matryca Knowledge link and anchor semantics while retaining the richer source-owned metadata contract established in PR #114. This repository remains authoritative and does not claim official OKF conformance.

This PR implements the source-side MKQ-3 gate. MKQ-4 remains pending until the private `logseq-matryca-parser` source profile declares `okf_entry_points` and a content-addressed projection passes against this PR's merged commit.

## Validation

- `UV_CACHE_DIR=/private/tmp/logseq-docs-gate-cache make all`
  - Ruff: passed
  - Mypy: passed (36 source files)
  - vendor-name-check: passed
  - docs-check: passed
  - pytest: 471 passed
  - coverage: 91.09% (threshold 80%)
- focused checker tests: 9 passed
- audit code impact: low; no affected runtime processes
- import-cycle check: 0 cycles
- `git diff --check`: passed
- independent Luna review: no actionable P0-P3 findings
- GitHub Actions run 171: 6/6 checks passed on Python 3.12 and 3.13

## Scope and non-actions

- no parser or graph runtime behavior changed
- no generated Matryca Knowledge projection changed
- pre-existing untracked `.serena/` state was excluded
- clean-checkout CI exposed and the branch removed two links to unversioned local editor rules

Refs #109
