### PR TITLE
docs: streamline README and add AI discovery

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,22 @@
+# Logseq Matryca Parser repository instructions
+
+Read [`../AGENTS.md`](../AGENTS.md) before planning or changing this repository.
+Use [`../docs/index.md`](../docs/index.md) as the canonical maintained knowledge
+map and [`../llms.txt`](../llms.txt) as the concise capability index.
+
+- Logseq Markdown is the source of truth; graphs, registries, exports, and AI
+  chunks are derived views.
+- Preserve deterministic AST identity, hierarchy, order, line ranges,
+  properties, references, and parse/serialize round trips.
+- Prefer documented package-root imports and keep optional integrations lazy.
+- Treat vault containment, symlinks, asset paths, target identity, atomic
+  replacement, and bounded writes as security boundaries.
+- Use impact analysis before changing parser or graph hub symbols named in
+  `AGENTS.md`.
+- Keep user-facing documentation, diagnostics, examples, and operator messages
+  in English.
+- Add focused regression tests for behavior changes.
+- Run `make all`, `make vendor-name-check`, and the zero-import-cycle check
+  before proposing completion.
+- Never commit credentials, vault data, local tool caches, generated audit data,
+  or `.matryca_xray_state.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,83 @@
-# Audit code — maintainer intelligence
+# AI agent orientation
+
+## Product in one paragraph
+
+Logseq Matryca Parser turns a directory of sovereign Logseq Markdown files into
+a deterministic typed AST and an in-memory graph. It preserves outline
+hierarchy, block UUIDs, page aliases, backlinks, properties, tasks, timestamps,
+and assets so humans and AI systems can retrieve, inspect, export, visualize,
+and safely extend a vault without flattening its structure.
+
+Markdown files are the source of truth. The in-memory graph, registries,
+backlinks, exports, visualizations, and AI chunks are derived views.
+
+## Capability map
+
+| Layer | Use it for | Primary entry point |
+|---|---|---|
+| **LOGOS** | Parse Logseq Markdown into a deterministic AST | `LogosParser`, `StackMachineParser` |
+| **Graph** | Load a vault, resolve pages and aliases, query nodes, inspect backlinks | `LogseqGraph` |
+| **SYNAPSE** | Export lineage-aware LangChain documents, LlamaIndex nodes, and enriched chunks | `SynapseAdapter` |
+| **FORGE** | Serialize JSON, clean Markdown, Logseq pages, and Obsidian-compatible output | `ForgeExporter`, `serialize_logseq_page` |
+| **KINETIC** | Run CLI parse, export, scan, visualize, agent-read, and agent-write workflows | `matryca-parse` |
+| **LENS** | Build an interactive graph visualization | `GraphVisualizer` |
+| **Agent access** | Read a token-efficient X-Ray outline or perform bounded writes | `agent-read`, `agent-write`, `logseq_agent_write` |
+
+## Start here
+
+- For installation and a first run, use [`README.md`](README.md).
+- For integration recipes, use [`docs/COOKBOOK.md`](docs/COOKBOOK.md).
+- For stable imports and compatibility guarantees, use
+  [`docs/reference/API_STABILITY.md`](docs/reference/API_STABILITY.md).
+- For architecture and ownership boundaries, use
+  [`docs/CLEAN_CODE_ARCHITECTURE.md`](docs/CLEAN_CODE_ARCHITECTURE.md).
+- For the maintained machine-readable knowledge map, use
+  [`docs/index.md`](docs/index.md).
+- For historical release capabilities, use
+  [`RELEASE_HIGHLIGHTS.md`](RELEASE_HIGHLIGHTS.md).
+
+Prefer imports from the package root when they are part of the documented
+stable API. Before editing, identify whether the task affects parsing, graph
+identity, serialization, filesystem writes, optional adapters, or CLI-only
+presentation. Do not infer runtime contracts from release history.
+
+## Repository working contract
+
+```bash
+uv sync --all-extras
+make all
+make vendor-name-check
+```
+
+- Keep all user-facing documentation and operator messages in English.
+- Preserve deterministic UUIDs, tree order, parent and left pointers, source
+  line ranges, and parse/serialize round trips.
+- Treat paths, symlinks, `file://` assets, atomic replacement, and vault
+  containment as security boundaries.
+- Keep optional integrations lazy; the base parser must remain lightweight.
+- Add focused regression tests for behavioral changes and do not lower the
+  coverage floor.
+- Do not commit local caches, generated audit data, vault contents, credentials,
+  or `.matryca_xray_state.json`.
+
+## Audit code — maintainer intelligence
 
 Maintainers may use **audit code** (local graph-based static analysis) to understand call chains, blast radius, and import cycles before structural work. **Do not** name specific third-party indexer products anywhere in this repository (issues, PRs, CHANGELOG, public docs, or agent config).
 
-## Always do
+### Always do
 
 - Run **impact analysis** before editing hub symbols (`StackMachineParser._refresh_node`, `_expand_macros_and_embeds_impl`, `LogseqGraph.load_directory`, `invalidate_and_reload_page`).
 - Use **query** / **context** for cross-module flows instead of guessing from grep alone.
 - Run `check(cycles)` — expect **0** import cycles in `src/`.
 - Run `make all` (and `make vendor-name-check`) after behavior or documentation changes.
 
-## Never do
+### Never do
 
 - NEVER add vendor AST indexers to CI, Dockerfiles, or `pyproject.toml`.
 - NEVER ignore **HIGH** or **CRITICAL** impact warnings on parser/graph hubs without explicit user approval.
 - NEVER commit tool-specific cache directories — use `.git/info/exclude` locally (Ghost Tooling policy).
 
