### PR TITLE
security(writer): enforce vault-bound atomic writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vault-bound writer and asset reads** — headless child writes now reject
+  external/untracked/symlink-swapped targets, verify target identity before
+  replacement, preserve permission and ownership metadata, expose typed safe
+  diagnostics and configurable limits, and support unified-diff dry runs;
+  `file://` and asset symlink reads are confined to the graph
+  ([#106](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/106)).
 - **Deep parser refreshes** — immutable node updates now rebuild the complete
   active branch to the root at arbitrary nesting depth, preserving soft breaks,
   properties, fenced code, queries, list properties, ordering, identity, and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -365,6 +365,13 @@ Full-directory loads are expensive for always-on agents. **`invalidate_and_reloa
 
 **`append_child_to_node`** (headless splice) invokes **`invalidate_and_reload_page`** after a successful write so agent tooling sees the same graph state as on-disk Markdown.
 
+The writer is vault-bound: it validates real-path containment and target
+identity before reading and immediately before atomic replacement, rejects
+external symlinks, preserves platform-supported mode/owner/group metadata, and supports mutation-free
+unified-diff previews through `dry_run=True`. Configurable source-size,
+content-size, and outline-depth limits support untrusted vault use. The canonical
+policy is the [filesystem safety contract](reference/FILESYSTEM_SAFETY.md).
+
 This keeps **global indexes consistent** without rebuilding the entire graph — including alias keys and custom titles declared in frontmatter.
 
 #### Live filesystem watcher (`start_watching`)

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -137,6 +137,20 @@ must reject ambiguous page identities, pass `strict_title_collisions=True` to
 `LogseqGraph.load_directory`. See the
 [diagnostics contract](reference/DIAGNOSTICS.md).
 
+Preview a headless child write without mutation:
+
+```bash
+matryca-parse agent-write /path/to/graph \
+  --target-uuid UUID \
+  --content "candidate child" \
+  --dry-run
+```
+
+The command prints a unified patch and performs no graph reload. Applied writes
+revalidate the real target immediately before atomic replacement and preserve
+permission and ownership metadata. See the
+[filesystem safety contract](reference/FILESYSTEM_SAFETY.md).
+
 **CLI tip:** run `matryca-parse export` after `load_directory` — KINETIC scans canonical pages internally (since v1.4.0).
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ entry points.
 | [`decisions/index.md`](decisions/index.md) | Maintainers | Canonical decision registry and ADR gaps |
 | [`reference/index.md`](reference/index.md) | Maintainers, integrators | Provenance and Matryca ecosystem relations |
 | [`reference/DIAGNOSTICS.md`](reference/DIAGNOSTICS.md) | Integrators, contributors | Stable diagnostic codes, payload schema, path safety, CLI rendering, and escalation |
+| [`reference/FILESYSTEM_SAFETY.md`](reference/FILESYSTEM_SAFETY.md) | Integrators, contributors | Vault containment, atomic replacement, dry-run, metadata, limits, and asset-read policy |
 | [`log.md`](log.md) | Maintainers | Maintained documentation chronology |
 | [`rfc/OLLAMA_RAG.md`](rfc/OLLAMA_RAG.md) | Integrators | Draft RFC for local Ollama RAG (issue [#34](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/34)) |
 | [`roadmaps/`](roadmaps/) | Historians | Executed architectural contracts (Waves 2–12) |

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -218,7 +218,9 @@ input to #104 and retain this fix as a prerequisite for #108 until merged.
 
 ### P0.2 — Writer may write outside vault via symlink
 
-**Status:** implementation prepared in the fifth stacked tranche for #106.
+**Status:** implementation published in
+[draft PR #121](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/121),
+the fifth stacked tranche for #106.
 
 Discovery accepts symlinked markdown under `pages/` or `journals/`. `parse_page_file` stores `path.resolve()`, i.e., the real target. `append_child_to_node` reads and rewrites that `source_path` without verifying it is inside `graph.graph_path`.
 
@@ -242,7 +244,7 @@ typed diagnostics, external symlink rejection, and confined `file://` reads.
 
 ### P1.1 — `file://` bypasses asset boundary
 
-**Status:** current read/confinement defect, high confidence.
+**Status:** implementation published in PR #121 as part of #106.
 
 `LogseqPage.resolve_asset_path` returns an absolute path for `file://` URIs before applying `graph_root` containment checks. This contradicts current docs stating asset resolver is vault-confined.
 
@@ -256,7 +258,9 @@ FILE_URI_RESULT /private/etc/passwd
 
 **Minimal slice:** apply a single canonicalization and containment function across all branches, including `file://`, percent-decoding, Windows path forms, and asset fallbacks. Define whether in-vault `file://` is supported or always rejected.
 
-**Recommended tracking:** either a dedicated security issue or explicit expansion of #106 from “write boundary” to “filesystem boundary.”
+**Delivery evidence:** PR #121 applies the same real-path containment rule to
+relative assets, fallback assets, symlinks, and `file://` URIs, with regression
+coverage for internal targets, external targets, escapes, and symlink loops.
 
 ### P1.2 — Stale backlinks after incremental rename
 

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -218,7 +218,7 @@ input to #104 and retain this fix as a prerequisite for #108 until merged.
 
 ### P0.2 — Writer may write outside vault via symlink
 
-**Status:** current confinement vulnerability, high confidence; directly overlaps #106.
+**Status:** implementation prepared in the fifth stacked tranche for #106.
 
 Discovery accepts symlinked markdown under `pages/` or `journals/`. `parse_page_file` stores `path.resolve()`, i.e., the real target. `append_child_to_node` reads and rewrites that `source_path` without verifying it is inside `graph.graph_path`.
 
@@ -231,7 +231,10 @@ SYMLINK_OUTSIDE_MUTATED True
 
 **Impact:** an untrusted vault can cause a local integration with repo permissions to modify an external Markdown file.
 
-**Minimal slice:** define and document a fail-closed symlink policy for all write paths; verify resolved target immediately before read and immediately before `os.replace`; reject mismatches between root, registered source, and current target.
+**Delivery evidence:** the fifth stacked tranche defines and tests fail-closed
+real-path containment, pre-read and pre-replace validation, target identity,
+mode/owner/group preservation, dry-run unified patches, configurable limits,
+typed diagnostics, external symlink rejection, and confined `file://` reads.
 
 **Required tests:** file symlink, directory symlink, symlink changes between parse and write, traversal path, rename race, dry-run without write, valid internal target.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ navigation layers only.
 | [Decision index](decisions/index.md) | Architectural decisions and missing ADRs |
 | [Reference index](reference/index.md) | Provenance and external relations |
 | [Structured diagnostics](reference/DIAGNOSTICS.md) | Stable diagnostic schema, codes, path safety, rendering, and escalation |
+| [Filesystem safety](reference/FILESYSTEM_SAFETY.md) | Vault containment, atomic write, dry-run, metadata, and asset-read policy |
 | [Documentation log](log.md) | Chronology of maintained knowledge changes |
 
 ## Quality claim

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,6 +21,10 @@ superseded_by: null
 
 ## 2026-08-07
 
+- Prepared the fifth stacked tranche for issue #106: fail-closed vault
+  containment, pre-read and pre-replace target validation, identity checks,
+  permission/owner preservation, mutation-free unified patches, configurable
+  limits, typed diagnostics, and confined symlink and `file://` asset reads.
 - Published [draft PR #120](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/120),
   stacked on #119, as the fourth tranche for issue #102: stable structured
   diagnostics for derived-title, frontmatter-title, and alias collisions;

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,7 +21,8 @@ superseded_by: null
 
 ## 2026-08-07
 
-- Prepared the fifth stacked tranche for issue #106: fail-closed vault
+- Published [draft PR #121](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/121),
+  stacked on #120, as the fifth tranche for issue #106: fail-closed vault
   containment, pre-read and pre-replace target validation, identity checks,
   permission/owner preservation, mutation-free unified patches, configurable
   limits, typed diagnostics, and confined symlink and `file://` asset reads.

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -29,5 +29,6 @@ maintained_documents = [
   "docs/reference/index.md",
   "docs/reference/API_STABILITY.md",
   "docs/reference/DIAGNOSTICS.md",
+  "docs/reference/FILESYSTEM_SAFETY.md",
   "docs/log.md",
 ]

--- a/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
+++ b/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
@@ -63,7 +63,7 @@ the newly filed parser P0.
 | #103 | Expand | Wave 0/3 | Add rename/backlink cold-load equivalence |
 | #104 | Expand | Wave 0/3 | Add arbitrary-depth parser regression matrix |
 | #105 | Keep | Wave 4 | Immutable build-once release lineage remains absent |
-| #106 | Implementation in next stacked PR | Wave 0 | Vault confinement, target identity, metadata preservation, dry-run patch, limits, typed diagnostics, symlink and `file://` tests implemented |
+| #106 | Implementation in [PR #121](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/121) | Wave 0 | Vault confinement, target identity, metadata preservation, dry-run patch, limits, typed diagnostics, symlink and `file://` tests; pending merge |
 | #107 | Keep | Wave 1 | Typing marker and stability contract remain absent |
 | #108 | Keep blocked by prerequisites | Wave 6 | Begin only after deep parser fix and #104 corpus |
 | #109 | Expand to MKQ-4 | Wave 1 | Bundle, metadata, lifecycle, links and deterministic source CI |

--- a/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
+++ b/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
@@ -63,7 +63,7 @@ the newly filed parser P0.
 | #103 | Expand | Wave 0/3 | Add rename/backlink cold-load equivalence |
 | #104 | Expand | Wave 0/3 | Add arbitrary-depth parser regression matrix |
 | #105 | Keep | Wave 4 | Immutable build-once release lineage remains absent |
-| #106 | Expand, priority | Wave 0 | Add symlink write escape and `file://` read boundary |
+| #106 | Implementation in next stacked PR | Wave 0 | Vault confinement, target identity, metadata preservation, dry-run patch, limits, typed diagnostics, symlink and `file://` tests implemented |
 | #107 | Keep | Wave 1 | Typing marker and stability contract remain absent |
 | #108 | Keep blocked by prerequisites | Wave 6 | Begin only after deep parser fix and #104 corpus |
 | #109 | Expand to MKQ-4 | Wave 1 | Bundle, metadata, lifecycle, links and deterministic source CI |

--- a/docs/reference/API_STABILITY.md
+++ b/docs/reference/API_STABILITY.md
@@ -42,7 +42,8 @@ minor release unless a security issue makes that unsafe.
 | Parser | `StackMachineParser`, `LogosParser`, `LogseqPage`, `LogseqNode`, `LogosNode`, `ASTVisitor` |
 | Graph | `LogseqGraph` |
 | Diagnostics | `Diagnostic`, `DiagnosticCode`, `DiagnosticSeverity`, `collect_graph_diagnostics` |
-| Errors | `LogseqParserError`, `LogseqIndentationError`, `BlockReferenceError`, `PageTitleCollisionError` |
+| Errors | `LogseqParserError`, `LogseqIndentationError`, `BlockReferenceError`, `PageTitleCollisionError`, `VaultWriteError` |
+| Writer preview | `WriteProposal` |
 | Markdown | `serialize_logseq_page`, `write_logseq_page`, `format_logseq_page_properties`, `format_logseq_block_property_lines` |
 | Paths | `discover_graph_files`, `derive_page_title_from_source_path`, `page_title_to_filename`, `filename_to_page_title`, `page_title_to_relative_path`, `encode_page_title_segment`, `decode_page_title_segment`, `is_excluded_graph_path` |
 
@@ -56,6 +57,8 @@ permissive default.
 
 Diagnostic code compatibility, serialization, and path-safety rules are defined
 in the [structured diagnostics contract](DIAGNOSTICS.md).
+Vault-bound writer and asset-read guarantees are defined in the
+[filesystem safety contract](FILESYSTEM_SAFETY.md).
 
 ## Experimental package-root surface
 

--- a/docs/reference/DIAGNOSTICS.md
+++ b/docs/reference/DIAGNOSTICS.md
@@ -46,6 +46,9 @@ paths that cannot be proven relative to the selected vault.
 |---|---|---|
 | `graph.broken_block_reference` | `error` | A block contains a `((uuid))` reference absent from the loaded graph |
 | `graph.page_title_collision` | `error` | Two physical pages compete for the same canonical or alias index key |
+| `writer.vault_escape` | `error` | A graph-bound writer target escapes containment or is not a tracked regular file |
+| `writer.target_changed` | `error` | A validated writer target changes before atomic replacement |
+| `writer.input_limit_exceeded` | `error` | Source, content, or outline depth exceeds a configured limit |
 
 Title-collision context contains `title`, `winner_path`, `loser_path`, and
 `reason`. The stable reasons are `derived_title`, `frontmatter_title`, and
@@ -93,6 +96,8 @@ except PageTitleCollisionError as error:
   error diagnostic is present and `0` otherwise.
 - A plain `scan` remains informational and does not escalate findings.
 
-Future parser-recovery, filesystem, and reload diagnostics must
+Filesystem codes and metadata behavior are defined in the
+[filesystem safety contract](FILESYSTEM_SAFETY.md). Future parser-recovery and
+reload diagnostics must
 reuse this payload and path policy. Each producer requires code/context tests
 and both output forms where it is exposed through the CLI.

--- a/docs/reference/FILESYSTEM_SAFETY.md
+++ b/docs/reference/FILESYSTEM_SAFETY.md
@@ -1,0 +1,89 @@
+---
+type: FilesystemSafetyContract
+title: Vault-bound filesystem safety contract
+description: Canonical containment, atomic replacement, dry-run, metadata, and input-limit policy for graph-bound writes and asset reads.
+status: stable
+classification: canonical
+audience: contributors
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-08-07
+verified: 2026-08-07
+stale_after: 2027-02-03
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# Vault-bound filesystem safety contract
+
+Graph-bound reads and writes treat the selected Logseq graph as a security
+boundary. A path discovered in Markdown or cached in a node is not trusted merely
+because parsing succeeded.
+
+## Writer policy
+
+`append_child_to_node` applies these checks:
+
+1. Resolve the selected graph root and registered node source.
+2. Require the real source to remain under the graph root and satisfy the
+   tracked `pages/` or `journals/` Markdown policy.
+3. Require a regular file and capture device, inode, size, and nanosecond mtime
+   before reading.
+4. Enforce configurable source-byte, content-byte, and outline-depth limits.
+5. Build the complete replacement and unified diff in memory.
+6. For an applied write, create and fsync a same-directory temporary file,
+   preserving permission bits and, where exposed by the platform, owner and
+   group. Preservation failure aborts before replacement.
+7. Resolve and stat the target again immediately before `os.replace`; reject
+   path escape, symlink replacement, or identity/content change.
+8. Atomically replace the target and only then refresh the in-memory graph.
+
+External symlink targets are rejected. A symlink whose real target remains
+inside the selected vault resolves to that in-vault target. Cross-process
+locking remains outside this contract and belongs to snapshot/mutation work.
+
+## Preview and limits
+
+```python
+from logseq_matryca_parser.agent_writer import append_child_to_node
+
+proposal = append_child_to_node(
+    graph,
+    target_uuid,
+    "candidate child",
+    dry_run=True,
+    max_source_bytes=8 * 1024 * 1024,
+    max_content_bytes=1024 * 1024,
+    max_target_depth=128,
+)
+assert proposal.path.is_relative_to(graph.graph_path)
+print(proposal.unified_diff)
+```
+
+Dry-run performs all validation and diff construction but creates no temporary
+file, performs no replacement, and does not reload the graph. KINETIC exposes
+the same behavior through `agent-write --dry-run` and accepts matching limit
+options.
+
+## Failures and diagnostics
+
+`VaultWriteError` carries one safe `Diagnostic`. Its stable codes are:
+
+| Code | Meaning |
+|---|---|
+| `writer.vault_escape` | Real target is outside the vault, untracked, or not a regular file |
+| `writer.target_changed` | Device, inode, size, mtime, or resolved target changed before replacement |
+| `writer.input_limit_exceeded` | Configured source, content, or depth limit was exceeded |
+
+Diagnostics never include an absolute external path. A source path is present
+only when it can be proven vault-relative.
+
+## Asset reads
+
+`LogseqPage.resolve_asset_path` applies the same real-path containment rule to
+relative links, `assets/` fallbacks, symlinks, and `file://` URIs. It returns an
+absolute path only for an existing target inside the graph; external or missing
+targets return `None`.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -46,6 +46,7 @@ artifacts.
 
 - [Python API stability and typing](API_STABILITY.md)
 - [Structured diagnostics](DIAGNOSTICS.md)
+- [Vault-bound filesystem safety](FILESYSTEM_SAFETY.md)
 - [Architecture](../CLEAN_CODE_ARCHITECTURE.md)
 - [AST primer](../logseq_ast_primer.md)
 - [Release process](../RELEASE_PROCESS.md)

--- a/src/logseq_matryca_parser/__init__.py
+++ b/src/logseq_matryca_parser/__init__.py
@@ -6,13 +6,14 @@ import sys
 
 from ._version import __version__
 from .agent_press import SessionAliasRegistry
-from .agent_writer import LogseqConfigReader, logseq_agent_write
+from .agent_writer import LogseqConfigReader, WriteProposal, logseq_agent_write
 from .diagnostics import Diagnostic, DiagnosticCode, DiagnosticSeverity, collect_graph_diagnostics
 from .exceptions import (
     BlockReferenceError,
     LogseqIndentationError,
     LogseqParserError,
     PageTitleCollisionError,
+    VaultWriteError,
 )
 from .forge import (
     FlatListForgeVisitor,
@@ -89,6 +90,8 @@ __all__ = [
     "SovereignNotePackage",
     "StackMachineParser",
     "SynapseAdapter",
+    "VaultWriteError",
+    "WriteProposal",
     "clean_node_content",
     "collect_graph_diagnostics",
     "decode_page_title_segment",

--- a/src/logseq_matryca_parser/agent_writer.py
+++ b/src/logseq_matryca_parser/agent_writer.py
@@ -5,17 +5,139 @@ from __future__ import annotations
 import logging
 import os
 import re
+import stat
 import tempfile
+from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime
+from difflib import unified_diff
 from pathlib import Path
-from typing import TYPE_CHECKING, NotRequired, TypedDict
+from typing import TYPE_CHECKING, NoReturn, NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from logseq_matryca_parser.graph import LogseqGraph
 
+from logseq_matryca_parser.diagnostics import Diagnostic, DiagnosticCode, DiagnosticSeverity
+from logseq_matryca_parser.exceptions import VaultWriteError
 from logseq_matryca_parser.logos_core import LogseqNode
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_SOURCE_BYTES = 8 * 1024 * 1024
+DEFAULT_MAX_CONTENT_BYTES = 1024 * 1024
+DEFAULT_MAX_TARGET_DEPTH = 128
+
+
+@dataclass(frozen=True)
+class WriteProposal:
+    """Immutable preview/result for one vault-contained markdown splice."""
+
+    path: Path
+    unified_diff: str
+    applied: bool
+
+
+def _raise_writer_error(
+    code: DiagnosticCode,
+    message: str,
+    *,
+    graph: LogseqGraph,
+    source_path: Path | None,
+    context: dict[str, str],
+) -> NoReturn:
+    relative_path: str | None = None
+    if source_path is not None:
+        with suppress(OSError, RuntimeError, ValueError):
+            relative_path = source_path.resolve().relative_to(graph.graph_path.resolve()).as_posix()
+    raise VaultWriteError(
+        Diagnostic(
+            code=code,
+            severity=DiagnosticSeverity.ERROR,
+            source_path=relative_path,
+            message=message,
+            context=context,
+        )
+    )
+
+
+def _validate_write_target(
+    graph: LogseqGraph,
+    source_path: Path,
+    *,
+    target_uuid: str,
+) -> tuple[Path, os.stat_result]:
+    try:
+        root = graph.graph_path.resolve(strict=True)
+        resolved = source_path.resolve(strict=True)
+        resolved.relative_to(root)
+    except (OSError, RuntimeError, ValueError):
+        _raise_writer_error(
+            DiagnosticCode.WRITER_VAULT_ESCAPE,
+            "Writer target is outside the selected vault",
+            graph=graph,
+            source_path=source_path,
+            context={"operation": "append_child", "target_uuid": target_uuid},
+        )
+    if not graph.is_tracked_markdown_path(resolved):
+        _raise_writer_error(
+            DiagnosticCode.WRITER_VAULT_ESCAPE,
+            "Writer target is not a tracked vault Markdown file",
+            graph=graph,
+            source_path=resolved,
+            context={"operation": "append_child", "target_uuid": target_uuid},
+        )
+    target_stat = os.stat(resolved, follow_symlinks=False)
+    if not stat.S_ISREG(target_stat.st_mode):
+        _raise_writer_error(
+            DiagnosticCode.WRITER_VAULT_ESCAPE,
+            "Writer target is not a regular file",
+            graph=graph,
+            source_path=resolved,
+            context={"operation": "append_child", "target_uuid": target_uuid},
+        )
+    return resolved, target_stat
+
+
+def _identity(target_stat: os.stat_result) -> tuple[int, int, int, int]:
+    return (
+        target_stat.st_dev,
+        target_stat.st_ino,
+        target_stat.st_size,
+        target_stat.st_mtime_ns,
+    )
+
+
+def _read_validated_target(
+    graph: LogseqGraph,
+    source_path: Path,
+    expected_stat: os.stat_result,
+    *,
+    target_uuid: str,
+) -> tuple[str, os.stat_result]:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(source_path, flags)
+    except OSError:
+        _raise_writer_error(
+            DiagnosticCode.WRITER_TARGET_CHANGED,
+            "Writer target changed before it could be read",
+            graph=graph,
+            source_path=source_path,
+            context={"operation": "append_child", "target_uuid": target_uuid},
+        )
+    with os.fdopen(fd, encoding="utf-8-sig") as handle:
+        opened_stat = os.fstat(handle.fileno())
+        if _identity(opened_stat) != _identity(expected_stat):
+            _raise_writer_error(
+                DiagnosticCode.WRITER_TARGET_CHANGED,
+                "Writer target changed before it could be read",
+                graph=graph,
+                source_path=source_path,
+                context={"operation": "append_child", "target_uuid": target_uuid},
+            )
+        return handle.read(), opened_stat
 
 
 class AgentWriteResult(TypedDict):
@@ -178,8 +300,17 @@ def _deepest_line_end(node: LogseqNode) -> int:
     return cursor.line_end
 
 
-def append_child_to_node(graph: LogseqGraph, target_uuid: str, content: str) -> None:
-    """Insert a child bullet under ``target_uuid`` in the on-disk source markdown file."""
+def append_child_to_node(
+    graph: LogseqGraph,
+    target_uuid: str,
+    content: str,
+    *,
+    dry_run: bool = False,
+    max_source_bytes: int = DEFAULT_MAX_SOURCE_BYTES,
+    max_content_bytes: int = DEFAULT_MAX_CONTENT_BYTES,
+    max_target_depth: int = DEFAULT_MAX_TARGET_DEPTH,
+) -> WriteProposal:
+    """Build or apply a fail-closed, vault-contained child splice."""
     target_node = graph.get_node_by_uuid(target_uuid)
     if target_node is None:
         msg = f"No node registered for uuid={target_uuid}"
@@ -188,14 +319,49 @@ def append_child_to_node(graph: LogseqGraph, target_uuid: str, content: str) -> 
         msg = f"Node uuid={target_uuid} has no source_path"
         raise ValueError(msg)
 
-    source_path = Path(target_node.source_path)
+    source_path, initial_stat = _validate_write_target(
+        graph,
+        Path(target_node.source_path),
+        target_uuid=target_uuid,
+    )
+    if min(max_source_bytes, max_content_bytes, max_target_depth) < 1:
+        raise ValueError("writer limits must be positive")
+    if initial_stat.st_size > max_source_bytes:
+        _raise_writer_error(
+            DiagnosticCode.WRITER_INPUT_LIMIT_EXCEEDED,
+            "Writer source exceeds the configured byte limit",
+            graph=graph,
+            source_path=source_path,
+            context={"limit": str(max_source_bytes), "target_uuid": target_uuid},
+        )
+    if len(content.encode("utf-8")) > max_content_bytes:
+        _raise_writer_error(
+            DiagnosticCode.WRITER_INPUT_LIMIT_EXCEEDED,
+            "Writer content exceeds the configured byte limit",
+            graph=graph,
+            source_path=source_path,
+            context={"limit": str(max_content_bytes), "target_uuid": target_uuid},
+        )
     insert_after_line = _insertion_line_after_node(target_node)
     child_level = target_node.indent_level + 1
+    if child_level > max_target_depth:
+        _raise_writer_error(
+            DiagnosticCode.WRITER_INPUT_LIMIT_EXCEEDED,
+            "Writer target exceeds the configured outline depth",
+            graph=graph,
+            source_path=source_path,
+            context={"limit": str(max_target_depth), "target_uuid": target_uuid},
+        )
     tab_size = graph.tab_size_for_node(target_node)
     indent = " " * (child_level * tab_size)
     new_line = f"{indent}- {content.rstrip()}"
 
-    raw_text = source_path.read_text(encoding="utf-8-sig")
+    raw_text, initial_stat = _read_validated_target(
+        graph,
+        source_path,
+        initial_stat,
+        target_uuid=target_uuid,
+    )
     if raw_text and not raw_text.endswith(("\n", "\r\n")):
         raw_text += "\n"
     lines = raw_text.splitlines(keepends=True)
@@ -209,6 +375,18 @@ def append_child_to_node(graph: LogseqGraph, target_uuid: str, content: str) -> 
 
     lines.insert(insert_index, f"{new_line}\n")
     updated = "".join(lines)
+    relative_path = source_path.relative_to(graph.graph_path.resolve()).as_posix()
+    patch = "".join(
+        unified_diff(
+            raw_text.splitlines(keepends=True),
+            updated.splitlines(keepends=True),
+            fromfile=f"a/{relative_path}",
+            tofile=f"b/{relative_path}",
+        )
+    )
+    proposal = WriteProposal(path=source_path, unified_diff=patch, applied=not dry_run)
+    if dry_run:
+        return proposal
     logger.debug(
         "append_child_to_node target=%s path=%s insert_index=%s indent_level=%s",
         target_uuid,
@@ -225,13 +403,36 @@ def append_child_to_node(graph: LogseqGraph, target_uuid: str, content: str) -> 
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(updated)
+            handle.flush()
+            os.fsync(handle.fileno())
+            mode = stat.S_IMODE(initial_stat.st_mode)
+            if hasattr(os, "fchmod"):
+                os.fchmod(handle.fileno(), mode)
+            else:
+                os.chmod(temp_path, mode)
+            if hasattr(os, "fchown"):
+                os.fchown(handle.fileno(), initial_stat.st_uid, initial_stat.st_gid)
+        current_path, current_stat = _validate_write_target(
+            graph,
+            source_path,
+            target_uuid=target_uuid,
+        )
+        if current_path != source_path or _identity(current_stat) != _identity(initial_stat):
+            _raise_writer_error(
+                DiagnosticCode.WRITER_TARGET_CHANGED,
+                "Writer target changed after it was read",
+                graph=graph,
+                source_path=current_path,
+                context={"operation": "append_child", "target_uuid": target_uuid},
+            )
         os.replace(temp_path, source_path)
-    except OSError:
+    except (OSError, VaultWriteError):
         if os.path.exists(temp_path):
             os.unlink(temp_path)
         raise
 
     graph.invalidate_and_reload_page(source_path)
+    return proposal
 
 
 def _demo() -> None:

--- a/src/logseq_matryca_parser/diagnostics.py
+++ b/src/logseq_matryca_parser/diagnostics.py
@@ -26,6 +26,9 @@ class DiagnosticCode(StrEnum):
 
     GRAPH_BROKEN_BLOCK_REFERENCE = "graph.broken_block_reference"
     GRAPH_PAGE_TITLE_COLLISION = "graph.page_title_collision"
+    WRITER_INPUT_LIMIT_EXCEEDED = "writer.input_limit_exceeded"
+    WRITER_TARGET_CHANGED = "writer.target_changed"
+    WRITER_VAULT_ESCAPE = "writer.vault_escape"
 
 
 @dataclass(frozen=True)

--- a/src/logseq_matryca_parser/exceptions.py
+++ b/src/logseq_matryca_parser/exceptions.py
@@ -35,5 +35,13 @@ class PageTitleCollisionError(LogseqParserError):
         )
 
 
+class VaultWriteError(Exception):
+    """Typed fail-closed writer error carrying a safe structured diagnostic."""
+
+    def __init__(self, diagnostic: Diagnostic) -> None:
+        self.diagnostic = diagnostic
+        super().__init__(diagnostic.message)
+
+
 class SessionAliasRegistryError(Exception):
     """Raised when the X-Ray alias state file cannot be parsed or validated."""

--- a/src/logseq_matryca_parser/kinetic_commands.py
+++ b/src/logseq_matryca_parser/kinetic_commands.py
@@ -361,10 +361,34 @@ def agent_write(
         "--state-file",
         help="Alias registry JSON (default: <graph>/.matryca_xray_state.json).",
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print a unified patch without writing or reloading the graph.",
+    ),
+    max_source_bytes: int = typer.Option(
+        8 * 1024 * 1024,
+        "--max-source-bytes",
+        min=1,
+        help="Reject source files larger than this byte limit.",
+    ),
+    max_content_bytes: int = typer.Option(
+        1024 * 1024,
+        "--max-content-bytes",
+        min=1,
+        help="Reject appended content larger than this UTF-8 byte limit.",
+    ),
+    max_target_depth: int = typer.Option(
+        128,
+        "--max-target-depth",
+        min=1,
+        help="Reject writes below this outline depth.",
+    ),
 ) -> None:
     """Append a child block under a parent via headless AST markdown splicing."""
     from logseq_matryca_parser.agent_press import XRAY_STATE_FILENAME, SessionAliasRegistry
     from logseq_matryca_parser.agent_writer import append_child_to_node
+    from logseq_matryca_parser.exceptions import VaultWriteError
     from logseq_matryca_parser.graph import LogseqGraph
 
     resolved = _resolve_graph_path(ctx, graph_path)
@@ -400,10 +424,22 @@ def agent_write(
         print("Parent block UUID could not be resolved.", file=sys.stderr)
         raise typer.Exit(code=1)
     try:
-        append_child_to_node(graph, parent_uuid, content)
-    except ValueError as exc:
+        proposal = append_child_to_node(
+            graph,
+            parent_uuid,
+            content,
+            dry_run=dry_run,
+            max_source_bytes=max_source_bytes,
+            max_content_bytes=max_content_bytes,
+            max_target_depth=max_target_depth,
+        )
+    except (ValueError, VaultWriteError) as exc:
         print(str(exc), file=sys.stderr)
         raise typer.Exit(code=1) from exc
+
+    if dry_run:
+        sys.stdout.write(proposal.unified_diff)
+        return
 
     console.print(
         f"[bold green]Appended child under[/] {parent_uuid}",

--- a/src/logseq_matryca_parser/logos_core.py
+++ b/src/logseq_matryca_parser/logos_core.py
@@ -105,18 +105,30 @@ class LogseqPage(BaseModel):
     root_nodes: list[LogseqNode] = Field(default_factory=list)
 
     def resolve_asset_path(self, asset_link: str) -> str | None:
-        """Resolve a Logseq asset link to an absolute filesystem path."""
+        """Resolve an existing asset only when its real path remains inside the graph."""
         normalized_link = unquote(asset_link.strip()).replace("\\", "/")
         if not normalized_link:
             return None
+
+        graph_root = self._infer_graph_root()
+
+        def contained(candidate: Path) -> str | None:
+            if graph_root is None:
+                return None
+            try:
+                resolved = candidate.resolve()
+                resolved.relative_to(graph_root.resolve())
+            except (OSError, RuntimeError, ValueError):
+                logger.debug("resolve_asset_path: reject path outside graph root")
+                return None
+            return str(resolved) if resolved.exists() else None
 
         if normalized_link.startswith("file://"):
             filesystem_path = normalized_link.replace("file://", "", 1)
             if os.name == "nt" and filesystem_path.startswith("/"):
                 filesystem_path = filesystem_path[1:]
-            return str(Path(filesystem_path).resolve())
+            return contained(Path(filesystem_path))
 
-        graph_root = self._infer_graph_root()
         if graph_root is not None and (
             normalized_link.startswith("../assets/") or normalized_link.startswith("assets/")
         ):
@@ -124,31 +136,20 @@ class LogseqPage(BaseModel):
             while root_relative.startswith("../"):
                 root_relative = root_relative[3:]
             root_relative_path = Path(root_relative)
-            return str((graph_root / root_relative_path).resolve())
+            return contained(graph_root / root_relative_path)
 
         if self.source_path:
             if normalized_link.startswith("/"):
                 logger.debug("resolve_asset_path: reject absolute path %s", normalized_link)
                 return None
             local_candidate = (Path(self.source_path).parent / normalized_link).resolve()
-            graph_root = self._infer_graph_root()
-            if graph_root is not None:
-                try:
-                    local_candidate.relative_to(graph_root.resolve())
-                except ValueError:
-                    logger.debug(
-                        "resolve_asset_path: path %s escapes graph root %s",
-                        local_candidate,
-                        graph_root,
-                    )
-                    return None
-            if local_candidate.exists():
-                return str(local_candidate)
+            resolved_local = contained(local_candidate)
+            if resolved_local is not None:
+                return resolved_local
 
         if graph_root is not None:
             fallback_asset = (graph_root / "assets" / Path(normalized_link).name).resolve()
-            if fallback_asset.exists():
-                return str(fallback_asset)
+            return contained(fallback_asset)
 
         return None
 

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -33,6 +33,8 @@ EXPECTED_ROOT_EXPORTS = {
     "SovereignNotePackage",
     "StackMachineParser",
     "SynapseAdapter",
+    "VaultWriteError",
+    "WriteProposal",
     "clean_node_content",
     "collect_graph_diagnostics",
     "decode_page_title_segment",

--- a/tests/test_writer_security.py
+++ b/tests/test_writer_security.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from typer.testing import CliRunner
+
+from logseq_matryca_parser import DiagnosticCode, LogseqGraph, VaultWriteError
+from logseq_matryca_parser.agent_writer import append_child_to_node
+from logseq_matryca_parser.kinetic import app
+
+runner = CliRunner()
+
+
+def _single_node_graph(tmp_path: Path) -> tuple[LogseqGraph, Path, str]:
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    page_path = pages / "Write.md"
+    page_path.write_text("- Parent\n", encoding="utf-8")
+    graph = LogseqGraph.load_directory(graph_root)
+    return graph, page_path, graph.pages["Write"].root_nodes[0].uuid
+
+
+def test_dry_run_returns_patch_without_mutation_or_reload(tmp_path: Path) -> None:
+    graph, page_path, target_uuid = _single_node_graph(tmp_path)
+    before = page_path.read_bytes()
+
+    proposal = append_child_to_node(graph, target_uuid, "preview", dry_run=True)
+
+    assert proposal.applied is False
+    assert proposal.path == page_path.resolve()
+    assert "--- a/pages/Write.md" in proposal.unified_diff
+    assert "+++ b/pages/Write.md" in proposal.unified_diff
+    assert "+  - preview" in proposal.unified_diff
+    assert page_path.read_bytes() == before
+    assert graph.pages["Write"].root_nodes[0].children == []
+
+
+def test_external_symlink_target_is_rejected_without_mutation(tmp_path: Path) -> None:
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    outside = tmp_path / "outside.md"
+    outside.write_text("- Outside\n", encoding="utf-8")
+    (pages / "Escape.md").symlink_to(outside)
+    graph = LogseqGraph.load_directory(graph_root)
+    target_uuid = next(graph.iter_canonical_pages()).root_nodes[0].uuid
+
+    with pytest.raises(VaultWriteError) as raised:
+        append_child_to_node(graph, target_uuid, "must not escape")
+
+    assert raised.value.diagnostic.code == DiagnosticCode.WRITER_VAULT_ESCAPE
+    assert raised.value.diagnostic.source_path is None
+    assert outside.read_text(encoding="utf-8") == "- Outside\n"
+
+
+def test_symlink_swap_before_replace_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    graph, page_path, target_uuid = _single_node_graph(tmp_path)
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside\n", encoding="utf-8")
+    real_mkstemp = tempfile.mkstemp
+
+    def swapping_mkstemp(
+        suffix: str | None = None,
+        prefix: str | None = None,
+        dir: str | os.PathLike[str] | None = None,
+        text: bool = False,
+    ) -> tuple[int, str]:
+        fd, temp_path = real_mkstemp(suffix=suffix, prefix=prefix, dir=dir, text=text)
+        page_path.unlink()
+        page_path.symlink_to(outside)
+        return fd, temp_path
+
+    monkeypatch.setattr("logseq_matryca_parser.agent_writer.tempfile.mkstemp", swapping_mkstemp)
+
+    with pytest.raises(VaultWriteError) as raised:
+        append_child_to_node(graph, target_uuid, "blocked")
+
+    assert raised.value.diagnostic.code == DiagnosticCode.WRITER_VAULT_ESCAPE
+    assert outside.read_text(encoding="utf-8") == "outside\n"
+
+
+def test_regular_target_swap_before_replace_is_detected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    graph, page_path, target_uuid = _single_node_graph(tmp_path)
+    replacement = page_path.parent / "replacement.md"
+    replacement.write_text("- replacement\n", encoding="utf-8")
+    real_mkstemp = tempfile.mkstemp
+
+    def swapping_mkstemp(
+        suffix: str | None = None,
+        prefix: str | None = None,
+        dir: str | os.PathLike[str] | None = None,
+        text: bool = False,
+    ) -> tuple[int, str]:
+        fd, temp_path = real_mkstemp(suffix=suffix, prefix=prefix, dir=dir, text=text)
+        replacement.replace(page_path)
+        return fd, temp_path
+
+    monkeypatch.setattr("logseq_matryca_parser.agent_writer.tempfile.mkstemp", swapping_mkstemp)
+
+    with pytest.raises(VaultWriteError) as raised:
+        append_child_to_node(graph, target_uuid, "blocked")
+
+    assert raised.value.diagnostic.code == DiagnosticCode.WRITER_TARGET_CHANGED
+    assert page_path.read_text(encoding="utf-8") == "- replacement\n"
+
+
+def test_atomic_replace_preserves_permission_bits(tmp_path: Path) -> None:
+    graph, page_path, target_uuid = _single_node_graph(tmp_path)
+    page_path.chmod(0o640)
+    original_owner = (page_path.stat().st_uid, page_path.stat().st_gid)
+
+    proposal = append_child_to_node(graph, target_uuid, "written")
+
+    assert proposal.applied is True
+    assert stat.S_IMODE(page_path.stat().st_mode) == 0o640
+    assert (page_path.stat().st_uid, page_path.stat().st_gid) == original_owner
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error_type"),
+    [
+        ({"max_source_bytes": 1}, VaultWriteError),
+        ({"max_content_bytes": 1}, VaultWriteError),
+        ({"max_target_depth": 0}, ValueError),
+    ],
+)
+def test_writer_limits_fail_before_mutation(
+    tmp_path: Path,
+    kwargs: dict[str, int],
+    error_type: type[Exception],
+) -> None:
+    graph, page_path, target_uuid = _single_node_graph(tmp_path)
+    before = page_path.read_bytes()
+
+    with pytest.raises(error_type):
+        append_child_to_node(graph, target_uuid, "too large", **cast(Any, kwargs))
+
+    assert page_path.read_bytes() == before
+
+
+def test_agent_write_cli_dry_run_prints_patch_only(tmp_path: Path) -> None:
+    graph, page_path, target_uuid = _single_node_graph(tmp_path)
+    before = page_path.read_bytes()
+
+    result = runner.invoke(
+        app,
+        [
+            "agent-write",
+            str(graph.graph_path),
+            "--target-uuid",
+            target_uuid,
+            "--content",
+            "preview",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "--- a/pages/Write.md" in result.output
+    assert "+  - preview" in result.output
+    assert page_path.read_bytes() == before
+
+
+def test_file_uri_asset_must_remain_inside_graph(tmp_path: Path) -> None:
+    graph, _page_path, _target_uuid = _single_node_graph(tmp_path)
+    inside = graph.graph_path / "assets" / "inside.txt"
+    inside.parent.mkdir()
+    inside.write_text("inside", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    page = graph.pages["Write"]
+
+    assert page.resolve_asset_path(inside.as_uri()) == str(inside.resolve())
+    assert page.resolve_asset_path(outside.as_uri()) is None
+
+
+def test_asset_symlink_escape_is_rejected(tmp_path: Path) -> None:
+    graph, _page_path, _target_uuid = _single_node_graph(tmp_path)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    link = graph.graph_path / "assets" / "escape.txt"
+    link.parent.mkdir()
+    link.symlink_to(outside)
+
+    assert graph.pages["Write"].resolve_asset_path("../assets/escape.txt") is None
+
+
+def test_symlink_loops_fail_closed(tmp_path: Path) -> None:
+    graph, page_path, target_uuid = _single_node_graph(tmp_path)
+    page = graph.pages["Write"]
+    loop = graph.graph_path / "assets" / "loop"
+    loop.parent.mkdir()
+    loop.symlink_to(loop)
+
+    page_path.unlink()
+    page_path.symlink_to(page_path)
+
+    with pytest.raises(VaultWriteError) as raised:
+        append_child_to_node(graph, target_uuid, "blocked")
+
+    assert raised.value.diagnostic.code == DiagnosticCode.WRITER_VAULT_ESCAPE
+    assert page.resolve_asset_path("../assets/loop") is None


### PR DESCRIPTION
## Summary\n\n- enforce real-path containment for graph-bound Markdown writes and asset reads\n- apply inode/device/size/mtime identity checks around atomic replacement\n- preserve supported file metadata and reject symlink loops or target swaps\n- add dry-run unified patches, configurable byte/depth limits, typed diagnostics, and CLI options\n- publish the canonical filesystem safety contract and align maintained documentation\n\n## Stack\n\n#117 -> #118 -> #119 -> #120 -> this PR\n\nBase branch: agent/graph-title-collision-contract\n\n## Validation\n\n- make all: 521 passed, 91.81% coverage\n- focused writer/parser/CLI/public API suite: 252 passed\n- Ruff: passed\n- Mypy: passed\n- documentation profile and vendor-name gate: passed\n- audit code import-cycle check: 0 cycles\n\nCloses #106