### PR TITLE
docs: reconcile and harden v1.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ to stable package exports or default CLI behavior.
   renders all findings with `scan --diagnostics`
   ([#102](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/102)).
 - **Documentation system guide** — [`docs/DOCUMENTATION_SYSTEM.md`](docs/DOCUMENTATION_SYSTEM.md) explains source authority, maintained versus historical surfaces, metadata, freshness, validation, the Matryca Knowledge projection workflow, and the repository's documentation evolution.
-- **Synapse RAG example** — [`examples/run_synapse_rag.py`](examples/run_synapse_rag.py) demonstrates all four `SynapseAdapter` methods (`to_langchain_documents`, `to_llamaindex_nodes`, `to_context_enriched_chunks`, `_expand_macros_and_embeds`) plus table-driven embed expansion edge cases.
 - **Embed expansion edge-case tests** — `TestEmbedExpansionEdgeCases` in [`tests/test_synapse.py`](tests/test_synapse.py) covers cycles, missing targets, and happy-path for both `{{embed [[Page]]}}` and `{{embed ((uuid))}}` (closes [#71](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/71)).
 - **Contributor onboarding (wave 4)** — ten new Good First Issues (GFI-39…GFI-48) filed on GitHub ([#88](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/88)–[#97](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/97)); index updated in [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md).
 
@@ -69,6 +68,14 @@ to stable package exports or default CLI behavior.
 - **Artifact lineage** — PyPI publication must succeed before the GitHub Release
   is created, and every consumer re-verifies the SHA-256 manifest for the exact
   distributions produced by the single build job.
+
+### Documentation erratum (2026-08-08)
+
+- The initial GitHub Release notes incorrectly listed
+  `examples/run_synapse_rag.py`. The file is not part of v1.7.0 and
+  [#90](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/90)
+  remains open. This documentation-only correction does not change the tag,
+  distributions, attestations, or published SHA-256 digests.
 
 ## [1.6.0] - 2026-07-02
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -39,6 +39,8 @@ version; use `vX.Y.Z` for the git tag).
 - [ ] Leave an empty `## [Unreleased]` section at the top
 - [ ] Set `__version__ = "X.Y.Z"` in `src/logseq_matryca_parser/_version.py`; Hatchling derives package metadata from this single source
 - [ ] Update `README.md`, `SECURITY.md`, and contributor-facing current-version references
+- [ ] Verify every file, command, issue disposition, and shipped capability
+      named in the versioned changelog against the exact release commit
 - [ ] Run `make all` (Ruff, Mypy, documentation checks, and Pytest)
 - [ ] Run `python -m scripts.check_release_contract --tag vX.Y.Z`
 - [ ] Build wheel and sdist once locally, run `python scripts/check_wheel_contract.py path/to/wheel.whl`, `twine check`, and record SHA-256 digests
@@ -52,8 +54,10 @@ python scripts/extract_changelog.py vX.Y.Z | less
 python -m scripts.check_release_contract --tag vX.Y.Z
 ```
 
-The first command shows exactly the section that will appear on GitHub. The
-second rejects a malformed tag, a tag/source/runtime mismatch, non-empty
+The first command shows exactly the section that will appear on GitHub. Review
+every file link and shipped claim against the exact commit that will receive
+the tag; a non-empty section can still contain a factual mistake. The second
+command rejects a malformed tag, a tag/source/runtime mismatch, non-empty
 `[Unreleased]`, a missing versioned section, or release notes without bullets.
 
 ### 3. Commit, tag, push
@@ -95,6 +99,23 @@ Do not rebuild or replace a published version. Inspect the failed job first:
 
 PyPI cannot be re-published for the same version; use a patch bump if the wheel upload failed.
 
+#### Post-publication documentation correction
+
+If the distributions are correct but the curated notes contain a factual
+documentation error:
+
+1. Do not move the tag, rebuild the distributions, or replace PyPI files.
+2. Verify the actual tagged tree and published package before deciding the
+   correction scope.
+3. Correct `CHANGELOG.md` on `main` with a dated erratum that states whether
+   artifact bytes, attestations, and digests are unchanged.
+4. Update the GitHub Release notes to the corrected versioned changelog text.
+5. Keep any undelivered issue open and record the correction in
+   [`docs/log.md`](log.md).
+
+Use a new patch release instead when runtime behavior or package contents — not
+only explanatory text — are wrong.
+
 ---
 
 ## Troubleshooting
@@ -103,7 +124,8 @@ PyPI cannot be re-published for the same version; use a patch bump if the wheel 
 |---------|-----|
 | Tag on GitHub but no **Release** page | Confirm whether PyPI succeeded; recover only from the checksummed artifact of that exact workflow run. |
 | PyPI version already exists | Bump patch version; never re-use a published version. |
-| Notes look wrong | Re-run locally: `python scripts/extract_changelog.py vX.Y.Z` and compare to `CHANGELOG.md`. |
+| Notes look wrong before publication | Re-run locally: `python scripts/extract_changelog.py vX.Y.Z`, compare to `CHANGELOG.md`, and verify every named file and capability against the tag candidate. |
+| Notes are factually wrong after publication | Preserve the tag and artifacts; follow the documentation-correction procedure above and keep undelivered issues open. |
 | CI fails on tests | Run `make all` locally before tagging. |
 | Tag/version mismatch | Run `python -m scripts.check_release_contract --tag vX.Y.Z`; align `_version.py`, runtime metadata, and changelog before creating a new tag. |
 | Hash verification fails | Stop. Do not publish or attach the bundle; create a clean patch release after diagnosis. |

--- a/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
+++ b/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
@@ -8,9 +8,9 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-07
-verified: 2026-08-07
-stale_after: 2026-11-04
+last_verified: 2026-08-08
+verified: 2026-08-08
+stale_after: 2026-11-06
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 source_commit: 8e90b44
@@ -318,11 +318,18 @@ and protects the target/workflow contract with focused tests. A repository-wide
 
 ### P1.6 — Release artifacts not built once
 
-**Status:** confirmed; covered by #105.
+**Status:** resolved by #105, PR #123, and v1.7.0 on 2026-08-08.
 
-Pre-flight, PyPI build, and GitHub release do not necessarily consume the same immutable wheel/sdist. Workflows use movable tags and the `nltk` VCS override is tag-based instead of commit-based.
+At the audit baseline, pre-flight, PyPI build, and GitHub release did not prove
+that they consumed the same immutable wheel/sdist, and workflow dependencies
+used movable tags. The v1.7.0 release graph now builds once, records and
+re-verifies SHA-256, publishes the exact files through PyPI OIDC, and creates
+the GitHub Release only after PyPI succeeds. Every external action is pinned to
+a reviewed full commit SHA.
 
-**Action:** build once, checksum, publish attested artifacts, release exact bytes, and align tags, versions, and changelog entries.
+**Evidence:** PR #123, release run 31237286005, public PyPI/GitHub hashes and
+provenance, and the execution record in section 17. #124 tracks the upstream
+Node.js runtime annotation without weakening this resolved lineage.
 
 ### P2 — Strategic debt valid but not as urgent as current findings
 
@@ -538,7 +545,8 @@ originally stacked on feature branches.
 
 ### Wave 4 — Release confidence
 
-- #105: build once / publish exact bytes;
+- #105: completed in v1.7.0 — build once / publish exact bytes;
+- #124: wait for official Node.js 24 artifact-action manifests, then repin;
 - pin actions by SHA;
 - pin VCS dependency commits;
 - install typed wheel in clean environment, verify `RECORD` and checksum;
@@ -656,7 +664,8 @@ FILE_URI_RESULT /private/etc/passwd
 ## 14. Limits and non-authoritative claims
 
 - No benchmark was run against a real or 10k-page vault.
-- No public release was qualified and no clean wheel installation was verified.
+- At the 2026-08-06 baseline, no public release was qualified and no clean wheel
+  installation was verified. Section 17 records the v1.7.0 resolution.
 - The follow-up phase opened PR #112, created issue #113, updated impacted issues, and closed only completed/duplicate entries in the reconciliation log. Milestones, branch protection, and remote workflows were not changed.
 - The study does not prove complete compatibility with all Logseq versions.
 - The symlink probe demonstrates macOS/POSIX behavior; the policy must include Windows matrix coverage.
@@ -720,7 +729,47 @@ every merged tranche reported seven passes and zero failures.
    federation still requires final checks on the resulting merged `main`.
 
 The unresolved roadmap is intentionally not folded into this stack: #103 and
-#104 are the next correctness foundations; #105 and #111 remain release and
-measurement work; #108 remains blocked on the corpus and benchmarks. Product
-RFCs and contributor issues retain their existing dispositions in the issue
-reconciliation ledger.
+#104 are the next correctness foundations; #111 remains measurement work; #108
+remains blocked on the corpus and benchmarks. #105 is completed by the release
+record below. Product RFCs and contributor issues retain their existing
+dispositions in the issue reconciliation ledger.
+
+## 17. v1.7.0 release execution record — 2026-08-08
+
+[PR #123](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/123)
+prepared the SemVer-minor release and squash merged as `af45c1b3`. Fourteen PR
+checks passed; fresh `main` CI and CodeQL also passed on that exact commit.
+Tag `v1.7.0` points to `af45c1b3e75dfc32f42cfede5083f90aec8b96ce`.
+
+The ordered [Release run](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/31237286005)
+completed every job:
+
+1. Python 3.12 and 3.13 pre-flight ran dependency audit, `make all`, and clean
+   checkout verification.
+2. One build job validated tag/source/runtime/changelog, built wheel and sdist,
+   ran wheel and Twine checks, recorded SHA-256, and uploaded one immutable
+   bundle.
+3. PyPI downloaded and verified that bundle, then published it through trusted
+   publishing with OIDC attestations.
+4. The GitHub Release ran only after PyPI succeeded, re-verified the same
+   manifest, and attached the same wheel, sdist, and `SHA256SUMS`.
+
+Public verification matched all three digest surfaces:
+
+| Distribution | SHA-256 |
+|---|---|
+| `logseq_matryca_parser-1.7.0-py3-none-any.whl` | `6624b59742206ad9c4cf68dd00686f0995861ebc304f9241d05b5a3d047cf354` |
+| `logseq_matryca_parser-1.7.0.tar.gz` | `57e44dd90cbc7aa43b7fb47462fdddfe4d8759a45fd6c268250cfa1356a36f62` |
+
+PyPI exposes provenance for both files. A direct PyPI install reported metadata
+version `1.7.0`; reinstalling the byte-identical published wheel into the
+qualified dependency environment produced runtime version `1.7.0`, imported
+from `site-packages`, and rendered `matryca-parse --help` successfully. #105 is
+closed with this evidence.
+
+The initial release notes incorrectly listed `examples/run_synapse_rag.py`,
+which is absent from the tag; #90 therefore remains open. The correction is a
+dated changelog and GitHub Release erratum only: tag, distributions,
+attestations, and digests remain unchanged. The only workflow annotations were
+upstream Node.js 20 deprecation warnings; #124 tracks migration when official
+Node.js 24 artifact-action manifests become available.

--- a/docs/log.md
+++ b/docs/log.md
@@ -8,9 +8,9 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-07
-verified: 2026-08-07
-stale_after: 2027-02-02
+last_verified: 2026-08-08
+verified: 2026-08-08
+stale_after: 2027-02-04
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -18,6 +18,30 @@ superseded_by: null
 ---
 
 # Documentation evolution log
+
+## 2026-08-08
+
+- Merged [PR #123](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/123)
+  and published the SemVer-minor v1.7.0 release from
+  `main@af45c1b3e75dfc32f42cfede5083f90aec8b96ce`.
+- Verified the complete ordered release run: Python 3.12/3.13 pre-flight,
+  dependency audit, non-mutating quality gate, one wheel/sdist build, wheel and
+  Twine contracts, SHA-256 manifest, PyPI trusted publication with OIDC
+  attestations, and GitHub Release creation from the same bundle.
+- Reconciled GitHub, PyPI, and local verification. Wheel SHA-256 is
+  `6624b59742206ad9c4cf68dd00686f0995861ebc304f9241d05b5a3d047cf354`;
+  sdist SHA-256 is
+  `57e44dd90cbc7aa43b7fb47462fdddfe4d8759a45fd6c268250cfa1356a36f62`.
+  PyPI provenance exists for both files; direct installation, runtime metadata,
+  package import, and CLI help report v1.7.0 successfully.
+- Closed #105 with public evidence and opened
+  [#124](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/124)
+  for the upstream Node.js 20 artifact-action annotations. Current official
+  releases still declare `node20`, so no unreviewed workaround was introduced.
+- Corrected a factual release-note error: `examples/run_synapse_rag.py` is not
+  present in v1.7.0, so #90 remains open. Added a dated changelog erratum and a
+  post-publication correction procedure; tag, artifacts, attestations, and
+  digests remain unchanged.
 
 ## 2026-08-07
 

--- a/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
+++ b/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md
@@ -8,9 +8,9 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-07
-verified: 2026-08-07
-stale_after: 2026-09-05
+last_verified: 2026-08-08
+verified: 2026-08-08
+stale_after: 2026-09-07
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: docs/quality/ISSUE_TRIAGE_2026-07.md
@@ -25,10 +25,11 @@ closure is justified only by current code, tests or an explicit duplicate;
 runtime behavior without a dedicated regression test remains tracked.
 
 The reconciliation was published in [PR #112](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/112).
-After the actions below, merged follow-up PRs #114-#121, and the evidence-based
-closure of #106, live verification on 2026-08-07 found 23 open issues. The
-parser P0 and the completed API, collision, and filesystem tranches are no
-longer part of the open backlog.
+After the actions below, merged follow-up PRs #114-#123, and the evidence-based
+closure of #105 and #106, live verification on 2026-08-08 found 23 open issues:
+#105 left the backlog after the verified v1.7.0 publication, while new upstream
+runtime follow-up #124 entered it. The parser P0 and the completed API,
+collision, filesystem, and release-lineage tranches are no longer open.
 
 ## Decisions
 
@@ -64,7 +65,7 @@ longer part of the open backlog.
 | #102 | Closed by merged [PR #120](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/120) | Shipped | Stable collision diagnostics, preserved winner policy, typed strict mode, CLI rendering, and no-ghost tests |
 | #103 | Expand | Wave 0/3 | Add rename/backlink cold-load equivalence |
 | #104 | Expand | Wave 0/3 | Add arbitrary-depth parser regression matrix |
-| #105 | Keep | Wave 4 | Immutable build-once release lineage remains absent |
+| #105 | Closed after [PR #123](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/123) and v1.7.0 verification | Shipped | One checksummed bundle reached PyPI through OIDC and the GitHub Release byte-for-byte; public provenance, hashes, install, runtime, metadata, and CLI were verified |
 | #106 | Closed after merged [PR #121](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/121) | Shipped | Vault confinement, target identity, metadata preservation, dry-run patch, limits, typed diagnostics, symlink and `file://` tests |
 | #107 | Closed by merged [PR #117](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/117) | Shipped | PEP 561 wheel marker, derived version contract, API tiers, import/signature tests, and downstream Mypy probe |
 | #108 | Keep blocked by prerequisites | Wave 6 | Begin only after deep parser fix and #104 corpus |
@@ -92,7 +93,7 @@ longer part of the open backlog.
 completed: parser P0 + #106 filesystem boundary + #101/#102/#107 foundations
   -> next: #103 snapshot correctness + #104 semantic corpus
   -> complete #109 documentation federation + #110 diagnostic producers
-  -> #105 release provenance
+  -> completed: #105 release provenance in v1.7.0
   -> #111 measured scale
   -> #108 parser phase extraction
 ```
@@ -117,3 +118,20 @@ not touch protected parser/graph hubs or weaken these gates.
 - [PR #122](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/122)
   publishes this final live-backlog reconciliation directly against `main`
   without claiming additional implementation scope.
+- Merged [PR #123](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/123)
+  and published v1.7.0 from `main@af45c1b3`. The ordered release run built one
+  wheel/sdist bundle, re-verified its SHA-256 manifest before PyPI and GitHub,
+  published OIDC attestations, and passed an independent install/runtime/CLI
+  check. #105 is closed.
+- Kept #90 open after live tree verification found that
+  `examples/run_synapse_rag.py` is still absent. The initial v1.7.0 release
+  notes listed it incorrectly; the changelog and GitHub Release receive a
+  transparent documentation-only erratum without changing artifacts.
+
+## Post-baseline issue — 2026-08-08
+
+- [#124](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/124)
+  tracks the Node.js 20 deprecation annotations emitted by the successful
+  v1.7.0 run. Official `upload-artifact` v7.0.1 and `download-artifact` v8.0.1
+  still declare `node20`, so the repository must wait for official Node.js 24
+  manifests and then repin reviewed full SHAs without changing release lineage.

--- a/scripts/check_release_contract.py
+++ b/scripts/check_release_contract.py
@@ -40,12 +40,41 @@ def runtime_version() -> str:
     return result.stdout.strip()
 
 
+def missing_repository_links(release_notes: str, repository_root: Path) -> list[str]:
+    """Return deterministic failures for missing or escaping local Markdown links."""
+    resolved_root = repository_root.resolve()
+    failures: set[str] = set()
+    destinations = re.findall(r"(?<!!)\[[^]]+\]\(([^)\s]+)", release_notes)
+
+    for raw_target in destinations:
+        target = raw_target.strip("<>")
+        if (
+            not target
+            or target.startswith(("#", "/"))
+            or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", target)
+        ):
+            continue
+
+        path_text = target.split("#", 1)[0].split("?", 1)[0]
+        if not path_text:
+            continue
+
+        candidate = (resolved_root / path_text).resolve()
+        if candidate != resolved_root and resolved_root not in candidate.parents:
+            failures.add(f"release notes link escapes repository: {target!r}")
+        elif not candidate.exists():
+            failures.add(f"release notes link target does not exist: {path_text!r}")
+
+    return sorted(failures)
+
+
 def validate_release(
     *,
     tag: str,
     source: str,
     runtime: str,
     changelog_text: str,
+    repository_root: Path | None = None,
 ) -> tuple[list[str], str | None]:
     """Return deterministic release-contract failures and release notes."""
     failures: list[str] = []
@@ -69,6 +98,8 @@ def validate_release(
         body = "\n".join(notes.splitlines()[1:]).strip()
         if not body or not any(line.lstrip().startswith("- ") for line in body.splitlines()):
             failures.append(f"changelog section [{tag_version}] has no release-note bullets")
+        if repository_root is not None:
+            failures.extend(missing_repository_links(notes, repository_root))
 
     try:
         unreleased = extract_changelog_section(
@@ -110,6 +141,7 @@ def main(argv: list[str] | None = None) -> int:
         source=source,
         runtime=runtime,
         changelog_text=changelog_text,
+        repository_root=ROOT,
     )
     for failure in failures:
         print(f"release-contract: {failure}")

--- a/tests/test_check_release_contract.py
+++ b/tests/test_check_release_contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from scripts.check_release_contract import validate_release
 
 
@@ -28,6 +30,49 @@ def test_valid_release_contract() -> None:
     assert failures == []
     assert notes is not None
     assert "Verified release artifact lineage" in notes
+
+
+def test_repository_relative_release_links_must_exist(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "present.md").write_text("# Present\n", encoding="utf-8")
+    changelog = _changelog().replace(
+        "- Verified release artifact lineage.",
+        "\n".join(
+            (
+                "- [Present](docs/present.md#present)",
+                "- [Missing](examples/missing.py)",
+                "- [External](https://example.com/release)",
+            )
+        ),
+    )
+
+    failures, _ = validate_release(
+        tag="v1.7.0",
+        source="1.7.0",
+        runtime="1.7.0",
+        changelog_text=changelog,
+        repository_root=tmp_path,
+    )
+
+    assert failures == ["release notes link target does not exist: 'examples/missing.py'"]
+
+
+def test_repository_relative_release_links_cannot_escape(tmp_path: Path) -> None:
+    changelog = _changelog().replace(
+        "- Verified release artifact lineage.",
+        "- [Outside](../outside.md)",
+    )
+
+    failures, _ = validate_release(
+        tag="v1.7.0",
+        source="1.7.0",
+        runtime="1.7.0",
+        changelog_text=changelog,
+        repository_root=tmp_path,
+    )
+
+    assert failures == ["release notes link escapes repository: '../outside.md'"]
 
 
 def test_tag_source_and_runtime_mismatches_are_reported() -> None:


### PR DESCRIPTION
## Summary

Reconcile the public v1.7.0 release with the maintained documentation and harden the release contract after independent post-publication verification.

## What changed

- record PR #123, `main@af45c1b3`, the successful release run, PyPI/GitHub provenance, exact public hashes, and installation/CLI verification in the maintained roadmap, issue ledger, and documentation log;
- close the completed #105 release-lineage tranche and record #124 as the separate upstream Node.js runtime follow-up;
- correct the initial release-note claim that `examples/run_synapse_rag.py` shipped — the file is absent, #90 remains open, and the correction does not alter the tag or artifacts;
- document the safe post-publication erratum procedure;
- make the release contract fail closed when versioned notes contain a missing or repository-escaping local Markdown link.

The current validator rejects the original tagged changelog with:

```text
release notes link target does not exist: 'examples/run_synapse_rag.py'
```

The corrected changelog passes. After this PR merges, the GitHub Release notes will be updated from the corrected v1.7.0 section; PyPI files, GitHub assets, attestations, tag, and SHA-256 digests remain unchanged.

## Public release evidence

- [v1.7.0 Release](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases/tag/v1.7.0)
- [Release workflow run 31237286005](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/31237286005)
- [PyPI 1.7.0](https://pypi.org/project/logseq-matryca-parser/1.7.0/)
- wheel SHA-256: `6624b59742206ad9c4cf68dd00686f0995861ebc304f9241d05b5a3d047cf354`
- sdist SHA-256: `57e44dd90cbc7aa43b7fb47462fdddfe4d8759a45fd6c268250cfa1356a36f62`

## Validation

- `make all`: 530 passed, 91.81% coverage, Ruff clean, Mypy clean, documentation profile clean, vendor-name policy clean
- focused release-contract tests: 7 passed
- corrected `v1.7.0` release contract: passed
- original tagged changelog: fails on the exact missing example path
- explicit `make vendor-name-check`: passed
- `git diff --check`: passed
- `src/` is byte-identical to the release-qualified commit; no parser/graph hub or package runtime code changed
