### PR TITLE
test(entrypoint): cover the python -m CLI help path

### DIFF
--- a/tests/test_module_entrypoint.py
+++ b/tests/test_module_entrypoint.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+
+
+def test_module_entrypoint_help() -> None:
+    """Ensure `python -m logseq_matryca_parser --help` executes cleanly and outputs CLI help."""
+    result = subprocess.run(
+        [sys.executable, "-m", "logseq_matryca_parser", "--help"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "matryca-parse" in result.stdout
+    assert "scan" in result.stdout

--- a/tests/test_module_entrypoint.py
+++ b/tests/test_module_entrypoint.py
@@ -2,12 +2,14 @@ import subprocess
 import sys
 
 
-def test_module_entrypoint_help() -> None:
+def test_module_entrypoint_help(tmp_path) -> None:
     """Ensure `python -m logseq_matryca_parser --help` executes cleanly and outputs CLI help."""
     result = subprocess.run(
         [sys.executable, "-m", "logseq_matryca_parser", "--help"],
+        cwd=tmp_path,
         capture_output=True,
         text=True,
+        timeout=10,
     )
 
     assert result.returncode == 0


### PR DESCRIPTION
## Description
Fixes #130 

Adds `tests/test_module_entrypoint.py` to verify that executing `python -m logseq_matryca_parser --help` exits cleanly with code 0 and exposes the core `matryca-parse` CLI surface and subcommands without requiring a user vault.

## Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🛡️ Sovereign Developer Checklist
- [x] I have read [`CONTRIBUTING.md`](../CONTRIBUTING.md) (or picked a task from [`docs/GOOD_FIRST_ISSUES.md`](../docs/GOOD_FIRST_ISSUES.md)).
- [x] I have executed `make all` locally, and all linters (Ruff), type-checkers (Mypy), and tests (Pytest) pass successfully.
- [x] I have added/updated tests for my changes (if applicable).
- [ ] I have updated the relevant documentation (`README.md`, `docs/`, `CONTRIBUTING.md` as needed).
- [ ] I updated [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]` for user-visible behavior changes.
- [x] My code follows the project's typing conventions (explicit hints on new functions; Pydantic `strict=True` on domain models).

## Screenshots / CLI Output (if applicable)
<img width="1162" height="462" alt="Screenshot 2026-08-10 123004" src="https://github.com/user-attachments/assets/8a55ef10-d1be-455e-8d33-9c7ad0f35c9e" />
