### PR TITLE
ci: make lint a non-mutating verification gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,6 @@ jobs:
 
     - name: Documentation check (non-mutating)
       run: make docs-check
+
+    - name: Verify checkout unchanged
+      run: make verify-clean

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,10 @@ git checkout -b feat/add-html-exporter
 
 ### 4. Code Quality & Linting (Mandatory)
 
-CI runs the same commands as your local environment: `uv sync --all-extras`, then `make lint`, `make check`, `make test`, and `make docs-check`. Before committing, run the full gate:
+CI runs the same non-mutating checks as your local environment: `uv sync
+--all-extras`, then `make lint`, `make check`, `make test`, and
+`make docs-check`. It finishes with `make verify-clean` to prove that no quality
+step changed the submitted checkout. Before committing, run the full local gate:
 
 ```bash
 make all
@@ -170,15 +173,18 @@ snapshot. New contributors should mirror patterns in
 Or run each step individually:
 
 ```bash
-make lint   # Ruff (with auto-fix)
+make lint   # Ruff verification; never rewrites files
 make check  # Mypy on src/, tests/, examples/, and the documentation checker
 make test   # Pytest on tests/
 ```
 
+When you explicitly want Ruff to repair local lint findings, use
+`make lint-fix`, inspect the resulting diff, and rerun `make all`.
+
 Equivalent `uv run` invocations:
 
 ```bash
-uv run ruff check . --fix
+uv run ruff check .
 uv run mypy src/ tests/ examples/ scripts/check_documentation.py
 uv run pytest -v tests/
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: all lint check test build vendor-name-check docs-check
+.PHONY: all lint lint-fix check test build vendor-name-check docs-check verify-clean
 
 all: lint check vendor-name-check docs-check test
 
 lint:
+	uv run ruff check .
+
+lint-fix:
 	uv run ruff check . --fix
 
 check:
@@ -16,6 +19,13 @@ test:
 
 docs-check:
 	uv run python scripts/check_documentation.py --root . --profile docs/maintained.toml --as-of-date $$(date -u +%F)
+
+verify-clean:
+	@status="$$(git status --porcelain)"; \
+	if [ -n "$$status" ]; then \
+		printf '%s\n' "$$status"; \
+		exit 1; \
+	fi
 
 build:
 	uv run python -m nuitka --standalone --onefile src/logseq_matryca_parser/kinetic.py

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -592,8 +592,10 @@ Recursive and character-budget chunkers assume **approximately flat prose**. Log
 ### Quality gate (v1.6.0)
 
 Local and CI parity: `uv sync --all-extras` → `make lint` → `make check` →
-`make test` → `make vendor-name-check`. The test gate enforces **≥80%**
-coverage on `src/logseq_matryca_parser`. Exact totals belong to dated audit
-evidence rather than this maintained architecture contract. Dedicated modules
-include `tests/test_layer_boundary.py`, `tests/test_exceptions.py` and
-`tests/test_extract_changelog.py`.
+`make test` → `make vendor-name-check` → `make docs-check`. These targets are
+non-mutating; CI then runs `make verify-clean` as an explicit checkout-integrity
+assertion. Local lint rewrites remain opt-in through `make lint-fix`. The test
+gate enforces **≥80%** coverage on `src/logseq_matryca_parser`. Exact totals
+belong to dated audit evidence rather than this maintained architecture
+contract. Dedicated modules include `tests/test_layer_boundary.py`,
+`tests/test_exceptions.py` and `tests/test_extract_changelog.py`.

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -289,9 +289,11 @@ Writer provides `mkstemp` + `os.replace`, which protects against partial file re
 
 ### P1.5 — Mutating lint in CI
 
