### PR TITLE
feat(graph): surface deterministic title collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `collect_graph_diagnostics()` for broken block references; vault-relative
   path enforcement; and pure JSON CLI output through `scan --diagnostics-json`
   ([#110](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/110)).
+- **Graph title-collision contract** — permissive loading now exposes stable
+  diagnostics for derived-title, frontmatter-title, and alias collisions while
+  preserving the existing deterministic winner and no-ghost invariants;
+  `strict_title_collisions=True` raises `PageTitleCollisionError`, and KINETIC
+  renders all findings with `scan --diagnostics`
+  ([#102](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/102)).
 - **Documentation system guide** — [`docs/DOCUMENTATION_SYSTEM.md`](docs/DOCUMENTATION_SYSTEM.md) explains source authority, maintained versus historical surfaces, metadata, freshness, validation, the Matryca Knowledge projection workflow, and the repository's documentation evolution.
 - **Synapse RAG example** — [`examples/run_synapse_rag.py`](examples/run_synapse_rag.py) demonstrates all four `SynapseAdapter` methods (`to_langchain_documents`, `to_llamaindex_nodes`, `to_context_enriched_chunks`, `_expand_macros_and_embeds`) plus table-driven embed expansion edge cases.
 - **Embed expansion edge-case tests** — `TestEmbedExpansionEdgeCases` in [`tests/test_synapse.py`](tests/test_synapse.py) covers cycles, missing targets, and happy-path for both `{{embed [[Page]]}}` and `{{embed ((uuid))}}` (closes [#71](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/71)).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -375,6 +375,18 @@ This keeps **global indexes consistent** without rebuilding the entire graph —
 
 **`StackMachineParser(..., strict_refs=False)`** (default) resolves same-page `((uuid))` block refs leniently. When **`strict_refs=True`**, unresolved refs raise **`BlockReferenceError`** at parse time — complementary to **`LogseqGraph.get_broken_references()`**, which scans the loaded graph post-hoc. **`LogseqGraph.load_directory(..., strict_refs=True)`** runs **`raise_if_broken_references()`** after indexing to fail fast on cross-page broken `((uuid))` refs.
 
+#### Title-collision policy (`strict_title_collisions`)
+
+Full-directory loading sorts physical files by resolved path before indexing.
+When canonical titles collide, the later path remains the historical winner.
+Alias insertion retains its historical remap policy: the alias owner replaces
+the previous key. Permissive loading exposes every conflict as
+`graph.page_title_collision`, including vault-relative winner and loser paths
+and a `derived_title`, `frontmatter_title`, or `alias` reason. Loser nodes and
+backlinks are not registered. Set
+**`LogseqGraph.load_directory(..., strict_title_collisions=True)`** to raise the
+typed **`PageTitleCollisionError`** instead of accepting the winner.
+
 #### Canonical page iteration (`iter_canonical_pages`, `page_for_node`)
 
 **`graph.pages`** may contain multiple keys (filename title, **`title::`** override, **`alias::`** keys) pointing at the same **`LogseqPage`** instance. Exporters and graph scans must not double-count alias keys. **`iter_canonical_pages()`** yields one page per unique object identity; **`page_for_node(node)`** returns the owning page for a block UUID. **KINETIC**, **SYNAPSE**, and **LENS** use canonical iteration for export and statistics (v1.4.0).

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -132,7 +132,10 @@ if broken:
 For stable machine-readable findings, use `collect_graph_diagnostics(graph)` or
 `matryca-parse scan /path/to/graph --diagnostics-json`. The JSON command emits
 only the diagnostic array, uses vault-relative paths, and exits `1` when an
-error finding exists. See the [diagnostics contract](reference/DIAGNOSTICS.md).
+error finding exists. Use `--diagnostics` for the human table. For vaults that
+must reject ambiguous page identities, pass `strict_title_collisions=True` to
+`LogseqGraph.load_directory`. See the
+[diagnostics contract](reference/DIAGNOSTICS.md).
 
 **CLI tip:** run `matryca-parse export` after `load_directory` — KINETIC scans canonical pages internally (since v1.4.0).
 

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -277,7 +277,9 @@ Interpretation: before rename there is a backlink; after `Target → Renamed`, t
 
 ### P1.3 — Title/alias collisions can hide a page
 
-**Status:** implementation prepared in the fourth stacked tranche for #102.
+**Status:** implementation published in
+[draft PR #120](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/120),
+stacked on #119, for #102.
 
 Pages are stored in a title-keyed dict, and aliases can remap canonical keys. Behavior is deterministic and the registry avoids many ghost nodes, but visibility loss is still primarily a logging concern.
 

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -277,11 +277,14 @@ Interpretation: before rename there is a backlink; after `Target → Renamed`, t
 
 ### P1.3 — Title/alias collisions can hide a page
 
-**Status:** confirmed and already covered by #102.
+**Status:** implementation prepared in the fourth stacked tranche for #102.
 
 Pages are stored in a title-keyed dict, and aliases can remap canonical keys. Behavior is deterministic and the registry avoids many ghost nodes, but visibility loss is still primarily a logging concern.
 
-**Action:** do not open a new initiative. Implement structured diagnostics, both winner paths, stable winner policy, and strict mode as already requested by #102.
+**Delivery evidence:** the fourth stacked tranche preserves the current winner,
+records stable structured diagnostics with both vault-relative paths and a
+reason, adds a typed opt-in strict mode, and covers derived, frontmatter, and
+alias collisions without ghost nodes.
 
 ### P1.4 — Writer, watcher, and readers do not share an atomic snapshot
 
@@ -321,8 +324,8 @@ Pre-flight, PyPI build, and GitHub release do not necessarily consume the same i
 - #110: structured diagnostics; stable payload, broken-reference producer, path
   policy, and JSON CLI are implemented in
   [draft PR #119](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/119),
-  the third stacked tranche, while
-  collision, parser-recovery, filesystem, and reload producers remain;
+  the third stacked tranche; the collision producer is prepared in the fourth
+  tranche, while parser-recovery, filesystem, and reload producers remain;
 - #111: 1k/10k page benchmarks and RSS/p95 budgets;
 - #108: incremental parser phase extraction only after #104 and P0.1 fix.
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,7 +21,8 @@ superseded_by: null
 
 ## 2026-08-07
 
-- Prepared the fourth stacked tranche for issue #102: stable structured
+- Published [draft PR #120](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/120),
+  stacked on #119, as the fourth tranche for issue #102: stable structured
   diagnostics for derived-title, frontmatter-title, and alias collisions;
   documented deterministic winner policy; typed opt-in strict rejection;
   human and JSON CLI rendering; and no-ghost regression coverage.

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,6 +21,10 @@ superseded_by: null
 
 ## 2026-08-07
 
+- Prepared the fourth stacked tranche for issue #102: stable structured
+  diagnostics for derived-title, frontmatter-title, and alias collisions;
+  documented deterministic winner policy; typed opt-in strict rejection;
+  human and JSON CLI rendering; and no-ghost regression coverage.
 - Published [draft PR #119](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/119),
   stacked on #118, as the third tranche for issue #110: a stable immutable
   diagnostic schema and code enum, deterministic broken-reference collection,

--- a/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
+++ b/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
@@ -59,7 +59,7 @@ the newly filed parser P0.
 | #96 | Close completed | Shipped | Current symmetric empty replacement is table-tested |
 | #97 | Close as duplicate of #89 | — | Orphan exclusion is a subset of #89 |
 | #101 | Keep, priority | Wave 1 | CI lint remains mutating |
-| #102 | Implementation in next stacked PR | Wave 2 | Stable collision diagnostics, preserved winner policy, typed strict mode, CLI rendering, and no-ghost tests implemented |
+| #102 | Implementation in [PR #120](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/120) | Wave 2 | Stable collision diagnostics, preserved winner policy, typed strict mode, CLI rendering, and no-ghost tests; pending merge |
 | #103 | Expand | Wave 0/3 | Add rename/backlink cold-load equivalence |
 | #104 | Expand | Wave 0/3 | Add arbitrary-depth parser regression matrix |
 | #105 | Keep | Wave 4 | Immutable build-once release lineage remains absent |
@@ -67,7 +67,7 @@ the newly filed parser P0.
 | #107 | Keep | Wave 1 | Typing marker and stability contract remain absent |
 | #108 | Keep blocked by prerequisites | Wave 6 | Begin only after deep parser fix and #104 corpus |
 | #109 | Expand to MKQ-4 | Wave 1 | Bundle, metadata, lifecycle, links and deterministic source CI |
-| #110 | Foundation in [PR #119](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/119) | Wave 2 | Stable payload, broken-reference code, JSON CLI, and path policy implemented; collision producer prepared next, while parser-recovery, filesystem, and reload producers remain |
+| #110 | Foundation in [PR #119](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/119) | Wave 2 | Stable payload, broken-reference code, JSON CLI, and path policy implemented; collision producer in PR #120, while parser-recovery, filesystem, and reload producers remain |
 | #111 | Expand | Wave 5 | Include #87 seed and incremental/cold-load correctness budgets |
 | #113 | Implementation in [PR #118](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/118) | Wave 0 | Iterative leaf-to-root rebuild and depth/family regression matrix; pending merge |
 

--- a/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
+++ b/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
@@ -59,7 +59,7 @@ the newly filed parser P0.
 | #96 | Close completed | Shipped | Current symmetric empty replacement is table-tested |
 | #97 | Close as duplicate of #89 | — | Orphan exclusion is a subset of #89 |
 | #101 | Keep, priority | Wave 1 | CI lint remains mutating |
-| #102 | Keep | Wave 2 | Collision diagnostics and strict mode remain absent |
+| #102 | Implementation in next stacked PR | Wave 2 | Stable collision diagnostics, preserved winner policy, typed strict mode, CLI rendering, and no-ghost tests implemented |
 | #103 | Expand | Wave 0/3 | Add rename/backlink cold-load equivalence |
 | #104 | Expand | Wave 0/3 | Add arbitrary-depth parser regression matrix |
 | #105 | Keep | Wave 4 | Immutable build-once release lineage remains absent |
@@ -67,7 +67,7 @@ the newly filed parser P0.
 | #107 | Keep | Wave 1 | Typing marker and stability contract remain absent |
 | #108 | Keep blocked by prerequisites | Wave 6 | Begin only after deep parser fix and #104 corpus |
 | #109 | Expand to MKQ-4 | Wave 1 | Bundle, metadata, lifecycle, links and deterministic source CI |
-| #110 | Foundation in [PR #119](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/119) | Wave 2 | Stable payload, broken-reference code, JSON CLI, and path policy implemented; title-collision, parser-recovery, filesystem, and reload producers remain |
+| #110 | Foundation in [PR #119](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/119) | Wave 2 | Stable payload, broken-reference code, JSON CLI, and path policy implemented; collision producer prepared next, while parser-recovery, filesystem, and reload producers remain |
 | #111 | Expand | Wave 5 | Include #87 seed and incremental/cold-load correctness budgets |
 | #113 | Implementation in [PR #118](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/118) | Wave 0 | Iterative leaf-to-root rebuild and depth/family regression matrix; pending merge |
 

--- a/docs/reference/API_STABILITY.md
+++ b/docs/reference/API_STABILITY.md
@@ -42,13 +42,17 @@ minor release unless a security issue makes that unsafe.
 | Parser | `StackMachineParser`, `LogosParser`, `LogseqPage`, `LogseqNode`, `LogosNode`, `ASTVisitor` |
 | Graph | `LogseqGraph` |
 | Diagnostics | `Diagnostic`, `DiagnosticCode`, `DiagnosticSeverity`, `collect_graph_diagnostics` |
-| Errors | `LogseqParserError`, `LogseqIndentationError`, `BlockReferenceError` |
+| Errors | `LogseqParserError`, `LogseqIndentationError`, `BlockReferenceError`, `PageTitleCollisionError` |
 | Markdown | `serialize_logseq_page`, `write_logseq_page`, `format_logseq_page_properties`, `format_logseq_block_property_lines` |
 | Paths | `discover_graph_files`, `derive_page_title_from_source_path`, `page_title_to_filename`, `filename_to_page_title`, `page_title_to_relative_path`, `encode_page_title_segment`, `decode_page_title_segment`, `is_excluded_graph_path` |
 
 The exact package-root export manifest and the signatures of the parser and
 graph entry points are regression-tested. Adding a new stable symbol requires
 updating this table and those tests in the same PR.
+
+`LogseqGraph.load_directory` accepts keyword-only `strict_refs=False` and
+`strict_title_collisions=False`. Both strict modes are opt-in, preserving the
+permissive default.
 
 Diagnostic code compatibility, serialization, and path-safety rules are defined
 in the [structured diagnostics contract](DIAGNOSTICS.md).

--- a/docs/reference/DIAGNOSTICS.md
+++ b/docs/reference/DIAGNOSTICS.md
@@ -45,6 +45,12 @@ paths that cannot be proven relative to the selected vault.
 | Code | Severity | Meaning |
 |---|---|---|
 | `graph.broken_block_reference` | `error` | A block contains a `((uuid))` reference absent from the loaded graph |
+| `graph.page_title_collision` | `error` | Two physical pages compete for the same canonical or alias index key |
+
+Title-collision context contains `title`, `winner_path`, `loser_path`, and
+`reason`. The stable reasons are `derived_title`, `frontmatter_title`, and
+`alias`. Paths remain vault-relative or use the literal `<unavailable>` when
+containment cannot be proven.
 
 Codes and field meanings are stable package-root API. New codes may be added in
 minor releases. Removing a code or changing its meaning requires the same
@@ -64,15 +70,29 @@ for diagnostic in collect_graph_diagnostics(graph):
 Collection is observational: it does not mutate graph state or replace
 `get_broken_references()` and `raise_if_broken_references()`.
 
+Permissive graph loading retains the historical winner and exposes collision
+diagnostics through `graph.index_diagnostics`. To reject collisions instead:
+
+```python
+from logseq_matryca_parser import LogseqGraph, PageTitleCollisionError
+
+try:
+    LogseqGraph.load_directory("/path/to/graph", strict_title_collisions=True)
+except PageTitleCollisionError as error:
+    for diagnostic in error.diagnostics:
+        print(diagnostic.context["winner_path"], diagnostic.context["loser_path"])
+```
+
 ## CLI rendering and escalation
 
-- `matryca-parse scan GRAPH --broken-refs` renders the human Rich table.
+- `matryca-parse scan GRAPH --diagnostics` renders all findings in a human Rich
+  table; `--broken-refs` retains the focused legacy table.
 - `matryca-parse scan GRAPH --diagnostics-json` writes only a JSON array to
   standard output, making it safe to pipe into automation.
-- Both diagnostic flags opt into error escalation: exit status is `1` when an
+- The diagnostic flags opt into error escalation: exit status is `1` when an
   error diagnostic is present and `0` otherwise.
 - A plain `scan` remains informational and does not escalate findings.
 
-Future title-collision, parser-recovery, filesystem, and reload diagnostics must
+Future parser-recovery, filesystem, and reload diagnostics must
 reuse this payload and path policy. Each producer requires code/context tests
 and both output forms where it is exposed through the CLI.

--- a/src/logseq_matryca_parser/__init__.py
+++ b/src/logseq_matryca_parser/__init__.py
@@ -8,7 +8,12 @@ from ._version import __version__
 from .agent_press import SessionAliasRegistry
 from .agent_writer import LogseqConfigReader, logseq_agent_write
 from .diagnostics import Diagnostic, DiagnosticCode, DiagnosticSeverity, collect_graph_diagnostics
-from .exceptions import BlockReferenceError, LogseqIndentationError, LogseqParserError
+from .exceptions import (
+    BlockReferenceError,
+    LogseqIndentationError,
+    LogseqParserError,
+    PageTitleCollisionError,
+)
 from .forge import (
     FlatListForgeVisitor,
     ForgeExporter,
@@ -79,6 +84,7 @@ __all__ = [
     "MarkdownForgeVisitor",
     "ObsidianForgeVisitor",
     "PageRegistry",
+    "PageTitleCollisionError",
     "SessionAliasRegistry",
     "SovereignNotePackage",
     "StackMachineParser",

--- a/src/logseq_matryca_parser/diagnostics.py
+++ b/src/logseq_matryca_parser/diagnostics.py
@@ -25,6 +25,7 @@ class DiagnosticCode(StrEnum):
     """Stable diagnostic codes currently emitted by the public API."""
 
     GRAPH_BROKEN_BLOCK_REFERENCE = "graph.broken_block_reference"
+    GRAPH_PAGE_TITLE_COLLISION = "graph.page_title_collision"
 
 
 @dataclass(frozen=True)
@@ -90,7 +91,7 @@ def _vault_relative_source(graph_path: Path, source_path: str | None) -> str | N
 
 def collect_graph_diagnostics(graph: LogseqGraph) -> list[Diagnostic]:
     """Collect deterministic graph diagnostics without changing graph behavior."""
-    diagnostics: list[Diagnostic] = []
+    diagnostics = list(graph.index_diagnostics)
     for node in graph.get_broken_references():
         page = graph.page_for_node(node)
         source_path = _vault_relative_source(graph.graph_path, node.source_path)

--- a/src/logseq_matryca_parser/exceptions.py
+++ b/src/logseq_matryca_parser/exceptions.py
@@ -1,5 +1,11 @@
 """Domain-specific parser exceptions."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from logseq_matryca_parser.diagnostics import Diagnostic
+
 
 class LogseqParserError(Exception):
     """Base exception for parser failures."""
@@ -11,6 +17,22 @@ class LogseqIndentationError(LogseqParserError):
 
 class BlockReferenceError(LogseqParserError):
     """Raised when a block reference cannot be resolved."""
+
+
+class PageTitleCollisionError(LogseqParserError):
+    """Raised when strict graph loading encounters one or more title collisions."""
+
+    def __init__(self, diagnostics: Sequence[Diagnostic]) -> None:
+        self.diagnostics = tuple(diagnostics)
+        if not self.diagnostics:
+            raise ValueError("PageTitleCollisionError requires at least one diagnostic")
+        first = self.diagnostics[0]
+        winner = first.context["winner_path"]
+        loser = first.context["loser_path"]
+        super().__init__(
+            f"Page title collision for {first.context['title']!r}: "
+            f"winner={winner}, loser={loser}"
+        )
 
 
 class SessionAliasRegistryError(Exception):

--- a/src/logseq_matryca_parser/graph.py
+++ b/src/logseq_matryca_parser/graph.py
@@ -14,7 +14,13 @@ from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
-from logseq_matryca_parser.exceptions import BlockReferenceError
+from logseq_matryca_parser.diagnostics import (
+    Diagnostic,
+    DiagnosticCode,
+    DiagnosticSeverity,
+    _vault_relative_source,
+)
+from logseq_matryca_parser.exceptions import BlockReferenceError, PageTitleCollisionError
 from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
 from logseq_matryca_parser.logos_parser import StackMachineParser
 from logseq_matryca_parser.logseq_markdown import _normalize_logseq_ref_token
@@ -274,7 +280,44 @@ def _apply_title_override(page: LogseqPage) -> tuple[LogseqPage, str | None]:
     return page.model_copy(update={"title": custom}), page.title
 
 
-def _enrich_pages_index(pages: dict[str, LogseqPage]) -> None:
+def _collision_diagnostic(
+    *,
+    graph_path: Path,
+    title: str,
+    winner: LogseqPage,
+    loser: LogseqPage,
+    reason: str,
+) -> Diagnostic:
+    winner_path = _vault_relative_source(graph_path, winner.source_path)
+    loser_path = _vault_relative_source(graph_path, loser.source_path)
+    return Diagnostic(
+        code=DiagnosticCode.GRAPH_PAGE_TITLE_COLLISION,
+        severity=DiagnosticSeverity.ERROR,
+        source_path=winner_path,
+        message=f"Page title {title!r} maps to more than one source",
+        context={
+            "loser_path": loser_path or "<unavailable>",
+            "reason": reason,
+            "title": title,
+            "winner_path": winner_path or "<unavailable>",
+        },
+    )
+
+
+def _collision_reason(*pages: LogseqPage) -> str:
+    for page in pages:
+        raw_title = page.properties.get("title")
+        if isinstance(raw_title, str) and raw_title.strip() == page.title:
+            return "frontmatter_title"
+    return "derived_title"
+
+
+def _enrich_pages_index(
+    pages: dict[str, LogseqPage],
+    *,
+    graph_path: Path | None = None,
+    diagnostics: list[Diagnostic] | None = None,
+) -> None:
     """Apply ``title::`` overrides and inject alias keys before backlink indexing."""
     snapshot = sorted(pages.items(), key=lambda item: item[1].source_path or "")
     seen_paths: set[str] = set()
@@ -293,6 +336,16 @@ def _enrich_pages_index(pages: dict[str, LogseqPage]) -> None:
         new_key = updated.title
         existing = pages.get(new_key)
         if existing is not None and existing.source_path != updated.source_path:
+            if graph_path is not None and diagnostics is not None:
+                diagnostics.append(
+                    _collision_diagnostic(
+                        graph_path=graph_path,
+                        title=new_key,
+                        winner=existing,
+                        loser=updated,
+                        reason="frontmatter_title",
+                    )
+                )
             logger.debug(
                 "pages index: title override skipped, %r already maps to another page",
                 new_key,
@@ -312,6 +365,16 @@ def _enrich_pages_index(pages: dict[str, LogseqPage]) -> None:
             if alias == page.title:
                 continue
             if alias in pages and pages[alias] is not page:
+                if graph_path is not None and diagnostics is not None:
+                    diagnostics.append(
+                        _collision_diagnostic(
+                            graph_path=graph_path,
+                            title=alias,
+                            winner=page,
+                            loser=pages[alias],
+                            reason="alias",
+                        )
+                    )
                 logger.debug("pages index: alias %r collision, remapping", alias)
             pages[alias] = page
 
@@ -409,6 +472,7 @@ class LogseqGraph(BaseModel):
     _node_registry: dict[str, LogseqNode] = PrivateAttr(default_factory=dict)
     _backlink_registry: dict[str, list[str]] = PrivateAttr(default_factory=dict)
     _lower_title_map: dict[str, str] = PrivateAttr(default_factory=dict)
+    _index_diagnostics: tuple[Diagnostic, ...] = PrivateAttr(default_factory=tuple)
 
     def __init__(
         self,
@@ -418,6 +482,7 @@ class LogseqGraph(BaseModel):
         node_registry: dict[str, LogseqNode] | None = None,
         backlink_registry: dict[str, list[str]] | None = None,
         lower_title_map: dict[str, str] | None = None,
+        diagnostics: list[Diagnostic] | None = None,
     ) -> None:
         super().__init__(graph_path=graph_path, pages=pages)
         self._node_registry = dict(node_registry) if node_registry is not None else {}
@@ -429,17 +494,27 @@ class LogseqGraph(BaseModel):
             if lower_title_map is not None
             else _build_lower_title_map(pages)
         )
+        self._index_diagnostics = tuple(diagnostics or ())
 
     @classmethod
-    def load_directory(cls, graph_path: Path, *, strict_refs: bool = False) -> LogseqGraph:
+    def load_directory(
+        cls,
+        graph_path: Path,
+        *,
+        strict_refs: bool = False,
+        strict_title_collisions: bool = False,
+    ) -> LogseqGraph:
         """Discover markdown under ``pages/`` and ``journals/``, parse concurrently, build indexes.
 
         When ``strict_refs`` is True, raise :class:`BlockReferenceError` if any block reference
         in the vault cannot be resolved against the loaded node registry (cross-page validation).
+        When ``strict_title_collisions`` is True, raise :class:`PageTitleCollisionError` instead
+        of accepting the historical deterministic winner for an ambiguous title or alias.
         """
         resolved = graph_path.expanduser().resolve()
         files = discover_graph_files(resolved)
         pages: dict[str, LogseqPage] = {}
+        diagnostics: list[Diagnostic] = []
         node_registry: dict[str, LogseqNode] = {}
 
         if not files:
@@ -468,9 +543,20 @@ class LogseqGraph(BaseModel):
 
         path_page_pairs.sort(key=lambda item: str(item[0].resolve()))
         for _path, page in path_page_pairs:
+            existing = pages.get(page.title)
+            if existing is not None and existing.source_path != page.source_path:
+                diagnostics.append(
+                    _collision_diagnostic(
+                        graph_path=resolved,
+                        title=page.title,
+                        winner=page,
+                        loser=existing,
+                        reason=_collision_reason(page, existing),
+                    )
+                )
             pages[page.title] = page
 
-        _enrich_pages_index(pages)
+        _enrich_pages_index(pages, graph_path=resolved, diagnostics=diagnostics)
         node_registry = _build_node_registry_from_pages(pages)
         backlink_registry = _build_backlink_registry(pages)
         lower_title_map = _build_lower_title_map(pages)
@@ -486,7 +572,10 @@ class LogseqGraph(BaseModel):
             node_registry=node_registry,
             backlink_registry=backlink_registry,
             lower_title_map=lower_title_map,
+            diagnostics=diagnostics,
         )
+        if strict_title_collisions and diagnostics:
+            raise PageTitleCollisionError(diagnostics)
         if strict_refs:
             graph.raise_if_broken_references()
         return graph
@@ -508,6 +597,11 @@ class LogseqGraph(BaseModel):
     def iter_canonical_pages(self) -> Iterator[LogseqPage]:
         """Yield each physical page once (dedupe ``pages`` alias keys)."""
         yield from iter_canonical_pages_from_dict(self.pages)
+
+    @property
+    def index_diagnostics(self) -> tuple[Diagnostic, ...]:
+        """Return immutable diagnostics produced while building the graph index."""
+        return self._index_diagnostics
 
     def iter_attached_nodes(self) -> Iterator[LogseqNode]:
         """Yield registry nodes that still belong to an indexed page (no collision ghosts)."""

--- a/src/logseq_matryca_parser/kinetic_commands.py
+++ b/src/logseq_matryca_parser/kinetic_commands.py
@@ -11,7 +11,11 @@ import typer
 from rich.table import Table
 
 from logseq_matryca_parser import logseq_agent_write
-from logseq_matryca_parser.diagnostics import Diagnostic, collect_graph_diagnostics
+from logseq_matryca_parser.diagnostics import (
+    Diagnostic,
+    DiagnosticCode,
+    collect_graph_diagnostics,
+)
 from logseq_matryca_parser.kinetic import (
     _build_official_logseq_demo_pages,
     _iter_nodes,
@@ -60,6 +64,24 @@ def _build_broken_references_table(diagnostics: list[Diagnostic]) -> Table:
     return table
 
 
+def _build_diagnostics_table(diagnostics: list[Diagnostic]) -> Table:
+    table = Table(title="Graph Diagnostics")
+    table.add_column("Severity", style="bold red")
+    table.add_column("Code", style="cyan", no_wrap=True)
+    table.add_column("Source", style="magenta")
+    table.add_column("Line", justify="right")
+    table.add_column("Message")
+    for diagnostic in diagnostics:
+        table.add_row(
+            diagnostic.severity.value,
+            diagnostic.code,
+            diagnostic.source_path or "<unknown>",
+            str(diagnostic.line or ""),
+            diagnostic.message,
+        )
+    return table
+
+
 def _build_deep_stats_tables(stats: dict[str, Any]) -> tuple[Table, Table, Table]:
     overview_table = Table(title="LENS Deep Statistics")
     overview_table.add_column("Metric", style="cyan")
@@ -100,6 +122,11 @@ def scan(
         "--diagnostics-json",
         help="Print structured diagnostics as JSON and exit 1 when errors are found.",
     ),
+    diagnostics_human: bool = typer.Option(
+        False,
+        "--diagnostics",
+        help="Print structured diagnostics as a human-readable table.",
+    ),
 ) -> None:
     """Scan a graph and print aggregate parsing statistics."""
     resolved = _resolve_graph_path(ctx, graph_path)
@@ -115,7 +142,11 @@ def scan(
         console.print("[yellow]No Markdown files found under pages/ or journals/.[/]")
         raise typer.Exit(code=0)
 
-    diagnostics = collect_graph_diagnostics(graph) if broken_refs or diagnostics_json else []
+    diagnostics = (
+        collect_graph_diagnostics(graph)
+        if broken_refs or diagnostics_json or diagnostics_human
+        else []
+    )
 
     if diagnostics_json:
         typer.echo(json.dumps([item.to_dict() for item in diagnostics], indent=2, sort_keys=True))
@@ -123,13 +154,26 @@ def scan(
 
     console.print(_build_stats_table(pages))
 
+    if diagnostics_human:
+        if diagnostics:
+            console.print("")
+            console.print(_build_diagnostics_table(diagnostics))
+        else:
+            console.print("[green]No graph diagnostics found.[/]")
+        raise typer.Exit(code=1 if diagnostics else 0)
+
     if broken_refs:
-        if not diagnostics:
+        broken_diagnostics = [
+            item
+            for item in diagnostics
+            if item.code == DiagnosticCode.GRAPH_BROKEN_BLOCK_REFERENCE
+        ]
+        if not broken_diagnostics:
             console.print("[green]No unresolved block references found.[/]")
             raise typer.Exit(code=0)
 
         console.print("")
-        console.print(_build_broken_references_table(diagnostics))
+        console.print(_build_broken_references_table(broken_diagnostics))
         raise typer.Exit(code=1)
 
 

--- a/tests/test_graph_collisions.py
+++ b/tests/test_graph_collisions.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from logseq_matryca_parser import (
+    Diagnostic,
+    DiagnosticCode,
+    LogseqGraph,
+    PageTitleCollisionError,
+    collect_graph_diagnostics,
+)
+from logseq_matryca_parser.kinetic import app
+
+runner = CliRunner()
+
+
+def _collision_diagnostics(graph: LogseqGraph) -> list[Diagnostic]:
+    return [
+        item
+        for item in collect_graph_diagnostics(graph)
+        if item.code == DiagnosticCode.GRAPH_PAGE_TITLE_COLLISION
+    ]
+
+
+def test_pages_journals_collision_preserves_winner_and_reports_paths(tmp_path: Path) -> None:
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    journals = graph_root / "journals"
+    pages.mkdir(parents=True)
+    journals.mkdir(parents=True)
+    (pages / "Daily.md").write_text("- pages winner\n", encoding="utf-8")
+    (journals / "Daily.md").write_text("- journals loser\n", encoding="utf-8")
+
+    graph = LogseqGraph.load_directory(graph_root)
+    diagnostics = _collision_diagnostics(graph)
+
+    assert graph.pages["Daily"].source_path == str((pages / "Daily.md").resolve())
+    assert len(diagnostics) == 1
+    diagnostic = diagnostics[0]
+    assert diagnostic.context == {
+        "loser_path": "journals/Daily.md",
+        "reason": "derived_title",
+        "title": "Daily",
+        "winner_path": "pages/Daily.md",
+    }
+    assert graph.search_content("journals loser") == []
+    assert len(graph.search_content("pages winner")) == 1
+
+
+def test_frontmatter_collision_reports_reason_and_has_no_ghost_nodes(tmp_path: Path) -> None:
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    (pages / "A.md").write_text("title:: Shared\n\n- loser-A\n", encoding="utf-8")
+    (pages / "B.md").write_text("title:: Shared\n\n- winner-B\n", encoding="utf-8")
+
+    graph = LogseqGraph.load_directory(graph_root)
+    diagnostic = _collision_diagnostics(graph)[0]
+
+    assert diagnostic.context["reason"] == "frontmatter_title"
+    assert diagnostic.context["winner_path"] == "pages/B.md"
+    assert diagnostic.context["loser_path"] == "pages/A.md"
+    assert graph.search_content("loser-A") == []
+    assert len(graph.search_content("winner-B")) == 1
+    assert all(graph.page_for_node(node) is not None for node in graph.iter_attached_nodes())
+
+
+def test_alias_collision_preserves_existing_remap_policy_and_reports_it(tmp_path: Path) -> None:
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    (pages / "A.md").write_text("alias:: B\n\n- alias winner\n", encoding="utf-8")
+    (pages / "B.md").write_text("- canonical loser\n", encoding="utf-8")
+
+    graph = LogseqGraph.load_directory(graph_root)
+    diagnostic = _collision_diagnostics(graph)[0]
+
+    assert graph.pages["B"].source_path == str((pages / "A.md").resolve())
+    assert diagnostic.context["reason"] == "alias"
+    assert diagnostic.context["winner_path"] == "pages/A.md"
+    assert diagnostic.context["loser_path"] == "pages/B.md"
+    assert graph.search_content("canonical loser") == []
+
+
+def test_strict_title_collision_raises_typed_error_with_relative_paths(tmp_path: Path) -> None:
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    journals = graph_root / "journals"
+    pages.mkdir(parents=True)
+    journals.mkdir(parents=True)
+    (pages / "Daily.md").write_text("- pages\n", encoding="utf-8")
+    (journals / "Daily.md").write_text("- journals\n", encoding="utf-8")
+
+    with pytest.raises(PageTitleCollisionError) as raised:
+        LogseqGraph.load_directory(graph_root, strict_title_collisions=True)
+
+    assert raised.value.diagnostics[0].code == DiagnosticCode.GRAPH_PAGE_TITLE_COLLISION
+    assert "pages/Daily.md" in str(raised.value)
+    assert "journals/Daily.md" in str(raised.value)
+    assert str(tmp_path) not in str(raised.value)
+
+
+def test_collision_diagnostics_render_as_json_and_human_table(tmp_path: Path) -> None:
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    journals = graph_root / "journals"
+    pages.mkdir(parents=True)
+    journals.mkdir(parents=True)
+    (pages / "Daily.md").write_text("- pages\n", encoding="utf-8")
+    (journals / "Daily.md").write_text("- journals\n", encoding="utf-8")
+
+    json_result = runner.invoke(app, ["scan", str(graph_root), "--diagnostics-json"])
+    human_result = runner.invoke(app, ["scan", str(graph_root), "--diagnostics"])
+    broken_refs_result = runner.invoke(app, ["scan", str(graph_root), "--broken-refs"])
+
+    assert json_result.exit_code == 1
+    payload = json.loads(json_result.output)
+    assert payload[0]["code"] == "graph.page_title_collision"
+    assert str(tmp_path) not in json_result.output
+    assert human_result.exit_code == 1
+    assert "Graph Diagnostics" in human_result.output
+    assert "graph.page_title_collision" in human_result.output
+    assert broken_refs_result.exit_code == 0
+    assert "No unresolved block references" in broken_refs_result.output

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -28,6 +28,7 @@ EXPECTED_ROOT_EXPORTS = {
     "MarkdownForgeVisitor",
     "ObsidianForgeVisitor",
     "PageRegistry",
+    "PageTitleCollisionError",
     "SessionAliasRegistry",
     "SovereignNotePackage",
     "StackMachineParser",
@@ -73,6 +74,15 @@ def test_stable_parser_signature() -> None:
 def test_stable_graph_loader_signature() -> None:
     signature = inspect.signature(package.LogseqGraph.load_directory)
 
-    assert tuple(signature.parameters) == ("graph_path", "strict_refs")
+    assert tuple(signature.parameters) == (
+        "graph_path",
+        "strict_refs",
+        "strict_title_collisions",
+    )
     assert signature.parameters["strict_refs"].kind is inspect.Parameter.KEYWORD_ONLY
     assert signature.parameters["strict_refs"].default is False
+    assert (
+        signature.parameters["strict_title_collisions"].kind
+        is inspect.Parameter.KEYWORD_ONLY
+    )
+    assert signature.parameters["strict_title_collisions"].default is False


### PR DESCRIPTION
## Summary

- preserve the current deterministic winner for derived-title, frontmatter-title, and alias collisions
- expose vault-relative graph.page_title_collision diagnostics without registering loser nodes or backlinks
- add the opt-in strict_title_collisions loader flag and typed PageTitleCollisionError
- render all diagnostics in human or JSON CLI forms and document the stable policy

## Stack

This PR is stacked on #119. Review and merge order: #117, #118, #119, then this PR.

## Validation

- make all: 509 passed, 91.41% coverage
- focused graph, CLI, diagnostics, exception, and API tests: 102 passed
- Mypy, Ruff, documentation, and vendor-name gates: passed
- audit code pre-change impact: CRITICAL, 47 direct callers and 6 affected flows
- audit code post-change review completed; import cycles: 0

## Compatibility

The new loader argument is keyword-only and defaults to false. Permissive winner behavior remains unchanged; strict rejection is explicit opt-in. Incremental reload behavior is not changed in this tranche.

Closes #102