-## SSOT
+### SSOT
 
 | Document | Purpose |
 |----------|---------|

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 [![Status: Stable](https://img.shields.io/badge/Status-Stable-22c55e.svg?style=flat-square)](#)
 ![Origin: Matryca.ai](https://img.shields.io/badge/Origin-Matryca.ai-gold?style=for-the-badge)
 
-**v1.7.1** — runnable offline SYNAPSE RAG integration, stricter release-note contracts, and security-refresh constraints for optional AI/development dependencies. See the [CHANGELOG](CHANGELOG.md) and [release process](docs/RELEASE_PROCESS.md).
-
 > *Turning a forest of local plain-text files into a unified semantic powerhouse.*
 
 <p align="center">
@@ -22,9 +20,32 @@
 
 [👉 **TRY THE LIVE INTERACTIVE DEMO**](https://MarcoPorcellato.github.io/logseq-matryca-parser/)
 
-[📘 **ARCHITECTURE**](docs/ARCHITECTURE.md) · [Clean Architecture SSOT](docs/CLEAN_CODE_ARCHITECTURE.md) · [AST Primer](docs/logseq_ast_primer.md) · [Cookbook](docs/COOKBOOK.md) · [Good first issues](docs/GOOD_FIRST_ISSUES.md) · [Knowledge bundle](docs/index.md) · [Docs index](docs/README.md) · [Documentation system](docs/DOCUMENTATION_SYSTEM.md) · [CodeQL](docs/CODEQL.md) · [Changelog](CHANGELOG.md) · [Release process](docs/RELEASE_PROCESS.md)
+[Quickstart](#quickstart) · [Documentation](docs/README.md) · [Cookbook](docs/COOKBOOK.md) · [Release highlights](RELEASE_HIGHLIGHTS.md) · [AI / LLM index](llms.txt)
 
 </div>
+
+---
+
+## Quickstart
+
+Install the package and scan a Logseq graph:
+
+```bash
+uv pip install logseq-matryca-parser
+matryca-parse scan /path/to/logseq/graph
+```
+
+The scan reports pages, blocks, references, and graph diagnostics without
+changing the vault. Continue with the [CLI and Python examples](#usage), or use
+the [Cookbook](docs/COOKBOOK.md) for RAG, graph-query, watcher, and agent recipes.
+
+### Choose your workflow
+
+- **Parse and query:** load one page or a complete vault as a typed AST and graph.
+- **Build RAG context:** export LangChain documents, LlamaIndex nodes, or enriched chunks.
+- **Move knowledge:** generate JSON, clean Markdown, or an Obsidian vault.
+- **Visualize:** render an interactive graph with LENS.
+- **Use an AI agent:** start from [`AGENTS.md`](AGENTS.md) or the concise [`llms.txt`](llms.txt) index.
 
 ---
 
@@ -106,263 +127,18 @@ Logseq Matryca Parser is a deterministic **Stack-Machine engine** that acts as t
 
 ---
 
-## ⚡ Release highlights (v1.7.1)
+## 🏗️ Core capabilities
 
-Patch release — completes the promised SYNAPSE example and closes the security
-alerts found during v1.7.0 post-release verification. **No intentional breaking
-changes** to package APIs or CLI behavior.
-
-| Area | Change |
+| Outcome | What Matryca provides |
 | :--- | :--- |
-| **SYNAPSE RAG** | New offline [`examples/run_synapse_rag.py`](examples/run_synapse_rag.py) exercises LangChain, LlamaIndex, context enrichment, and resolved page-embed expansion. |
-| **Release integrity** | Release notes now fail validation when a repository-local link is missing or escapes the source tree. |
-| **Dependency security** | Optional AI/development resolution constrains `aiohttp>=3.14.3` and `setuptools>=83.0.0`; base runtime dependencies are unchanged. |
-| **Test suite** | **532** pytest cases with **91.90%** coverage. |
-
----
-
-## ⚡ Release highlights (v1.7.0)
-
-Minor release — repository-wide correctness, safety, API, documentation, and release-engineering hardening. **No intentional breaking changes** to default CLI behavior or stable package exports.
-
-| Area | Change |
-| :--- | :--- |
-| **Correctness** | Arbitrary-depth immutable parser refreshes preserve ordering, identity, properties, soft breaks, fences, and round trips. |
-| **Diagnostics and graph** | Stable structured findings, JSON output, deterministic title-collision diagnostics, and opt-in strict rejection. |
-| **Writer security** | Vault containment, symlink and target-identity checks, metadata preservation, dry-run patches, and bounded writes. |
-| **Public package** | PEP 561 `py.typed`, documented API stability tiers, root exports, signature tests, and wheel/downstream Mypy contracts. |
-| **Documentation** | English maintained-document profile, authority and lifecycle metadata, deterministic link/freshness validation, and Matryca Knowledge federation guidance. |
-| **Release integrity** | One checksummed wheel/sdist build is reused for attested PyPI publication and GitHub Release assets. |
-| **Test suite** | **528** pytest cases with **91.81%** coverage. |
-
----
-
-## ⚡ Release highlights (v1.5.0)
-
-Minor release — CLI vault hygiene for broken block references. **No intentional breaking changes** to default `scan` behavior (`--broken-refs` is opt-in).
-
-| Area | Change |
-| :--- | :--- |
-| **KINETIC `scan`** | New `--broken-refs` flag prints unresolved `((uuid))` refs in a Rich table and exits `1` for CI pipelines ([#77](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/77)). |
-| **Test suite** | **451** pytest cases (**+1** vs v1.4.2). |
-
----
-
-## ⚡ Release highlights (v1.4.2)
-
-Patch release — agent-write and SYNAPSE correctness fixes. **No intentional breaking changes** to public APIs.
-
-| Area | Change |
-| :--- | :--- |
-| **agent-write** | Headless splice normalizes files missing a final newline; corrupt `.matryca_xray_state.json` yields a controlled CLI exit ([#72](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/72), [#60](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/60)). |
-| **SYNAPSE RAG** | Cyclic `{{embed [[Page]]}}` chains truncate at the re-entrant edge without duplicating parent literal text ([#65](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/65)). |
-| **Test suite** | **450** pytest cases (**+72** vs v1.4.1): wave 2 community coverage ([#58](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/58)) plus regression tests for the three fixes. |
-
----
-
-## ⚡ Release highlights (v1.4.1)
-
-Patch release — contributor test coverage and onboarding refresh. **No intentional changes** to parser, graph, or CLI runtime behavior.
-
-| Area | Change |
-| :--- | :--- |
-| **Test suite** | **378** pytest cases (**+107** vs v1.4.0): `normalize_logseq_timestamp`, `clean_node_content`, `logseq_paths` fallbacks, exception hierarchy, `extract_changelog` script, KINETIC `--help`, `agent-read --query`, direct `ObsidianForgeVisitor` tests ([#42](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/42)). |
-| **New test modules** | `tests/test_exceptions.py`, `tests/test_extract_changelog.py`. |
-| **Contributor index** | [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) wave 2 ([#43](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/43)–[#52](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/52)); wave-1 items marked complete. |
-
----
-
-## ⚡ Release highlights (v1.4.0)
-
-Minor release — graph integrity, export hygiene, and parser hardening from the local static-analysis bug hunt (waves 1–8). No intentional breaking changes to default parse behavior.
-
-| Area | Change |
-| :--- | :--- |
-| **Graph index** | **`iter_canonical_pages()`** and **`page_for_node()`** deduplicate alias keys; **`load_directory`** rebuilds **`_node_registry`** from indexed pages only (no ghost nodes after title collision). |
-| **Case-insensitive queries** | **`search_content`**, **`GraphQuery.has_tag`**, and **`get_nodes_by_tag`** match tags case-insensitively (optional `#` prefix). |
-| **Live watcher** | **`LogseqGraphWatcher`** handles **`on_deleted`** and **`on_moved`**; **`invalidate_and_reload_page`** purges registries when a page file was deleted. |
-| **Agent writes** | **`append_child_to_node`** calls **`invalidate_and_reload_page`** so the in-memory graph matches disk after headless splice. |
-| **SYNAPSE** | Page/block embed expansion uses **`get_page`** (case-insensitive) and fail-safe empty replacement (no infinite loops on unresolved embeds). |
-| **Serialization** | Per-page **`tab_size`** at parse time; **`serialize_logseq_page`** and **`append_child_to_node`** preserve four-space vault indentation. |
-| **Paths & assets** | **`resolve_relative_page_link`** supports **`../`** / **`./`**; **`resolve_asset_path`** rejects absolute paths and links that escape the graph root. |
-| **Strict refs** | **`LogseqGraph.load_directory(strict_refs=True)`** validates cross-page block refs via **`raise_if_broken_references()`**. |
-| **Docs & community** | [`docs/COOKBOOK.md`](docs/COOKBOOK.md), [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md), [`docs/BUG_HUNT_REPORT.md`](docs/BUG_HUNT_REPORT.md) (audit complete). |
-
----
-
-## ⚡ Release highlights (v1.3.1)
-
-Patch release — aligns example and skill install docs with the project's **`uv`** workflow. No parser or public API changes.
-
-| Area | Change |
-| :--- | :--- |
-| **Examples** | `examples/run_demo.py` error hint uses **`uv sync --all-extras`**. |
-| **Claude skill** | **`claude-skill-logseq-read/SKILL.md`** recommends **`uv pip install`**. |
-
----
-
-## ⚡ Release highlights (v1.3.0)
-
-Minor release — architectural quick wins, runtime robustness, and expanded public API. No breaking changes to default parser behavior.
-
-| Area | Change |
-| :--- | :--- |
-| **Public API** | Root **`logseq_matryca_parser`** exports **`SynapseAdapter`**, **`SessionAliasRegistry`**, **`GraphVisualizer`**, **`discover_graph_files`**, and core LOGOS symbols via explicit **`__all__`**. |
-| **Graph model** | **`LogseqGraph`** uses **`validate_assignment=True`** instead of frozen/`object.__setattr__` for incremental reloads. |
-| **Live watcher** | **`start_watching()`** debounces filesystem events (~500ms) and ignores editor temp/swap files (`.swp`, `~`, `.tmp`, `.DS_Store`). |
-| **Strict refs** | **`StackMachineParser(strict_refs=True)`** raises **`BlockReferenceError`** for unresolved same-page `((uuid))` refs (default off). |
-| **SYNAPSE** | **`SynapseMetadata`** / **`build_synapse_metadata`** for vector-store-safe fields; **LlamaIndex** adds **`SOURCE`**, **`NEXT`**, **`PREVIOUS`** relationships. |
-| **KINETIC CLI** | Global **`--verbose`** / **`--graph`** via **`@app.callback()`**; optional-dependency hints recommend **`uv sync --extra ai\|viz`**. |
-| **LENS** | Lazy-imports NetworkX/PyVis so core installs stay lightweight. |
-| **Security** | Transitive **`aiohttp`** / **`nltk`** constraints for optional **`[ai]`** extras. |
-
----
-
-## ⚡ Release highlights (v1.2.2)
-
-Patch release — fixes a failing CodeQL GitHub Actions workflow; **no parser or public API changes**.
-
-| Area | Change |
-| :--- | :--- |
-| **CodeQL** | Removed duplicate `.github/workflows/codeql.yml`; scanning continues via GitHub **default setup** (Node 24 runners). |
-| **Docs** | New [`docs/CODEQL.md`](docs/CODEQL.md) explains default vs advanced setup and troubleshooting. |
-
----
-
-## ⚡ Release highlights (v1.2.1)
-
-Infrastructure and contributor experience — no parser API breaks.
-
-| Area | Capability |
-| :--- | :--- |
-| **Python matrix** | CI and PyPI pre-flight test **3.12** and **3.13**; PyPI classifier for 3.13. |
-| **Quality gates** | `make all` parity in GitHub Actions (`uv sync --all-extras` → lint, mypy, pytest with **≥80%** coverage). |
-| **Security** | GitHub CodeQL default setup (SAST), `pip-audit` on production deps, expanded `SECURITY.md`, PyPI publish blocked until pre-flight passes. |
-| **Community** | `CODE_OF_CONDUCT.md`, `CODEOWNERS`, issue-template config, CONTRIBUTING with `uv` workflow. |
-| **Docs** | Root `ROADMAP_*.md` consolidated under [`docs/roadmaps/`](docs/roadmaps/). |
-
-Contributor setup: [`CONTRIBUTING.md`](CONTRIBUTING.md) · [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) · Security: [`SECURITY.md`](SECURITY.md) · CodeQL: [`docs/CODEQL.md`](docs/CODEQL.md)
-
----
-
-## ⚡ Recent superpowers (v1.2.0)
-
-### Graph parity, assets, and parser hardening
-
-| Area | Capability |
-| :--- | :--- |
-| **Asset extraction** | `LogseqNode.assets` collects markdown images, `{{pdf}}` macros, and local `[label](path)` attachments; `LogseqPage.resolve_asset_path` maps to absolute paths (`%20` decode, graph-root relative). |
-| **YAML frontmatter** | `---` blocks at file start populate `LogseqPage.properties` like native `key::` lines; **`title:`** in YAML sets `page.title` at parse; **`serialize_logseq_page`** preserves `---` fences on round-trip when the source file used YAML. |
-| **`page-tags::`** | Block and page `page-tags::` inject implicit graph tokens like `tags::`; list-shaped values feed `refs`. |
-| **Case-insensitive routing** | `LogseqGraph.get_page` and `resolve_relative_page_link` resolve titles via a lowercase index (Datomic parity). |
-| **Extended shielding** | HTML comments, `{{query}}` / `{{advancedquery}}`, and escaped `\#` / `\[\[` do not emit false graph tokens (embed macros still harvest nested wikilinks). |
-| **Property & temporal fixes** | Comma-split ignores commas inside `[[wikilinks]]`; properties after code fences; quoted value stripping; `SCHEDULED`/`DEADLINE` ranges, repeaters, and Org warning periods; legacy `___` / `%2F` / Dendron filenames; UTF-8 BOM via `utf-8-sig`. |
-
-### Round-trip serialization (v1.2.0)
-
-| Area | Capability |
-| :--- | :--- |
-| **Soft-break bodies** | Multiline block continuations serialize without double-indenting alignment spaces. |
-| **List-shaped block props** | `tags::` / `page-tags::` with indented `-` bullets round-trip as Logseq lists (not Python repr). |
-| **`:LOGBOOK:` drawers** | Org drawers re-emit as `:LOGBOOK:` / `:END:` blocks, not bogus `logbook::` property lines. |
-| **Derived temporal keys** | Parsed `scheduled::`, `repeater::`, and related derived fields are omitted from serialized `key::` output. |
-| **Stable block UUIDs** | Parse → `serialize_logseq_page` → parse preserves block `id::` / UUIDs on the same outline. |
-
-```python
-from logseq_matryca_parser.graph import LogseqGraph
-from logseq_matryca_parser.logos_parser import LogosParser
-
-graph = LogseqGraph.load_directory("/path/to/logseq/graph")
-
-# Case-insensitive page lookup
-page = graph.get_page("my page")  # same object as graph.pages["My Page"]
-
-# Assets on a parsed block (Vision / document pipelines)
-single = LogosParser().parse_page_file("pages/Notes.md")
-block = single.root_nodes[0]
-if block.assets:
-    abs_path = single.resolve_asset_path(block.assets[0])
-```
-
-Deep dive: [Architecture §3.1 — LOGOS](docs/ARCHITECTURE.md#31-logos--deterministic-stack-machine-parsing) · [§3.6 — LogseqGraph](docs/ARCHITECTURE.md#36-logseqgraph--namespace-scoping-o1-invalidation-live-watch) · [AST primer](docs/logseq_ast_primer.md).
-
-### Still included from v1.1.1
-
-| Area | Capability |
-| :--- | :--- |
-| **Graph index** | `title::` / `TITLE::` overrides filename titles; `alias::` / `aliases::` inject extra `graph.pages` keys. |
-| **Backlinks** | `[[Dev]]` resolves against alias keys (`get_backlinks("Dev")`). |
-| **Incremental reload** | `invalidate_and_reload_page` re-applies title/alias enrichment after watcher edits. |
-| **Parser shields** | LaTeX, `#+BEGIN_QUERY`, fenced code, drawers; `{{embed [[Page]]}}` harvests nested wikilinks. |
-| **Property contiguity** | `key::` contiguous under bullets; soft-break closes the window (fence exception in v1.2.0). |
-| **Tasks & bullets** | GFM checkboxes, extended Org markers, ordered-list bullets, aliased `((uuid))` clean text. |
-
-### Obsidian-native export
-Compile an entire Logseq graph into an **Obsidian vault layout**: YAML frontmatter from page properties, list body preserved, Logseq `((uuid))` links rewritten to **`[[Page#^anchor]]`**, and trailing **`^block-id`** on referenced blocks. Namespace titles become nested folders (e.g. `Projects/AI/Demo.md`).
-
-```bash
-matryca-parse export /path/to/logseq/graph /path/to/obsidian/vault --format obsidian
-```
-
-> **Note:** Wikilinks currently use the **Logseq page title** (e.g. `[[Target#^…]]`). Vault files may live under namespace folders (`Projects/AI/Demo.md`). Obsidian usually resolves unique titles; aligning link text to folder paths is a possible future refinement.
-
-### Live incremental watcher
-`LogseqGraph` supports **surgical file invalidation** (optional dependency: `uv sync --extra watch`). `start_watching()` runs a recursive **watchdog** observer with **~500ms debounce** and ignores editor temp/swap files: on `created` / `modified` / `deleted` / `moved` under `pages/` or `journals/`, only the affected file is re-parsed (or purged when deleted); stale synthetic UUIDs are removed from `_node_registry` and scrubbed from `_backlink_registry`—no full-graph cold reload.
-
-### Fluent topological queries
-Filter the global node registry with a **chainable** API (tags, task state, ancestry under a parent UUID):
-
-```python
-from logseq_matryca_parser.graph import LogseqGraph
-
-graph = LogseqGraph.load_directory("/path/to/logseq/graph")
-hits = (
-    graph.query()
-    .has_tag("idea")
-    .under_parent("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-    .is_task_state("TODO")
-    .execute()
-)
-```
-
-### Agent-Native X-Ray Mode (Token Optimization)
-For autonomous LLM agents, passing raw Markdown into the context window wastes thousands of tokens on **36-character UUIDs**, hidden `id::` properties, drawers, and collapsed directives that carry no immediate semantic signal. **X-Ray mode** compresses the parsed AST into **ultra-dense, zero-fluff plain text**: each block becomes `{indent}[{alias}] {clean_text}`, with heavy Logseq UUIDs replaced by **sequential integer aliases** (`[0]`, `[1]`, …) held in a session registry. On typical outlines this can reduce context consumption by **up to ~35×** compared to dumping full block payloads.
-
-```bash
-matryca-parse agent-read /path/to/graph --tag idea
-matryca-parse agent-read /path/to/graph --query "quantum"
-```
-
-The agent reads cheap topology now; the registry resolves aliases back to sovereign UUIDs when you wire targeted writes.
-
-### Headless Write Engine & AST Linter (Wave 12)
-The parser is **no longer read-only**. Wave 12 adds a **headless Markdown splicer** ([`agent_writer.py`](src/logseq_matryca_parser/agent_writer.py)): `append_child_to_node` uses AST line numbers and indentation (`(indent_level + 1) × tab_size`) to insert a new bullet **atomically** into the sovereign `.md` file—via `tempfile` + `os.replace`—without Logseq’s fragile HTTP API. Beyond surgical node splicing, the engine now supports **full bidirectional page generation** via [`serialize_logseq_page`](src/logseq_matryca_parser/logseq_markdown.py) and [`write_logseq_page`](src/logseq_matryca_parser/logseq_markdown.py)—rebuilding entire Logseq-compliant `.md` pages from an in-memory AST. Pair **`agent-read`** with **`agent-write`**: X-Ray persists its alias map to **`.matryca_xray_state.json`** at the graph root so stateless CLI invocations can **read, then write** in sequence.
-
-```bash
-matryca-parse agent-read /path/to/graph --tag idea
-matryca-parse agent-write /path/to/graph --alias 0 --content "Follow-up from the agent"
-```
-
-For graph hygiene, **`LogseqGraph.get_broken_references()`** flags nodes whose `((uuid))` block refs point at missing registry targets—structural linting, not regex guessing. From the CLI: `matryca-parse scan /path/to/graph --broken-refs` (exit `1` when broken refs exist).
-
----
-
-## 🏗️ Core Capabilities
-
-| Feature | Description |
-| :--- | :--- |
-| **LOGOS Engine** | Deterministic AST parsing. YAML + native frontmatter ingest, **format-preserving** `serialize_logseq_page` (YAML vs `key::` by source), list-shaped block property layout, **assets**, property contiguity (incl. post-fence), comma-safe wikilink splits, temporal ranges/repeaters, legacy filename decode, BOM-safe reads, and **shielded** code/math/query/HTML/escape regions. |
-| **Multimodal assets** | **`LogseqNode.assets`** + **`LogseqPage.resolve_asset_path`** for PDFs and images relative to the graph root (Vision / document RAG). |
-| **LogseqGraph** | In-memory vault: `pages` index (with **title/alias enrichment** and **case-insensitive lookup**), **`iter_canonical_pages()`** / **`page_for_node()`**, backlinks, effective properties, namespace resolution, fluent `GraphQuery`, optional **watchdog** invalidation (create/modify/delete/move). |
-| **Advanced Task Extraction** | Task **state** (TODO / DOING / DELEGATED / IN-PROGRESS / …), **priority** markers `[#A]`–`[#C]` promoted to `task_priority`, and **SCHEDULED** / **DEADLINE** Logseq timestamps normalized to **UTC Unix epoch seconds** on `scheduled_at` / `deadline_at` for temporal graph and retrieval pipelines. |
-| **SYNAPSE Adapter** | Native exports for **LangChain** and **LlamaIndex** with automated lineage metadata; **context-enriched** chunks with breadcrumbs, embed expansion, and inherited properties. |
-| **FORGE** | JSON, clean Markdown, and **Obsidian** vault serialization (`ObsidianForgeVisitor`, `ForgeExporter.to_obsidian_markdown`). |
-| **LENS Visualizer** | 60FPS interactive graph rendering (10k+ nodes) with Glassmorphism HUD. |
-| **Agent-Native Printing Press** | [`agent_press.py`](src/logseq_matryca_parser/agent_press.py): **`SessionAliasRegistry`** maps session aliases ↔ block UUIDs; **`to_xray_markdown`** emits token-minimal outline text for autonomous agents (`matryca-parse agent-read`). |
-| **Native Markdown Serialization** | [`logseq_markdown.py`](src/logseq_matryca_parser/logseq_markdown.py) + [`logseq_paths.py`](src/logseq_matryca_parser/logseq_paths.py): rebuild and write Logseq-compliant markdown from an AST—page header preserves **YAML `---` or native `key::`** by source format, block properties at **parent whitespace + 2 spaces** (including bullet-list `tags::`), `:LOGBOOK:` drawers, and namespace titles via **`___`** pathing rules. |
-| **Headless Write Engine** | [`agent_writer.py`](src/logseq_matryca_parser/agent_writer.py): **`append_child_to_node`** splices child bullets into on-disk Markdown from AST topology; **`serialize_logseq_page`** / **`write_logseq_page`** emit full pages; **`matryca-parse agent-write`** resolves aliases via **`.matryca_xray_state.json`**. |
-| **AST Linters** | **`LogseqGraph.get_broken_references()`** returns originating nodes when `block_refs` target UUIDs absent from the global registry; **`matryca-parse scan --broken-refs`** exposes the same check from KINETIC (v1.5.0). |
-| **Sovereign AI** | 100% Local. Zero telemetry. Private by design. |
+| **Parse faithfully — LOGOS** | Deterministic AST parsing for outlines, YAML and native properties, tasks, temporal markers, references, assets, code/math/query shields, stable UUIDs, line ranges, and format-preserving round trips. |
+| **Understand the vault — Graph** | Canonical pages, aliases, backlinks, inherited properties, case-insensitive lookup, namespace resolution, fluent queries, broken-reference diagnostics, and optional per-file live reloads. |
+| **Export and integrate — SYNAPSE, FORGE, LENS** | Lineage-aware LangChain and LlamaIndex exports, context-enriched chunks, JSON and Markdown serialization, Obsidian vault generation, and interactive graph visualization. |
+| **Automate safely — KINETIC and agent tools** | CLI parse, scan, export, and visualization; token-efficient X-Ray reads; append-only logging; bounded AST writes; vault containment, dry-run patches, and atomic replacement. |
+
+The base parser is local-first and has zero telemetry. Optional AI, watcher, and
+visualization dependencies remain lazy. See the [architecture](docs/ARCHITECTURE.md)
+and [API stability reference](docs/reference/API_STABILITY.md) for exact boundaries.
 
 ### Data model — `LogseqNode` task fields
 
@@ -383,12 +159,9 @@ Marker syntax (`[#A]`, `SCHEDULED: <...>`, `DEADLINE: <...>`) is stripped from `
 
 ---
 
-## 🛠️ Quickstart
+## Usage
 
 ```bash
-# Install from PyPI (latest: v1.7.1)
-uv pip install logseq-matryca-parser
-
 # Optional: filesystem watcher for live incremental graph updates
 uv pip install 'logseq-matryca-parser[watch]'
 
@@ -490,6 +263,25 @@ We welcome issues, pull requests, and constructive feedback.
 | **Documentation system** | [docs/DOCUMENTATION_SYSTEM.md](docs/DOCUMENTATION_SYSTEM.md) — authority, lifecycle, metadata, and federation |
 | **Code of Conduct** | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community standards |
 | **Security** | [SECURITY.md](SECURITY.md) — report vulnerabilities privately |
+
+## 📦 Release history
+
+Read the complete [release highlights](RELEASE_HIGHLIGHTS.md), the exhaustive
+[changelog](CHANGELOG.md), or the signed artifacts on
+[GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
+
+- **v1.7.1** — Added the runnable offline SYNAPSE RAG example and tightened release-note and optional-dependency security checks.
+- **v1.7.0** — Hardened parser correctness, graph diagnostics, writer safety, API stability, documentation governance, and release provenance.
+- **v1.5.0** — Added opt-in CLI detection of unresolved block references for vault and CI hygiene.
+- **v1.4.2** — Fixed agent-write newline handling, controlled corrupt-state failures, and cyclic SYNAPSE page embeds.
+- **v1.4.1** — Expanded contributor tests and refreshed the good-first-issue onboarding path.
+- **v1.4.0** — Strengthened graph integrity, live reloads, serialization, path safety, strict references, and parser edge cases.
+- **v1.3.1** — Aligned examples and skill installation instructions with the repository's `uv` workflow.
+- **v1.3.0** — Expanded the stable API and improved graph reloads, strict references, SYNAPSE metadata, CLI behavior, and optional imports.
+- **v1.2.2** — Restored CodeQL workflow reliability and documented its supported configuration.
+- **v1.2.1** — Added the Python 3.12/3.13 CI matrix, security gates, release pre-flight, and contributor infrastructure.
+- **v1.2.0** — Added graph parity, assets, round-trip serialization, Obsidian export, live watching, agent X-Ray mode, and headless writes.
+- **v1.1.1** — Established title and alias indexing, backlinks, incremental reload, parser shields, property parsing, and broader task markers.
 
 ---
 Architected by **Marco Porcellato** | Powered by **Matryca.ai**

--- a/RELEASE_HIGHLIGHTS.md
+++ b/RELEASE_HIGHLIGHTS.md
@@ -1,0 +1,281 @@
+# Release highlights
+
+This page preserves the reader-focused highlights for each documented release.
+For the exhaustive change history, see the [changelog](CHANGELOG.md). For
+published artifacts and attestations, see
+[GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
+
+## v1.7.1
+
+Patch release — completes the promised SYNAPSE example and closes the security
+alerts found during v1.7.0 post-release verification. **No intentional breaking
+changes** to package APIs or CLI behavior.
+
+| Area | Change |
+| :--- | :--- |
+| **SYNAPSE RAG** | New offline [`examples/run_synapse_rag.py`](examples/run_synapse_rag.py) exercises LangChain, LlamaIndex, context enrichment, and resolved page-embed expansion. |
+| **Release integrity** | Release notes now fail validation when a repository-local link is missing or escapes the source tree. |
+| **Dependency security** | Optional AI/development resolution constrains `aiohttp>=3.14.3` and `setuptools>=83.0.0`; base runtime dependencies are unchanged. |
+| **Test suite** | **532** pytest cases with **91.90%** coverage. |
+
+## v1.7.0
+
+Minor release — repository-wide correctness, safety, API, documentation, and
+release-engineering hardening. **No intentional breaking changes** to default
+CLI behavior or stable package exports.
+
+| Area | Change |
+| :--- | :--- |
+| **Correctness** | Arbitrary-depth immutable parser refreshes preserve ordering, identity, properties, soft breaks, fences, and round trips. |
+| **Diagnostics and graph** | Stable structured findings, JSON output, deterministic title-collision diagnostics, and opt-in strict rejection. |
+| **Writer security** | Vault containment, symlink and target-identity checks, metadata preservation, dry-run patches, and bounded writes. |
+| **Public package** | PEP 561 `py.typed`, documented API stability tiers, root exports, signature tests, and wheel/downstream Mypy contracts. |
+| **Documentation** | English maintained-document profile, authority and lifecycle metadata, deterministic link/freshness validation, and Matryca Knowledge federation guidance. |
+| **Release integrity** | One checksummed wheel/sdist build is reused for attested PyPI publication and GitHub Release assets. |
+| **Test suite** | **528** pytest cases with **91.81%** coverage. |
+
+## v1.5.0
+
+Minor release — CLI vault hygiene for broken block references. **No intentional
+breaking changes** to default `scan` behavior (`--broken-refs` is opt-in).
+
+| Area | Change |
+| :--- | :--- |
+| **KINETIC `scan`** | New `--broken-refs` flag prints unresolved `((uuid))` refs in a Rich table and exits `1` for CI pipelines ([#77](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/77)). |
+| **Test suite** | **451** pytest cases (**+1** vs v1.4.2). |
+
+## v1.4.2
+
+Patch release — agent-write and SYNAPSE correctness fixes. **No intentional
+breaking changes** to public APIs.
+
+| Area | Change |
+| :--- | :--- |
+| **agent-write** | Headless splice normalizes files missing a final newline; corrupt `.matryca_xray_state.json` yields a controlled CLI exit ([#72](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/72), [#60](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/60)). |
+| **SYNAPSE RAG** | Cyclic `{{embed [[Page]]}}` chains truncate at the re-entrant edge without duplicating parent literal text ([#65](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/65)). |
+| **Test suite** | **450** pytest cases (**+72** vs v1.4.1): wave 2 community coverage ([#58](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/58)) plus regression tests for the three fixes. |
+
+## v1.4.1
+
+Patch release — contributor test coverage and onboarding refresh. **No
+intentional changes** to parser, graph, or CLI runtime behavior.
+
+| Area | Change |
+| :--- | :--- |
+| **Test suite** | **378** pytest cases (**+107** vs v1.4.0): `normalize_logseq_timestamp`, `clean_node_content`, `logseq_paths` fallbacks, exception hierarchy, `extract_changelog` script, KINETIC `--help`, `agent-read --query`, direct `ObsidianForgeVisitor` tests ([#42](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/42)). |
+| **New test modules** | `tests/test_exceptions.py`, `tests/test_extract_changelog.py`. |
+| **Contributor index** | [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) wave 2 ([#43](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/43)–[#52](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/52)); wave-1 items marked complete. |
+
+## v1.4.0
+
+Minor release — graph integrity, export hygiene, and parser hardening from the
+local static-analysis bug hunt (waves 1–8). No intentional breaking changes to
+default parse behavior.
+
+| Area | Change |
+| :--- | :--- |
+| **Graph index** | **`iter_canonical_pages()`** and **`page_for_node()`** deduplicate alias keys; **`load_directory`** rebuilds **`_node_registry`** from indexed pages only (no ghost nodes after title collision). |
+| **Case-insensitive queries** | **`search_content`**, **`GraphQuery.has_tag`**, and **`get_nodes_by_tag`** match tags case-insensitively (optional `#` prefix). |
+| **Live watcher** | **`LogseqGraphWatcher`** handles **`on_deleted`** and **`on_moved`**; **`invalidate_and_reload_page`** purges registries when a page file was deleted. |
+| **Agent writes** | **`append_child_to_node`** calls **`invalidate_and_reload_page`** so the in-memory graph matches disk after headless splice. |
+| **SYNAPSE** | Page/block embed expansion uses **`get_page`** (case-insensitive) and fail-safe empty replacement (no infinite loops on unresolved embeds). |
+| **Serialization** | Per-page **`tab_size`** at parse time; **`serialize_logseq_page`** and **`append_child_to_node`** preserve four-space vault indentation. |
+| **Paths & assets** | **`resolve_relative_page_link`** supports **`../`** / **`./`**; **`resolve_asset_path`** rejects absolute paths and links that escape the graph root. |
+| **Strict refs** | **`LogseqGraph.load_directory(strict_refs=True)`** validates cross-page block refs via **`raise_if_broken_references()`**. |
+| **Docs & community** | [`docs/COOKBOOK.md`](docs/COOKBOOK.md), [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md), [`docs/BUG_HUNT_REPORT.md`](docs/BUG_HUNT_REPORT.md) (audit complete). |
+
+## v1.3.1
+
+Patch release — aligns example and skill install docs with the project's **`uv`**
+workflow. No parser or public API changes.
+
+| Area | Change |
+| :--- | :--- |
+| **Examples** | `examples/run_demo.py` error hint uses **`uv sync --all-extras`**. |
+| **Claude skill** | **`claude-skill-logseq-read/SKILL.md`** recommends **`uv pip install`**. |
+
+## v1.3.0
+
+Minor release — architectural quick wins, runtime robustness, and expanded
+public API. No breaking changes to default parser behavior.
+
+| Area | Change |
+| :--- | :--- |
+| **Public API** | Root **`logseq_matryca_parser`** exports **`SynapseAdapter`**, **`SessionAliasRegistry`**, **`GraphVisualizer`**, **`discover_graph_files`**, and core LOGOS symbols via explicit **`__all__`**. |
+| **Graph model** | **`LogseqGraph`** uses **`validate_assignment=True`** instead of frozen/`object.__setattr__` for incremental reloads. |
+| **Live watcher** | **`start_watching()`** debounces filesystem events (~500ms) and ignores editor temp/swap files (`.swp`, `~`, `.tmp`, `.DS_Store`). |
+| **Strict refs** | **`StackMachineParser(strict_refs=True)`** raises **`BlockReferenceError`** for unresolved same-page `((uuid))` refs (default off). |
+| **SYNAPSE** | **`SynapseMetadata`** / **`build_synapse_metadata`** for vector-store-safe fields; **LlamaIndex** adds **`SOURCE`**, **`NEXT`**, **`PREVIOUS`** relationships. |
+| **KINETIC CLI** | Global **`--verbose`** / **`--graph`** via **`@app.callback()`**; optional-dependency hints recommend **`uv sync --extra ai\|viz`**. |
+| **LENS** | Lazy-imports NetworkX/PyVis so core installs stay lightweight. |
+| **Security** | Transitive **`aiohttp`** / **`nltk`** constraints for optional **`[ai]`** extras. |
+
+## v1.2.2
+
+Patch release — fixes a failing CodeQL GitHub Actions workflow; **no parser or
+public API changes**.
+
+| Area | Change |
+| :--- | :--- |
+| **CodeQL** | Removed duplicate `.github/workflows/codeql.yml`; scanning continues via GitHub **default setup** (Node 24 runners). |
+| **Docs** | New [`docs/CODEQL.md`](docs/CODEQL.md) explains default vs advanced setup and troubleshooting. |
+
+## v1.2.1
+
+Infrastructure and contributor experience — no parser API breaks.
+
+| Area | Capability |
+| :--- | :--- |
+| **Python matrix** | CI and PyPI pre-flight test **3.12** and **3.13**; PyPI classifier for 3.13. |
+| **Quality gates** | `make all` parity in GitHub Actions (`uv sync --all-extras` → lint, mypy, pytest with **≥80%** coverage). |
+| **Security** | GitHub CodeQL default setup (SAST), `pip-audit` on production deps, expanded `SECURITY.md`, PyPI publish blocked until pre-flight passes. |
+| **Community** | `CODE_OF_CONDUCT.md`, `CODEOWNERS`, issue-template config, CONTRIBUTING with `uv` workflow. |
+| **Docs** | Root `ROADMAP_*.md` consolidated under [`docs/roadmaps/`](docs/roadmaps/). |
+
+Contributor setup: [`CONTRIBUTING.md`](CONTRIBUTING.md) ·
+[`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) · Security:
+[`SECURITY.md`](SECURITY.md) · CodeQL: [`docs/CODEQL.md`](docs/CODEQL.md)
+
+## v1.2.0
+
+### Graph parity, assets, and parser hardening
+
+| Area | Capability |
+| :--- | :--- |
+| **Asset extraction** | `LogseqNode.assets` collects markdown images, `{{pdf}}` macros, and local `[label](path)` attachments; `LogseqPage.resolve_asset_path` maps to absolute paths (`%20` decode, graph-root relative). |
+| **YAML frontmatter** | `---` blocks at file start populate `LogseqPage.properties` like native `key::` lines; **`title:`** in YAML sets `page.title` at parse; **`serialize_logseq_page`** preserves `---` fences on round-trip when the source file used YAML. |
+| **`page-tags::`** | Block and page `page-tags::` inject implicit graph tokens like `tags::`; list-shaped values feed `refs`. |
+| **Case-insensitive routing** | `LogseqGraph.get_page` and `resolve_relative_page_link` resolve titles via a lowercase index (Datomic parity). |
+| **Extended shielding** | HTML comments, `{{query}}` / `{{advancedquery}}`, and escaped `\#` / `\[\[` do not emit false graph tokens (embed macros still harvest nested wikilinks). |
+| **Property & temporal fixes** | Comma-split ignores commas inside `[[wikilinks]]`; properties after code fences; quoted value stripping; `SCHEDULED`/`DEADLINE` ranges, repeaters, and Org warning periods; legacy `___` / `%2F` / Dendron filenames; UTF-8 BOM via `utf-8-sig`. |
+
+### Round-trip serialization
+
+| Area | Capability |
+| :--- | :--- |
+| **Soft-break bodies** | Multiline block continuations serialize without double-indenting alignment spaces. |
+| **List-shaped block props** | `tags::` / `page-tags::` with indented `-` bullets round-trip as Logseq lists (not Python repr). |
+| **`:LOGBOOK:` drawers** | Org drawers re-emit as `:LOGBOOK:` / `:END:` blocks, not bogus `logbook::` property lines. |
+| **Derived temporal keys** | Parsed `scheduled::`, `repeater::`, and related derived fields are omitted from serialized `key::` output. |
+| **Stable block UUIDs** | Parse → `serialize_logseq_page` → parse preserves block `id::` / UUIDs on the same outline. |
+
+```python
+from logseq_matryca_parser.graph import LogseqGraph
+from logseq_matryca_parser.logos_parser import LogosParser
+
+graph = LogseqGraph.load_directory("/path/to/logseq/graph")
+
+# Case-insensitive page lookup
+page = graph.get_page("my page")  # same object as graph.pages["My Page"]
+
+# Assets on a parsed block (Vision / document pipelines)
+single = LogosParser().parse_page_file("pages/Notes.md")
+block = single.root_nodes[0]
+if block.assets:
+    abs_path = single.resolve_asset_path(block.assets[0])
+```
+
+Deep dive: [Architecture §3.1 — LOGOS](docs/ARCHITECTURE.md#31-logos--deterministic-stack-machine-parsing) ·
+[§3.6 — LogseqGraph](docs/ARCHITECTURE.md#36-logseqgraph--namespace-scoping-o1-invalidation-live-watch) ·
+[AST primer](docs/logseq_ast_primer.md).
+
+### Still included from v1.1.1
+
+| Area | Capability |
+| :--- | :--- |
+| **Graph index** | `title::` / `TITLE::` overrides filename titles; `alias::` / `aliases::` inject extra `graph.pages` keys. |
+| **Backlinks** | `[[Dev]]` resolves against alias keys (`get_backlinks("Dev")`). |
+| **Incremental reload** | `invalidate_and_reload_page` re-applies title/alias enrichment after watcher edits. |
+| **Parser shields** | LaTeX, `#+BEGIN_QUERY`, fenced code, drawers; `{{embed [[Page]]}}` harvests nested wikilinks. |
+| **Property contiguity** | `key::` contiguous under bullets; soft-break closes the window (fence exception in v1.2.0). |
+| **Tasks & bullets** | GFM checkboxes, extended Org markers, ordered-list bullets, aliased `((uuid))` clean text. |
+
+### Obsidian-native export
+
+Compile an entire Logseq graph into an **Obsidian vault layout**: YAML
+frontmatter from page properties, list body preserved, Logseq `((uuid))` links
+rewritten to **`[[Page#^anchor]]`**, and trailing **`^block-id`** on referenced
+blocks. Namespace titles become nested folders (for example,
+`Projects/AI/Demo.md`).
+
+```bash
+matryca-parse export /path/to/logseq/graph /path/to/obsidian/vault --format obsidian
+```
+
+> **Note:** Wikilinks currently use the **Logseq page title** (for example,
+> `[[Target#^…]]`). Vault files may live under namespace folders
+> (`Projects/AI/Demo.md`). Obsidian usually resolves unique titles; aligning link
+> text to folder paths is a possible future refinement.
+
+### Live incremental watcher
+
+`LogseqGraph` supports **surgical file invalidation** (optional dependency:
+`uv sync --extra watch`). `start_watching()` runs a recursive **watchdog**
+observer with **~500ms debounce** and ignores editor temp/swap files (`.swp`,
+`~`, `.tmp`, `.DS_Store`). On `created`, `modified`, `deleted`, or `moved`
+events under `pages/` or `journals/`, only the affected file is re-parsed or
+purged; stale synthetic UUIDs are removed from `_node_registry` and scrubbed
+from `_backlink_registry`—no full-graph cold reload.
+
+### Fluent topological queries
+
+Filter the global node registry with a chainable API:
+
+```python
+from logseq_matryca_parser.graph import LogseqGraph
+
+graph = LogseqGraph.load_directory("/path/to/logseq/graph")
+hits = (
+    graph.query()
+    .has_tag("idea")
+    .under_parent("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    .is_task_state("TODO")
+    .execute()
+)
+```
+
+### Agent-native X-Ray mode (token optimization)
+
+For autonomous LLM agents, passing raw Markdown into the context window wastes
+thousands of tokens on **36-character UUIDs**, hidden `id::` properties,
+drawers, and collapsed directives that carry no immediate semantic signal.
+**X-Ray mode** compresses the parsed AST into **ultra-dense, zero-fluff plain
+text**: each block becomes `{indent}[{alias}] {clean_text}`, with heavy Logseq
+UUIDs replaced by **sequential integer aliases** (`[0]`, `[1]`, …) held in a
+session registry. On typical outlines this can reduce context consumption by
+**up to ~35×** compared to dumping full block payloads.
+
+```bash
+matryca-parse agent-read /path/to/graph --tag idea
+matryca-parse agent-read /path/to/graph --query "quantum"
+```
+
+The agent reads cheap topology now; the registry resolves aliases back to
+sovereign UUIDs when you wire targeted writes.
+
+### Headless write engine and AST linter (Wave 12)
+
+The parser is **no longer read-only**. Wave 12 adds a **headless Markdown
+splicer** ([`agent_writer.py`](src/logseq_matryca_parser/agent_writer.py)):
+`append_child_to_node` uses AST line numbers and indentation
+(`(indent_level + 1) × tab_size`) to insert a new bullet **atomically** into the
+sovereign `.md` file—via `tempfile` + `os.replace`—without Logseq's fragile HTTP
+API. Beyond surgical node splicing, the engine supports **full bidirectional
+page generation** through
+[`serialize_logseq_page`](src/logseq_matryca_parser/logseq_markdown.py) and
+[`write_logseq_page`](src/logseq_matryca_parser/logseq_markdown.py), rebuilding
+entire Logseq-compliant `.md` pages from an in-memory AST. Pair **`agent-read`**
+with **`agent-write`**: X-Ray persists its alias map to
+`.matryca_xray_state.json` at the graph root so stateless CLI invocations can
+read, then write in sequence.
+
+```bash
+matryca-parse agent-read /path/to/graph --tag idea
+matryca-parse agent-write /path/to/graph --alias 0 --content "Follow-up from the agent"
+```
+
+For graph hygiene, **`LogseqGraph.get_broken_references()`** flags nodes whose
+`((uuid))` block refs point at missing registry targets—structural linting, not
+regex guessing. The CLI exposes the same check through
+`matryca-parse scan /path/to/graph --broken-refs` and exits `1` when broken
+references exist.

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ entry points.
 | [`CODEQL.md`](CODEQL.md) | Maintainers | CodeQL default setup notes |
 | [`BUG_HUNT_REPORT.md`](BUG_HUNT_REPORT.md) | Maintainers, contributors | Local static analysis bug audit (Clean Architecture lens, runtime evidence) |
 | [`REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Maintainers, contributors | Evidence-backed repository audit, confirmed defects, issue map, and sequenced improvement roadmap |
+| [`README_READABILITY_REPORT_2026-08-08.md`](README_READABILITY_REPORT_2026-08-08.md) | Maintainers | Measured human and AI README assessment with a phased simplification proposal |
 | [`quality/ISSUE_RECONCILIATION_2026-08-06.md`](quality/ISSUE_RECONCILIATION_2026-08-06.md) | Maintainers, contributors | Evidence-backed disposition of every issue open at the audit baseline |
 | [`decisions/index.md`](decisions/index.md) | Maintainers | Canonical decision registry and ADR gaps |
 | [`reference/index.md`](reference/index.md) | Maintainers, integrators | Provenance and Matryca ecosystem relations |
@@ -69,6 +70,10 @@ entry points.
 ## Root-level docs
 
 - [`../README.md`](../README.md) — project overview and quickstart
+- [`../RELEASE_HIGHLIGHTS.md`](../RELEASE_HIGHLIGHTS.md) — reader-focused release history
+- [`../AGENTS.md`](../AGENTS.md) — product map, execution contract, and safety rules for AI agents
+- [`../llms.txt`](../llms.txt) — concise standard-format LLM discovery and capability index
+- [`../.github/copilot-instructions.md`](../.github/copilot-instructions.md) — thin GitHub-specific adapter to the canonical agent guidance
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — setup, `make all`, PR workflow, **Your first PR**
 - [`../CHANGELOG.md`](../CHANGELOG.md) — shipped releases and Unreleased changes
 - [`../CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) — community standards

--- a/docs/README_READABILITY_REPORT_2026-08-08.md
+++ b/docs/README_READABILITY_REPORT_2026-08-08.md
@@ -1,0 +1,330 @@
+---
+type: ReadmeReadabilityReport
+title: README human and AI readability report - 2026-08-08
+description: Evidence-backed assessment and phased proposal for a shorter human README and a clearer AI-agent entry path.
+status: draft
+classification: active
+audience: maintainers
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: advisory
+last_verified: 2026-08-08
+verified: 2026-08-08
+stale_after: 2027-02-04
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# README human and AI readability report — 2026-08-08
+
+## 1. Purpose and decision boundary
+
+This report separates two kinds of work:
+
+1. **Implemented now:** move detailed release narratives out of the root README,
+   retain a one-line-per-release summary at its bottom, add a prominent link to
+   the detailed history, improve the root AI-agent instructions, publish a
+   proposal-format `llms.txt`, and add a thin GitHub-specific instruction
+   adapter.
+2. **Proposed for maintainer approval:** simplify and reorder the remaining
+   README without removing product capabilities or changing technical claims.
+
+The report is advisory. Sections 6–10 are a decision aid, not authorization to
+rewrite the rest of the README.
+
+## 2. Measured baseline and immediate result
+
+Before this change, the root README was 495 lines long. Detailed release
+material occupied lines 109–349: 241 lines, or approximately 49% of the file.
+The core capability table began at line 350 and the Quickstart began at line
+382. A first-time reader therefore encountered release archaeology before
+installation or a runnable example.
+
+The implemented separation produces this result:
+
+| Measure | Before | After this change | Effect |
+|---|---:|---:|---|
+| Root README length | 495 lines | 287 lines | 208 fewer lines, about 42% shorter |
+| Detailed release history in README | 241 lines | 0 lines | Moved without loss to `RELEASE_HIGHLIGHTS.md` |
+| Quickstart position | Line 382 | Line 29 | 353 lines earlier |
+| Release summary | Multiple tables and examples | One line per documented release | Scannable chronology at the bottom |
+| AI-agent orientation | Audit-tool rules only | `AGENTS.md`, `llms.txt`, canonical machine index, and thin Copilot adapter | Faster, safer cross-tool orientation |
+
+The detailed history is now in [`RELEASE_HIGHLIGHTS.md`](../RELEASE_HIGHLIGHTS.md).
+The exhaustive source of individual changes remains [`CHANGELOG.md`](../CHANGELOG.md).
+
+## 3. Evidence from GitHub guidance
+
+GitHub says a README is often the first item a repository visitor sees and
+typically needs to explain what the project does, why it is useful, how to get
+started, where to get help, and who maintains it. GitHub also recommends moving
+longer documentation out of the README and supports relative links so those
+documents remain valid across branches. See
+[About the repository README file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes).
+
+GitHub automatically derives a table of contents from headings. This favors a
+small number of stable, descriptive sections over many repetitive release
+headings. The same official guide confirms that relative links are the correct
+way to route readers from the root README into repository documentation.
+
+For AI tooling, GitHub documents `AGENTS.md` as repository agent instructions
+and recommends short, repository-specific context that helps an agent
+understand, build, test, and validate changes. See
+[Adding repository custom instructions for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions)
+and
+[About customizing GitHub Copilot responses](https://docs.github.com/en/copilot/concepts/prompting/response-customization).
+
+These sources support the chosen split:
+
+- `README.md` is the short human front door.
+- `RELEASE_HIGHLIGHTS.md` holds reader-friendly release history.
+- `CHANGELOG.md` is the exhaustive change ledger.
+- `AGENTS.md` is the execution-oriented AI-agent entry point.
+- `llms.txt` is the concise inference-time discovery and capability index.
+- `.github/copilot-instructions.md` adapts the canonical guidance for GitHub
+  tooling without becoming another source of truth.
+- `docs/index.md` remains the canonical maintained machine knowledge map.
+
+The [`llms.txt` proposal](https://github.com/AnswerDotAI/llms-txt) defines the
+chosen format: one H1, a concise blockquote, optional explanatory text, H2 link
+groups, and a specially named `Optional` section for material that can be
+skipped under tighter context budgets. The filename is plural by specification.
+This is a community proposal, not a guarantee that any particular model or
+agent will fetch the file automatically; its immediate value is a compact,
+explicit, human-readable project map.
+
+## 4. Patterns from mature open-source READMEs
+
+The repositories below are not treated as an objective ranking. They are a
+benchmark sample of mature, widely adopted projects with clear README patterns.
+
+### 4.1 uv
+
+The [`astral-sh/uv` README](https://github.com/astral-sh/uv) opens with one
+sentence, a compact highlights list, installation, and task-oriented examples.
+Detailed reference material is delegated to the documentation site. The useful
+pattern for this repository is progressive disclosure: value first, first
+success second, deeper capability families later.
+
+### 4.2 Rich
+
+The [`Textualize/rich` README](https://github.com/Textualize/rich) quickly moves
+from a plain-language product statement to compatibility, installation, and a
+minimal executable example. It demonstrates features through small examples
+rather than describing every historical addition before the first command.
+
+### 4.3 FastAPI
+
+The [`fastapi/fastapi` README](https://github.com/fastapi/fastapi) establishes a
+single product definition, lists reader outcomes, then provides install, create,
+run, and verify steps. The lesson is not its total length; it is the explicit
+success path and the repeated use of concrete output over abstract subsystem
+language.
+
+### 4.4 Pydantic and HTTPX
+
+The [`pydantic/pydantic` README](https://github.com/pydantic/pydantic) and
+[`encode/httpx` README](https://github.com/encode/httpx) use a recognizable
+library sequence: concise purpose, install command, minimal API example,
+capabilities, documentation, and contribution links. This is a strong model for
+a Python parser whose primary adoption path is package installation.
+
+## 5. What already works well
+
+The current README has valuable material that should be preserved:
+
+- a memorable problem statement;
+- visible CI, Python, license, PyPI, and status signals;
+- a live visual demonstration;
+- a concrete comparison with naive Markdown chunking;
+- a topology diagram that explains why hierarchy matters;
+- a broad and accurate capability inventory;
+- CLI and Python examples;
+- direct routes to architecture, Cookbook, security, and contribution guides;
+- explicit local-first and zero-telemetry positioning.
+
+The goal is not to make the README generic. It is to make these strengths appear
+in the order a new reader needs them.
+
+## 6. Remaining human-readability findings
+
+### 6.1 The first success now appears immediately
+
+The Quickstart now begins at line 29 instead of line 382. It contains one
+install command, one parse command, an observable-result explanation, and
+short routes into the main workflows. Advanced examples remain in the later
+Usage section.
+
+**Result:** the first-command-before-line-80 acceptance target is met without
+removing the deeper examples needed by experienced users.
+
+### 6.2 The value proposition repeats
+
+The hero, Vision, Matryca Solution, PKM Landscape, Problem, Solution, comparison
+table, and Core Capabilities repeat overlapping claims about hierarchy,
+plain-text sovereignty, and AI-ready context.
+
+**Recommendation:** keep one two-sentence definition, one short “why it matters”
+comparison, and one diagram. Move broader market positioning to a dedicated
+document if it remains important.
+
+### 6.3 Marketing language sometimes outruns evidence
+
+Words such as “ultimate,” “perfect,” “immortality,” and unqualified performance
+claims are vivid but can reduce technical trust. Claims such as “60FPS,” “10k+
+nodes,” or “35×” should point to a reproducible benchmark or be softened.
+
+**Recommendation:** prefer measured outcomes and scope qualifiers. Example:
+“keeps Markdown as the source of truth” is clearer than “immortality of
+plain-text.”
+
+### 6.4 The opening navigation is dense
+
+The hero currently exposes many same-weight links in one line. Architecture,
+clean architecture, AST primer, Cookbook, issues, knowledge bundle, docs system,
+security tooling, changelog, and release process do not all serve the same
+first-time-reader need.
+
+**Result:** the hero now keeps five primary routes: Quickstart, Documentation,
+Cookbook, Release highlights, and the AI/LLM index. Specialist links remain in
+the documentation index.
+
+### 6.5 Wide tables are hard to scan on narrow screens
+
+The four-column PKM landscape and long Core Capabilities cells work on desktop
+but are costly on mobile and difficult for screen readers or text extraction.
+
+**Recommendation:** use short bullets for the core promise and reserve tables
+for true side-by-side decisions. Split capabilities into four outcome groups:
+parse, understand, export, and automate.
+
+### 6.6 Reader identity is implicit
+
+The README serves several audiences—Logseq users, RAG engineers, Python
+integrators, agent builders, and contributors—but does not offer an early route
+for each.
+
+**Recommendation:** add a compact “Choose your path” block with links:
+
+- Parse one page or a vault.
+- Build a RAG pipeline.
+- Export to Obsidian or JSON.
+- Read or write with an AI agent.
+- Contribute to the parser.
+
+## 7. Proposed human-first README architecture
+
+The following order is recommended for a second, separately reviewed change:
+
+1. **Hero:** name, one-sentence outcome, badges, demo.
+2. **What it does:** three bullets describing input, transformation, and output.
+3. **60-second Quickstart:** install, one CLI command, one observable result.
+4. **Choose your workflow:** parse, RAG, export, visualize, agent access.
+5. **Why topology matters:** one compact comparison or the existing diagram.
+6. **Capabilities:** four grouped blocks with links to detailed docs.
+7. **Python API:** one minimal stable-import example.
+8. **Safety and compatibility:** local-first, supported Python, optional extras,
+   filesystem-write boundary.
+9. **Documentation, help, and contribution:** one small resource table.
+10. **Roadmap and support.**
+11. **Release history:** the one-line list, always at the bottom.
+
+The first successful command is now before line 80 and capabilities are grouped
+by user outcome. A future editorial pass may still pursue the 180–220-line
+target by consolidating the overlapping positioning sections.
+
+## 8. Plain-language editorial rules
+
+Apply these rules during the proposed rewrite:
+
+- Start sections with the user outcome, then name the subsystem.
+- Define LOGOS, SYNAPSE, FORGE, KINETIC, and LENS only where each first appears.
+- Prefer sentences with one main idea and concrete verbs.
+- Replace broad superlatives with testable, scoped statements.
+- Use “Logseq graph” or “vault” consistently; explain the chosen term once.
+- Show one canonical install path first; list alternatives afterward.
+- Keep code examples runnable and no longer than needed to produce a result.
+- Use meaningful link text instead of generic “here” or emoji-only links.
+- Treat test counts and release metrics as dated facts; avoid duplicating them in
+  evergreen capability sections.
+- Link detailed architecture, governance, and historical evidence rather than
+  reproducing it.
+
+## 9. AI-agent layer
+
+### 9.1 Implemented now
+
+The AI entry layer now includes:
+
+- [`AGENTS.md`](../AGENTS.md), which gives an arriving agent:
+
+  - a one-paragraph product and source-of-truth definition;
+  - a capability-to-entry-point map;
+  - stable documentation routes;
+  - the install and validation commands;
+  - parser, graph, serialization, filesystem, and optional-dependency guardrails;
+  - the existing audit-code impact and cycle policy;
+- [`llms.txt`](../llms.txt), which follows the proposed standard and supplies a
+  curated project summary, essential links, runnable entry points, contribution
+  routes, and a lower-priority `Optional` history group; a deterministic
+  contract test verifies its structure and every repository target;
+- [`.github/copilot-instructions.md`](../.github/copilot-instructions.md), a thin
+  GitHub-specific adapter that points back to the canonical agent and machine
+  entry points.
+
+The root README links prominently to both `AGENTS.md` and `llms.txt`. This keeps
+the human README focused while supporting both operational agents and
+inference-time discovery.
+
+### 9.2 Recommended next AI improvements
+
+1. Do not add a manually maintained `llms-full.txt`: the repository already
+   publishes Markdown sources, and concatenating them would increase drift and
+   context cost. Generate one only when a concrete consumer requires it.
+2. Add task-specific nearest-scope `AGENTS.md` files only where parser,
+   filesystem-writing, or documentation rules materially differ.
+3. Keep `docs/index.md` as the canonical machine entry point and add new
+   maintained documents to its executable profile.
+4. Test agent onboarding with bounded tasks: locate the stable parser import,
+   run one example, identify the write safety boundary, and name the full gate.
+5. If the discovery surface expands, generate new entries from the maintained
+   profile rather than adding a second manually curated inventory.
+
+## 10. Phased decision plan
+
+| Phase | Change | Expected value | Risk | Approval recommendation |
+|---|---|---|---|---|
+| **A — complete** | Extract detailed releases, add bottom summary and direct link | High immediate scanability | Low | Keep |
+| **B — complete** | Add `AGENTS.md` orientation, `llms.txt`, and thin Copilot routing | Faster, safer cross-tool agent onboarding | Low | Keep |
+| **C — complete** | Move Quickstart directly below the hero | Faster first success | Low | Keep |
+| **D — proposed** | Collapse Vision, landscape, Problem, and Solution into one concise explanation | Removes repetition and marketing density | Medium editorial judgment | Review wording before merge |
+| **E — complete** | Group capabilities by user outcome and shorten the hero navigation | Better scanning and mobile readability | Low | Keep |
+| **F — proposed** | Add evidence links or soften performance and comparative claims | Higher technical credibility | Medium; may alter positioning | Review claim by claim |
+| **G — optional** | Generate a full-context bundle or scoped agent files | Wider agent compatibility | Risk of duplicated truth | Add only with a concrete consumer |
+
+## 11. Acceptance criteria for the next rewrite
+
+A future README simplification should be accepted only if:
+
+- a new reader can identify input, output, and primary benefit in the first
+  screen;
+- installation and one successful command appear before line 80;
+- the document remains between 180 and 220 lines unless a reviewed example
+  justifies exceeding the target;
+- all current capability families remain discoverable through direct links;
+- stable imports and optional extras remain accurate;
+- filesystem-writing features are not presented as unrestricted;
+- release detail remains in `RELEASE_HIGHLIGHTS.md` and the summary stays at the
+  bottom of the root README;
+- human documentation links and AI-agent routes pass deterministic validation;
+- `make all`, `make vendor-name-check`, and the zero-cycle check pass;
+- no measured claim is added without a reproducible source.
+
+## 12. Recommended next decision
+
+Review Phase D and F separately as the next possible tranche: consolidate the
+overlapping positioning sections, then qualify comparative and performance
+claims one by one. Both require maintainer review because they change product
+voice and positioning, not just document structure.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,12 @@ navigation layers only.
 | Resource | Role |
 |---|---|
 | [Documentation portal](README.md) | Human navigation by audience |
+| [AI agent guide](../AGENTS.md) | Product map, execution contract, safety boundaries, and repository gates |
+| [LLM discovery index](../llms.txt) | Concise standard-format project and capability map for inference-time discovery |
 | [Documentation system](DOCUMENTATION_SYSTEM.md) | Canonical governance, lifecycle, metadata, and federation guide |
 | [Architecture](CLEAN_CODE_ARCHITECTURE.md) | Canonical architecture and public graph API |
 | [Repository roadmap](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Current evidence-backed improvement plan |
+| [README readability report](README_READABILITY_REPORT_2026-08-08.md) | Measured human and AI readability assessment and phased proposal |
 | [Issue reconciliation](quality/ISSUE_RECONCILIATION_2026-08-06.md) | Current GitHub backlog decisions |
 | [Decision index](decisions/index.md) | Architectural decisions and missing ADRs |
 | [Reference index](reference/index.md) | Provenance and external relations |

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,6 +21,29 @@ superseded_by: null
 
 ## 2026-08-08
 
+- Moved 241 lines of detailed release history from the root README into
+  [`RELEASE_HIGHLIGHTS.md`](../RELEASE_HIGHLIGHTS.md), retained a one-line
+  summary per documented release at the README bottom, and added a prominent
+  direct link. The root README falls from 495 to 287 lines and its Quickstart
+  moves from line 382 to line 29. The hero navigation is reduced to five
+  primary routes and capabilities are grouped by user outcome.
+- Added the maintained
+  [README human and AI readability report](README_READABILITY_REPORT_2026-08-08.md)
+  with official GitHub guidance, mature-project benchmarks, measured findings,
+  a proposed human-first outline, plain-language rules, acceptance criteria,
+  and approval-separated follow-up phases.
+- Expanded [`AGENTS.md`](../AGENTS.md) from audit-only rules into a concise
+  product map, task entry guide, source-of-truth statement, execution contract,
+  and parser, graph, filesystem, optional-dependency, and validation guardrails.
+- Added a proposal-format [`llms.txt`](../llms.txt) with a concise project
+  summary, essential documentation and runnable entry points, and an explicit
+  `Optional` history section. Added thin
+  [GitHub Copilot instructions](../.github/copilot-instructions.md) that route to
+  `AGENTS.md`, `docs/index.md`, and `llms.txt` instead of duplicating their
+  detailed content. An exhaustive `llms-full.txt` was intentionally omitted to
+  avoid stale duplicated documentation and excessive context. A deterministic
+  contract test validates the `llms.txt` structure and every linked repository
+  target.
 - Merged [PR #126](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/126)
   and published the corrective
   [v1.7.1 release](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases/tag/v1.7.1)

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -23,6 +23,7 @@ maintained_documents = [
   "docs/DOCUMENTATION_SYSTEM.md",
   "docs/CLEAN_CODE_ARCHITECTURE.md",
   "docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md",
+  "docs/README_READABILITY_REPORT_2026-08-08.md",
   "docs/quality/ISSUE_RECONCILIATION_2026-08-06.md",
   "docs/quality/README.md",
   "docs/decisions/index.md",

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,50 @@
+# Logseq Matryca Parser
+
+> A deterministic Python parser, typed AST, in-memory graph, RAG adapter, exporter, visualizer, and bounded agent-access layer for sovereign Logseq Markdown vaults.
+
+Logseq Markdown files are the source of truth. The parser preserves outliner
+hierarchy, block UUIDs, page aliases, backlinks, properties, tasks, timestamps,
+and assets instead of flattening a vault into unrelated text chunks. Derived
+views include graph queries, LangChain documents, LlamaIndex nodes,
+context-enriched chunks, JSON and Obsidian exports, interactive visualization,
+and token-efficient agent reads and writes.
+
+Use documented package-root imports for stable APIs. Treat filesystem writes,
+symlinks, asset paths, graph identity, and parse/serialize round trips as safety
+boundaries. Read AGENTS.md before changing the repository.
+
+## Start here
+
+- [Human overview](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/README.md): Product purpose, capabilities, installation, CLI, Python API, and support routes.
+- [AI agent instructions](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/AGENTS.md): Product map, source-of-truth model, repository contract, safety rules, and validation gates.
+- [Machine knowledge index](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/index.md): Canonical maintained documentation entry point.
+- [Cookbook](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/COOKBOOK.md): Runnable integration recipes for RAG, graph queries, watching, agents, and testing.
+
+## Core capabilities
+
+- [Architecture](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/ARCHITECTURE.md): LOGOS parsing, LogseqGraph, SYNAPSE, FORGE, KINETIC, LENS, agents, and data flow.
+- [Clean architecture](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/CLEAN_CODE_ARCHITECTURE.md): Canonical module boundaries, stable graph APIs, and dependency rules.
+- [AST primer](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/logseq_ast_primer.md): Logseq Markdown topology, indentation, properties, references, tasks, and temporal semantics.
+- [API stability](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/reference/API_STABILITY.md): Stable, provisional, and internal API tiers plus typing guarantees.
+- [Structured diagnostics](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/reference/DIAGNOSTICS.md): Diagnostic payloads, codes, rendering, path safety, and escalation.
+- [Filesystem safety](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/reference/FILESYSTEM_SAFETY.md): Vault containment, symlink policy, atomic replacement, dry runs, metadata, and limits.
+
+## Runnable entry points
+
+- [Offline SYNAPSE RAG example](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/examples/run_synapse_rag.py): LangChain, LlamaIndex, enriched chunks, and page-embed expansion without a user vault.
+- [Demo example](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/examples/run_demo.py): Small end-to-end parser demonstration.
+- [CLI implementation](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/src/logseq_matryca_parser/kinetic.py): Parse, scan, export, visualize, agent-read, agent-write, append, and demo commands.
+- [Public package API](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/src/logseq_matryca_parser/__init__.py): Supported package-root exports.
+
+## Build, test, and contribute
+
+- [Contributing](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/CONTRIBUTING.md): Environment setup, quality gates, tests, and pull-request workflow.
+- [Security policy](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/SECURITY.md): Supported versions and private vulnerability reporting.
+- [Release process](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/RELEASE_PROCESS.md): SemVer, immutable build, provenance, PyPI, and GitHub publication procedure.
+
+## Optional
+
+- [Release highlights](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/RELEASE_HIGHLIGHTS.md): Reader-focused history of shipped capability milestones.
+- [Changelog](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/CHANGELOG.md): Exhaustive versioned changes.
+- [Repository improvement roadmap](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md): Dated audit evidence and sequenced improvement record.
+- [Issue reconciliation](https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/docs/quality/ISSUE_RECONCILIATION_2026-08-06.md): Dated backlog decisions and shipped evidence.

--- a/tests/test_llms_txt_contract.py
+++ b/tests/test_llms_txt_contract.py
@@ -1,0 +1,28 @@
+"""Contract tests for the root llms.txt discovery surface."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LLMS_TXT = ROOT / "llms.txt"
+RAW_PREFIX = "https://raw.githubusercontent.com/MarcoPorcellato/logseq-matryca-parser/main/"
+MARKDOWN_LINK = re.compile(r"\[[^]]+\]\(([^)]+)\)")
+
+
+def test_llms_txt_format_and_repository_targets() -> None:
+    text = LLMS_TXT.read_text(encoding="utf-8")
+    nonempty = [line for line in text.splitlines() if line.strip()]
+
+    assert nonempty[0] == "# Logseq Matryca Parser"
+    assert nonempty[1].startswith("> ")
+    assert sum(line.startswith("# ") for line in nonempty) == 1
+    assert "## Optional" in nonempty
+
+    links = MARKDOWN_LINK.findall(text)
+    assert links
+    for target in links:
+        assert target.startswith(RAW_PREFIX), target
+        repository_path = ROOT / target.removeprefix(RAW_PREFIX)
+        assert repository_path.is_file(), repository_path


### PR DESCRIPTION
## Summary

- move detailed version narratives into `RELEASE_HIGHLIGHTS.md` and retain a one-line release index at the bottom of the root README
- move the 60-second Quickstart directly below the hero, simplify primary navigation, and group capabilities by reader outcome
- add a maintained README readability report grounded in official GitHub guidance and current mature-project patterns
- add `llms.txt`, expanded `AGENTS.md` orientation, and a thin Copilot instruction adapter for AI discovery without duplicating documentation authority
- add a deterministic contract test for the `llms.txt` structure and local targets

## Validation

- `make all` — 533 passed, 91.90% coverage; Ruff and Mypy passed
- `make vendor-name-check` — passed as part of `make all`
- maintained documentation check — passed as part of `make all`
- import-cycle check — 0 cycles
- `git diff --check` — passed

## Review notes

The root README is now 287 lines instead of 495. Detailed release information is preserved in the dedicated document; no runtime behavior or release artifact changes are included. `llms.txt` follows the plural community-proposal filename. A duplicated `llms-full.txt` is intentionally omitted because the maintained documentation index remains the canonical complete map.