-**Status:** implementation prepared on 2026-08-07; tracked by #101.
+**Status:** implementation published on 2026-08-07 in
+[draft PR #116](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/116);
+tracked by #101.
 
-The delivery branch separates verification-only `lint` from opt-in `lint-fix`,
+PR #116 separates verification-only `lint` from opt-in `lint-fix`,
 keeps `make all` non-mutating, adds a final CI checkout-integrity assertion,
 and protects the target/workflow contract with focused tests. A repository-wide
 `ruff format --check` gate was evaluated and deliberately not activated because

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -8,8 +8,8 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-06
-verified: 2026-08-06
+last_verified: 2026-08-07
+verified: 2026-08-07
 stale_after: 2026-11-04
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -289,9 +289,15 @@ Writer provides `mkstemp` + `os.replace`, which protects against partial file re
 
 ### P1.5 — Mutating lint in CI
 
-**Status:** confirmed; covered by #101.
+**Status:** implementation prepared on 2026-08-07; tracked by #101.
 
-Separate `lint`/`format-check` from `lint-fix`/`format`, add dirty-tree checks, and keep `make all` as a non-mutating gate.
+The delivery branch separates verification-only `lint` from opt-in `lint-fix`,
+keeps `make all` non-mutating, adds a final CI checkout-integrity assertion,
+and protects the target/workflow contract with focused tests. A repository-wide
+`ruff format --check` gate was evaluated and deliberately not activated because
+23 pre-existing files on `main` require a separate mechanical-formatting tranche.
+The finding remains open until the implementation PR is merged and remote CI is
+green.
 
 ### P1.6 — Release artifacts not built once
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -8,8 +8,8 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-06
-verified: 2026-08-06
+last_verified: 2026-08-07
+verified: 2026-08-07
 stale_after: 2027-02-02
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -21,6 +21,11 @@ superseded_by: null
 
 ## 2026-08-07
 
+- Prepared the issue #101 delivery tranche: verification-only `lint`, explicit
+  opt-in `lint-fix`, a non-mutating `make all`, and a final CI
+  checkout-integrity assertion guarded by focused contract tests. A global
+  Ruff formatter gate was measured but deferred because the existing baseline
+  requires a separate 23-file mechanical-formatting change.
 - Added a source-owned maintained-document profile in
   [`docs/maintained.toml`](maintained.toml) and implemented
   [`scripts/check_documentation.py`](../scripts/check_documentation.py) with deterministic

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,8 +21,9 @@ superseded_by: null
 
 ## 2026-08-07
 
-- Prepared the issue #101 delivery tranche: verification-only `lint`, explicit
-  opt-in `lint-fix`, a non-mutating `make all`, and a final CI
+- Published the issue #101 delivery tranche as
+  [draft PR #116](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/116):
+  verification-only `lint`, explicit opt-in `lint-fix`, a non-mutating `make all`, and a final CI
   checkout-integrity assertion guarded by focused contract tests. A global
   Ruff formatter gate was measured but deferred because the existing baseline
   requires a separate 23-file mechanical-formatting change.

--- a/tests/test_quality_gate_contract.py
+++ b/tests/test_quality_gate_contract.py
@@ -1,0 +1,48 @@
+"""Regression tests for the non-mutating Makefile and CI quality contract."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _dry_run(target: str) -> list[str]:
+    result = subprocess.run(
+        ["make", "--no-print-directory", "--dry-run", target],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def test_lint_targets_separate_verification_from_rewrites() -> None:
+    assert _dry_run("lint") == ["uv run ruff check ."]
+    assert _dry_run("lint-fix") == ["uv run ruff check . --fix"]
+
+
+def test_all_uses_only_non_mutating_ruff_targets() -> None:
+    commands = _dry_run("all")
+
+    assert "uv run ruff check ." in commands
+    assert "uv run ruff check . --fix" not in commands
+
+
+def test_ci_finishes_with_clean_checkout_assertion() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    lint = workflow.index("run: make lint")
+    verify_clean = workflow.index("run: make verify-clean")
+
+    assert lint < verify_clean
+    assert verify_clean > workflow.index("run: make docs-check")
+
+
+def test_verify_clean_reports_any_dirty_checkout() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+
+    assert 'status="$$(git status --porcelain)"' in makefile
+    assert "printf '%s\\n' \"$$status\"" in makefile


### PR DESCRIPTION
## Summary

- make `make lint` verification-only and keep repairs opt-in through `make lint-fix`
- keep `make all` non-mutating and add a final CI checkout-integrity assertion
- add focused regression tests for the Makefile and workflow contract
- update contributor, architecture, roadmap, and documentation-history guidance

## Why

CI previously ran `ruff check . --fix`, so a non-conformant submission could be rewritten and still pass. The new flow verifies the submitted checkout without repairing it and fails if any quality step leaves the tree dirty.

## Design boundary

A repository-wide `ruff format --check` gate was evaluated but is not activated in this PR because 23 pre-existing files on `main` require formatting. That mechanical migration should remain a separate tranche; the dirty-tree assertion satisfies the current formatter-or-clean-tree acceptance criterion without widening this change.

## Validation

- `make all`: 475 passed, 91.09% coverage
- Ruff, Mypy, vendor-name, and deterministic documentation gates passed
- focused quality-contract tests: 4 passed
- audit-code cycle check: 0 cycles
- negative `make verify-clean` probe correctly failed and reported the dirty checkout

Closes #101
