### PR TITLE
test(paths): specify deterministic graph discovery order

### DIFF
--- a/tests/test_logseq_paths.py
+++ b/tests/test_logseq_paths.py
@@ -153,6 +153,43 @@ def test_discover_graph_files_skips_backup_and_recycle_dirs(tmp_path: Path) -> N
     assert discovered[0].name == "Real.md"
 
 
+def test_discover_graph_files_returns_deterministic_relative_order(tmp_path: Path) -> None:
+    graph_root = tmp_path / "vault"
+    included = [
+        Path("journals/2026_02_02.md"),
+        Path("pages/zeta.md"),
+        Path("pages/nested/second.md"),
+        Path("journals/nested/2026_02_01.md"),
+        Path("pages/alpha.md"),
+        Path("pages/nested/first.md"),
+    ]
+    excluded = [
+        Path("pages/logseq/bak/backup.md"),
+        Path("pages/.recycle/deleted.md"),
+        Path("journals/.git/ignored.md"),
+    ]
+    for relative_path in [*included, *excluded]:
+        path = graph_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("- note\n", encoding="utf-8")
+
+    repeated_results = [
+        [path.relative_to(graph_root) for path in discover_graph_files(graph_root)]
+        for _ in range(3)
+    ]
+
+    expected = [
+        Path("pages/alpha.md"),
+        Path("pages/nested/first.md"),
+        Path("pages/nested/second.md"),
+        Path("pages/zeta.md"),
+        Path("journals/2026_02_02.md"),
+        Path("journals/nested/2026_02_01.md"),
+    ]
+    assert repeated_results == [expected, expected, expected]
+    assert not any(path in result for result in repeated_results for path in excluded)
+
+
 # ── edge-case coverage per issue #22 ─────────────────────────────────────
 
 


### PR DESCRIPTION
## Description

Fixes #135

Adds one `tmp_path` regression that creates page and journal files out of order, repeats discovery three times, and compares the exact paths relative to the graph root. The fixture covers pages-before-journals ordering, nested sorting, and the existing `logseq`, `.recycle`, and `.git` exclusions.

This is test-only; discovery behavior and user-facing documentation are unchanged.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature which would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🛡️ Sovereign Developer Checklist

- [x] I have read `CONTRIBUTING.md` and picked a good-first issue.
- [x] I have executed `make all` locally; Ruff, Mypy, documentation checks, and all 534 tests pass at 91.90% coverage.
- [x] I have added the focused test requested by the issue.
- [x] Documentation is unchanged because this only specifies existing behavior.
- [x] A changelog entry is not needed because there is no user-visible behavior change.
- [x] No production functions or domain models are changed.

## Screenshots / CLI Output

```text
tests/test_logseq_paths.py: 33 passed
full suite: 534 passed
coverage: 91.90%
vendor-name-check: OK
```
