### PR TITLE
test(parser): add shield-aware compatibility assurance corpus

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/fixtures/compat/** text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Parser compatibility corpus foundation (#104-A)** — added six original,
+  offline Apache-2.0 fixtures with source hashes and strict provenance, schema,
+  parser-configuration, behavior, diagnostics, and identity-policy metadata;
+  one private projector now drives exact-parse snapshots and semantic
+  parse/serialize/parse checks without changing the stable package API. The
+  expanded parent issue #104 remains open for graph reload, generated malformed
+  input, and broader filesystem-assurance work.
 - **Parser assurance reference study** — added a license-safe comparative
   analysis of `martinkoutecky/lsdoc@c79cb059` and a dependency-ordered plan for
   a project-owned semantic corpus, optional external-oracle decision, original

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   graph checks, and a source-location RFC. No AGPL source, tests, corpora,
   schemas, or documentation were copied or adapted.
 
+### Fixed
+
+- **Compatibility-corpus assurance oracle** — canonical reference-property
+  sequences now preserve commas inside page references; property-origin
+  wikilinks are removed by occurrence while equal content links and their order
+  remain visible. Valid fixtures reject undeclared diagnostics and Boolean
+  schema/configuration fields; corpus bytes are forced to LF, and the snapshot
+  generator is covered by the maintained mypy gate. This changes tests and
+  tooling only, not package runtime behavior.
+
 ## [1.7.1] - 2026-08-08
 
 Patch release correcting the v1.7.0 SYNAPSE example promise, hardening release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Compatibility-corpus assurance oracle** — canonical reference-property
-  sequences now preserve commas inside page references; property-origin
-  wikilinks are removed by occurrence while equal content links and their order
-  remain visible. Valid fixtures reject undeclared diagnostics and Boolean
-  schema/configuration fields; corpus bytes are forced to LF, and the snapshot
-  generator is covered by the maintained mypy gate. This changes tests and
-  tooling only, not package runtime behavior.
+  sequences now preserve commas inside page references and normalize complex
+  `#[[tag]]` values; property-origin wikilinks are removed by occurrence while
+  equal content links and their order remain visible, including when matching
+  text appears inside parser-shielded code, comments, math, fences, or queries.
+  Valid fixtures reject undeclared diagnostics and Boolean schema/configuration
+  fields; corpus bytes are forced to LF, and the snapshot generator is covered
+  by the maintained mypy gate. This changes tests and tooling only, not package
+  runtime behavior.
 
 ## [1.7.1] - 2026-08-08
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint-fix:
 	uv run ruff check . --fix
 
 check:
-	uv run mypy src/ tests/ examples/ scripts/check_documentation.py scripts/check_release_contract.py scripts/check_wheel_contract.py
+	uv run mypy src/ tests/ examples/ scripts/check_documentation.py scripts/check_release_contract.py scripts/check_wheel_contract.py scripts/update_compat_snapshots.py
 
 vendor-name-check:
 	bash scripts/check_vendor_free_docs.sh

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -61,7 +61,7 @@ Markdown source-of-truth model.
 | M0 publication | merged as [PR #159](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/159) | source head `a6056413`, squash merge `30946446`, terminal validation recorded in the PR |
 | Existing delivery anchors | #87, #103, #104, #108, #111 are open; #106 and #113 are closed | live GitHub issue reads on 2026-08-16 |
 | Local implementation checkpoint | `8806205c35b104ed65d00a273acc9eeca572ae38` | clean local commit on `agent/parser-assurance-m1`; exact-head tests passed, but independent oracle review rejected publication |
-| Current milestone | M1-B documentation evidence recorded locally; final frozen Sol review pending | first frozen Sol review on `6fcf4b274a3a04ef4c9783cf83149d6ef4aeeabb` returned `NEEDS_CORRECTION`; non-amending corrective implementation `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` passed exact-head local qualification; no push or PR |
+| Current milestone | M1-B second corrective implementation locally qualified; refreshed documentation evidence and final frozen Sol review pending | second frozen Sol review on `5007dc357e05775c6221c8aa84f9a11edc695e0d` returned `NEEDS_CORRECTION`; non-amending corrective implementation `7870b84` passed exact-head local qualification with 584 tests; no push or PR |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
 publication, or qualification.
@@ -137,6 +137,15 @@ the semantic projector removed a real content wikilink for `[[Foo]]` combined
 with `tags:: Foo`, and it projected `[[Project Authored]], [[Fixture]]` as one
 malformed token. Manifest probes also proved that non-empty unverified
 diagnostic codes and Boolean values in integer fields were accepted.
+
+A second frozen full-patch Sol review at `5007dc357e05775c6221c8aa84f9a11edc695e0d`
+found that unequal backtick runs still made the independent oracle disagree
+with parser shielding and remove an authentic visible link. It also exposed an
+invalid review receipt: the patch hash had been computed after token-filtered
+output instead of from raw `git --no-pager diff --no-ext-diff --binary
+--full-index` bytes. Corrective implementation `7870b84` added exact delimiter
+parity, closed fence/query-region boundaries, and a differential probe matrix;
+future review receipts use only raw Git output.
 
 M1-B is a corrective sub-milestone of M1, not a new product feature. It must:
 
@@ -703,7 +712,7 @@ It must not replace the requirements in this plan.
 - [x] The corrective implementation commit is clean, exact-head qualified, and
   has a frozen full diff prepared for a final GPT-5.6 Sol review; unresolved
   historical P1/P2 findings remain tied to historical checkpoints.
-- [x] A separate documentation-evidence commit records implementation `9e8708e`;
+- [x] A refreshed documentation-evidence commit records implementation `7870b84`;
   hosted validation and merge remain deferred until explicit user authorization.
 - [ ] The remaining expanded #104 acceptance criteria are proved through the
   dependency-owned #103 and M3 evidence before #104 is closed.
@@ -742,4 +751,6 @@ Completion is unproven until every applicable item has authoritative evidence.
 | 2026-08-16 | M1-B corrective review | verified and prepared | Primary runtime probes reproduced both P1s and proved acceptance of non-empty unverified diagnostics and Boolean integer fields. Source review confirmed raw-byte hashes without LF checkout policy and omission of the snapshot generator from the maintained mypy command. Two bounded Spark inventories were advisory; the primary retained semantic and security decisions. The goal remains paused and no implementation, push, or PR is claimed. |
 | 2026-08-16 | M1-B first corrective implementation `996c5a5` and evidence head `6fcf4b2` | locally qualified, then superseded | The implementation added comma-aware canonical references, count-based property-link subtraction, LF fixture policy, strict manifest guards, and snapshot-generator mypy coverage without changing `src/`. Exact-head local qualification passed at `996c5a5` with 572 tests; the separate evidence commit produced frozen review head `6fcf4b2`. These checks remain valid historical receipts, but the later Sol review found additional oracle defects, so neither checkpoint is publication-ready evidence. |
 | 2026-08-16 | M1-B first frozen Sol review `6fcf4b2` | verified and unresolved | Review requested `NEEDS_CORRECTION`. Reproduced P1 (property-link shielding ignored inline-code/HTML-comment and related regions) allowing authentic content-wikilink removal, and P2 (`#[[Foo]]` projected as `[[Foo]]`). Historic checkpoint retained as rejected/superseded evidence. |
-| 2026-08-16 | M1-B corrective implementation `9e8708e` | locally qualified (non-amending) | Corrected commit changed only `CHANGELOG.md`, `tests/parser_assurance/projection.py`, and `tests/test_compat_corpus.py`; preserved `8806205` and `996c5a5` as historical rejected/superseded evidence. Exact-head qualification passed with 7 focused Sol regressions, snapshot freshness, `make all` (`579` tests and coverage gate), Ruff, mypy, documentation validation, vendor-name check, diff check, and zero-cycle check. |
+| 2026-08-16 | M1-B corrective implementation `9e8708e` | locally qualified, then superseded | Corrected the first frozen review's simple shield cases and `#[[Foo]]` normalization. Exact-head qualification passed with 579 tests, but the next full-patch Sol review found incomplete parity for unequal backtick runs; this receipt is therefore historical, not publication-ready. |
+| 2026-08-16 | M1-B second frozen Sol review `5007dc3` | verified and unresolved | Review returned `NEEDS_CORRECTION`: valid mixed-backtick input still removed an authentic content wikilink, simple tests did not cover unequal delimiter runs, and the supplied patch hash/line receipt was invalid because it came from filtered rather than raw Git diff bytes. |
+| 2026-08-16 | M1-B second corrective implementation `7870b84` | locally qualified (non-amending) | Added parser-equivalent exact backtick-run matching, bounded fence/query-region closing, precise inline-math closing, unclosed-comment parity, the exact Sol reproducer, and post-region visible-link regressions. A 14-family direct differential probe found no parser/oracle wikilink mismatch. Exact-head snapshot freshness and `make all` passed with 584 tests and 92.16% coverage; Ruff, mypy, documentation, vendor-name, diff, and zero-cycle checks passed. No `src/`, package, API, dependency, push, PR, merge, or release change occurred. |

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -61,7 +61,7 @@ Markdown source-of-truth model.
 | M0 publication | merged as [PR #159](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/159) | source head `a6056413`, squash merge `30946446`, terminal validation recorded in the PR |
 | Existing delivery anchors | #87, #103, #104, #108, #111 are open; #106 and #113 are closed | live GitHub issue reads on 2026-08-16 |
 | Local implementation checkpoint | `8806205c35b104ed65d00a273acc9eeca572ae38` | clean local commit on `agent/parser-assurance-m1`; exact-head tests passed, but independent oracle review rejected publication |
-| Current milestone | M1-B evidence recorded locally; frozen Sol review pending | implementation `996c5a52b08f2670ecd80fb3f1515b65ae567465`; no push or PR |
+| Current milestone | M1-B documentation evidence recorded locally; final frozen Sol review pending | first frozen Sol review on `6fcf4b274a3a04ef4c9783cf83149d6ef4aeeabb` returned `NEEDS_CORRECTION`; non-amending corrective implementation `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` passed exact-head local qualification; no push or PR |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
 publication, or qualification.
@@ -124,7 +124,15 @@ The review established these M1-A decisions:
 
 An independent patch review of local commit `8806205c35b104ed65d00a273acc9eeca572ae38`
 on 2026-08-16 found the architecture acceptable but the assurance oracle not
-yet safe to publish. Primary-agent runtime probes reproduced both P1 findings:
+yet safe to publish. A first frozen review of implementation head
+`6fcf4b274a3a04ef4c9783cf83149d6ef4aeeabb` returned `NEEDS_CORRECTION`.
+That review found two additional oracle defects: property-link extraction did
+not honor parser shielding, so a literal such as ``note:: `[[Foo]]` `` could
+cause an authentic visible `[[Foo]]` to be removed from projected content; and
+the hash-page tag `#[[Foo]]` normalized to `[[Foo]]` instead of `Foo`.
+
+The earlier primary-agent runtime probes against `8806205` reproduced both
+initial P1 findings:
 the semantic projector removed a real content wikilink for `[[Foo]]` combined
 with `tags:: Foo`, and it projected `[[Project Authored]], [[Fixture]]` as one
 malformed token. Manifest probes also proved that non-empty unverified
@@ -654,7 +662,9 @@ The checkout must be clean and the audit-code cycle check must report zero
 cycles. The exact implementation SHA then receives a frozen primary and
 low-cost independent review. A later documentation-evidence commit must pass at
 least `make all`, `make vendor-name-check`, documentation validation, diff
-check, and hosted required checks on its own exact head.
+check, and the next GPT-5.6 Sol review on its own exact head. Hosted required
+checks remain mandatory after an explicitly authorized push and PR; none are
+claimed locally.
 
 ## 15. Interruption and recovery
 
@@ -690,11 +700,11 @@ It must not replace the requirements in this plan.
   reference-property families with comma-aware, count-based semantics.
 - [x] M1-B enforces LF corpus bytes, empty valid-fixture diagnostics, exact
   integer manifest fields, and snapshot-generator mypy coverage.
-- [ ] The corrective implementation commit is clean, exact-head qualified, and
-  has a frozen final diff ready for independent Sol review without unresolved
-  P0/P1/P2 findings.
-- [x] A separate local evidence commit records implementation `996c5a5`; hosted
-  validation remains deferred until an explicitly authorized push and PR.
+- [x] The corrective implementation commit is clean, exact-head qualified, and
+  has a frozen full diff prepared for a final GPT-5.6 Sol review; unresolved
+  historical P1/P2 findings remain tied to historical checkpoints.
+- [x] A separate documentation-evidence commit records implementation `9e8708e`;
+  hosted validation and merge remain deferred until explicit user authorization.
 - [ ] The remaining expanded #104 acceptance criteria are proved through the
   dependency-owned #103 and M3 evidence before #104 is closed.
 - [ ] The external-oracle decision is recorded, including a valid negative
@@ -730,4 +740,6 @@ Completion is unproven until every applicable item has authoritative evidence.
 | 2026-08-16 | M1-A working-tree qualification | provisional | `rtk uv run python scripts/update_compat_snapshots.py` passed in non-mutating freshness mode; `rtk make all` passed with 553 tests and 92.07% coverage; Ruff, mypy, documentation, vendor-name, and diff checks passed; audit code reported zero `src/` import cycles. `rtk uv run python scripts/update_compat_snapshots.py --write` is the only explicit regeneration mode, and stale snapshots make the default command exit nonzero. This is not E1/E2 because the qualified bytes were not yet committed. |
 | 2026-08-16 | M1-A local commit `8806205` | exact-head tests passed; publication rejected | Clean local commit recorded 556 passing tests, 92.07% coverage, snapshot freshness, `make all`, vendor-name, diff, and zero-cycle checks. A later independent full-patch review found two oracle P1s: malformed multi-reference normalization and deletion of authentic content wikilinks. The commit must not be pushed as M1-A evidence. |
 | 2026-08-16 | M1-B corrective review | verified and prepared | Primary runtime probes reproduced both P1s and proved acceptance of non-empty unverified diagnostics and Boolean integer fields. Source review confirmed raw-byte hashes without LF checkout policy and omission of the snapshot generator from the maintained mypy command. Two bounded Spark inventories were advisory; the primary retained semantic and security decisions. The goal remains paused and no implementation, push, or PR is claimed. |
-| 2026-08-16 | M1-B corrective implementation `996c5a5` | locally qualified | Added comma-aware canonical reference-property sequences; reverse count-subtraction of property-origin wikilinks to preserve content-link order; LF fixture-byte policy; exact integer and empty-diagnostics manifest guards; and snapshot-generator mypy coverage. Focused tests, Ruff, and mypy passed; exact-head snapshot freshness, `make all` (572 tests and coverage gate), vendor-name check, documentation check, diff check, and zero-cycle audit passed. No `src/`, package, dependency, push, PR, merge, or release change occurred. Spark and Luna worker starts were blocked before execution by the local permission initializer, so no delegated output was accepted. |
+| 2026-08-16 | M1-B first corrective implementation `996c5a5` and evidence head `6fcf4b2` | locally qualified, then superseded | The implementation added comma-aware canonical references, count-based property-link subtraction, LF fixture policy, strict manifest guards, and snapshot-generator mypy coverage without changing `src/`. Exact-head local qualification passed at `996c5a5` with 572 tests; the separate evidence commit produced frozen review head `6fcf4b2`. These checks remain valid historical receipts, but the later Sol review found additional oracle defects, so neither checkpoint is publication-ready evidence. |
+| 2026-08-16 | M1-B first frozen Sol review `6fcf4b2` | verified and unresolved | Review requested `NEEDS_CORRECTION`. Reproduced P1 (property-link shielding ignored inline-code/HTML-comment and related regions) allowing authentic content-wikilink removal, and P2 (`#[[Foo]]` projected as `[[Foo]]`). Historic checkpoint retained as rejected/superseded evidence. |
+| 2026-08-16 | M1-B corrective implementation `9e8708e` | locally qualified (non-amending) | Corrected commit changed only `CHANGELOG.md`, `tests/parser_assurance/projection.py`, and `tests/test_compat_corpus.py`; preserved `8806205` and `996c5a5` as historical rejected/superseded evidence. Exact-head qualification passed with 7 focused Sol regressions, snapshot freshness, `make all` (`579` tests and coverage gate), Ruff, mypy, documentation validation, vendor-name check, diff check, and zero-cycle check. |

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -60,7 +60,8 @@ Markdown source-of-truth model.
 | Parent roadmap | current repository-wide quality SSOT | [stellar roadmap](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) |
 | M0 publication | merged as [PR #159](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/159) | source head `a6056413`, squash merge `30946446`, terminal validation recorded in the PR |
 | Existing delivery anchors | #87, #103, #104, #108, #111 are open; #106 and #113 are closed | live GitHub issue reads on 2026-08-16 |
-| Current milestone | M1-A local freeze and exact-head qualification | branch `agent/parser-assurance-m1`; push, PR, and hosted exact-head checks remain unproven |
+| Local implementation checkpoint | `8806205c35b104ed65d00a273acc9eeca572ae38` | clean local commit on `agent/parser-assurance-m1`; exact-head tests passed, but independent oracle review rejected publication |
+| Current milestone | M1-B corrective assurance hardening prepared; goal paused | [restart handoff](internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md); no push or PR |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
 publication, or qualification.
@@ -118,6 +119,39 @@ The review established these M1-A decisions:
    sources. Existing focused tests remain authoritative; corpus tests reuse
    their behaviors and replace the private deep-refresh semantic tuple rather
    than creating a third semantic definition.
+
+### 2.2 M1-B corrective review reconciliation
+
+An independent patch review of local commit `8806205c35b104ed65d00a273acc9eeca572ae38`
+on 2026-08-16 found the architecture acceptable but the assurance oracle not
+yet safe to publish. Primary-agent runtime probes reproduced both P1 findings:
+the semantic projector removed a real content wikilink for `[[Foo]]` combined
+with `tags:: Foo`, and it projected `[[Project Authored]], [[Fixture]]` as one
+malformed token. Manifest probes also proved that non-empty unverified
+diagnostic codes and Boolean values in integer fields were accepted.
+
+M1-B is a corrective sub-milestone of M1, not a new product feature. It must:
+
+1. represent `tags`, `page-tags`, `alias`, and `aliases` as ordered canonical
+   token sequences, splitting commas only outside `[[...]]` references;
+2. derive property-origin wikilink occurrences independently and subtract only
+   their multiplicity from aggregate node wikilinks, preserving content links
+   with the same value;
+3. preserve raw-byte fixture SHA-256 claims while forcing LF checkout bytes for
+   `tests/fixtures/compat/**` through `.gitattributes`;
+4. reject every non-empty `expected_diagnostics` list while M1 accepts only
+   valid fixtures and has no diagnostic comparison runner;
+5. reject Boolean schema versions and Boolean `tab_size` values with exact
+   integer-type checks;
+6. include `scripts/update_compat_snapshots.py` in the maintained mypy command
+   and protect that inclusion with a quality-gate contract test; and
+7. preserve commit `8806205` as historical evidence, deliver corrections in a
+   new local commit, qualify that exact implementation SHA, then use a separate
+   documentation-evidence commit to record it before any push.
+
+The P1/P2 labels describe assurance-contract risk, not parser runtime behavior:
+M1-B remains test, fixture, tooling, Git policy, and documentation work. It must
+not change `src/`, package exports, runtime dependencies, or close #104.
 
 ## 3. Status vocabulary
 
@@ -354,9 +388,16 @@ converted into a pass or silently added to an allowlist.
 **Exit evidence**
 
 - Original Apache-2.0 fixtures only; source hashes and manifest provenance
-  validated; discovery order cannot change canonical snapshots.
+  validated; `.gitattributes` proves LF checkout bytes for the corpus; discovery
+  order cannot change canonical snapshots.
 - Exact-parse, semantic-roundtrip, identity, hierarchy, depth, and bounded
   file-entrypoint tests remain in the fast CI budget.
+- Regression tests prove comma-aware canonical reference-property sequences,
+  preservation of content wikilinks that coincide with property tags, and
+  count-based removal of property-origin wikilink occurrences.
+- The valid-only manifest rejects non-empty diagnostics, Boolean schema
+  versions, and Boolean tab sizes; the quality-gate contract proves the snapshot
+  generator remains in the mypy command.
 - The root export manifest is unchanged, no runtime/package dependency is added,
   `make all` and `make vendor-name-check` pass, and `src/` has zero import cycles.
 
@@ -570,6 +611,12 @@ converted into a pass or silently added to an allowlist.
 7. Every delegated conclusion is rechecked against source or deterministic
    validation before acceptance.
 
+For M1-B, a low-cost worker may own one bounded mechanical file group after the
+contract in section 2.2 is fixed: projector regression-test scaffolding;
+manifest negative-test scaffolding; or documentation chronology. The primary
+agent retains reference-token semantics, path/EOL security, exact-head
+qualification, Git-history decisions, and publication judgment.
+
 ## 14. Validation and publication gates
 
 For this documentation milestone:
@@ -591,6 +638,24 @@ Implementation milestones additionally require:
 - separate approval for merge, release, external service deployment, or license
   change.
 
+M1-B additionally requires these exact local commands on the corrective
+implementation commit:
+
+```bash
+rtk uv run python scripts/update_compat_snapshots.py
+rtk uv run pytest -q tests/test_compat_corpus.py tests/test_parser_deep_refresh.py tests/test_quality_gate_contract.py
+rtk uv run ruff check scripts/update_compat_snapshots.py tests/parser_assurance tests/test_compat_corpus.py tests/test_parser_deep_refresh.py tests/test_quality_gate_contract.py
+rtk make all
+rtk make vendor-name-check
+rtk git diff --check origin/main...HEAD
+```
+
+The checkout must be clean and the audit-code cycle check must report zero
+cycles. The exact implementation SHA then receives a frozen primary and
+low-cost independent review. A later documentation-evidence commit must pass at
+least `make all`, `make vendor-name-check`, documentation validation, diff
+check, and hosted required checks on its own exact head.
+
 ## 15. Interruption and recovery
 
 At every handoff record the source base, branch, exact HEAD, worktree path,
@@ -606,6 +671,9 @@ Milestone reports use:
 - residual risks;
 - next dependency.
 
+The current resumable checkpoint is
+[`internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md`](internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md).
+
 ## 16. Persistent goal
 
 The short execution pointer is versioned separately at
@@ -616,9 +684,16 @@ It must not replace the requirements in this plan.
 
 - [x] M0 is merged and publicly available through PR #159.
 - [x] #104-A is implemented and locally qualified on the working tree with an
-  original, provenance-safe projection and corpus foundation.
-- [ ] #104-A is committed, exact-head qualified, reviewed, merged, and covered
-  by terminal hosted validation.
+  initial original, provenance-safe projection and corpus foundation; the
+  resulting commit is retained as rejected pre-correction evidence.
+- [ ] M1-B preserves authentic content wikilinks and canonicalizes all four
+  reference-property families with comma-aware, count-based semantics.
+- [ ] M1-B enforces LF corpus bytes, empty valid-fixture diagnostics, exact
+  integer manifest fields, and snapshot-generator mypy coverage.
+- [ ] The corrective implementation commit is clean, exact-head qualified, and
+  independently reviewed without unresolved P0/P1/P2 findings.
+- [ ] A separate evidence commit records the implementation SHA and is covered
+  by terminal hosted validation before #104-A is merged.
 - [ ] The remaining expanded #104 acceptance criteria are proved through the
   dependency-owned #103 and M3 evidence before #104 is closed.
 - [ ] The external-oracle decision is recorded, including a valid negative
@@ -652,3 +727,5 @@ Completion is unproven until every applicable item has authoritative evidence.
 | 2026-08-16 | M1-A implementation | local, uncommitted | Added one private two-profile projector, a strict versioned manifest, six original Apache-2.0 fixtures and exact snapshots, bounded file-entrypoint assertions, and reuse from the deep-refresh regression suite. No `src/`, root export, or runtime dependency changed; final qualification and publication remain separate gates. |
 | 2026-08-16 | M1-A implementation review | reconciled | A bounded Spark review found no P0/P1. Its valid non-atomic snapshot-write P2 was corrected; manifest-negative and snapshot-CLI contracts were added. Its `source_uuid` P2 was rejected after primary verification because the projection deliberately exposes source identity and the dedicated test applies each `preserve`/`absent` policy without masking drift. |
 | 2026-08-16 | M1-A working-tree qualification | provisional | `rtk uv run python scripts/update_compat_snapshots.py` passed in non-mutating freshness mode; `rtk make all` passed with 553 tests and 92.07% coverage; Ruff, mypy, documentation, vendor-name, and diff checks passed; audit code reported zero `src/` import cycles. `rtk uv run python scripts/update_compat_snapshots.py --write` is the only explicit regeneration mode, and stale snapshots make the default command exit nonzero. This is not E1/E2 because the qualified bytes were not yet committed. |
+| 2026-08-16 | M1-A local commit `8806205` | exact-head tests passed; publication rejected | Clean local commit recorded 556 passing tests, 92.07% coverage, snapshot freshness, `make all`, vendor-name, diff, and zero-cycle checks. A later independent full-patch review found two oracle P1s: malformed multi-reference normalization and deletion of authentic content wikilinks. The commit must not be pushed as M1-A evidence. |
+| 2026-08-16 | M1-B corrective review | verified and prepared | Primary runtime probes reproduced both P1s and proved acceptance of non-empty unverified diagnostics and Boolean integer fields. Source review confirmed raw-byte hashes without LF checkout policy and omission of the snapshot generator from the maintained mypy command. Two bounded Spark inventories were advisory; the primary retained semantic and security decisions. The goal remains paused and no implementation, push, or PR is claimed. |

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -16,7 +16,7 @@ okf_spec_version: null
 supersedes: null
 superseded_by: null
 parent_plan: docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
-source_commit: 8ecb6e37c1ebc01a2e79eb999599eb3ecb7babc6
+source_commit: e2a3f9a8d190fd115028d0ad344c31fded0357d9
 reference_commit: c79cb059da5b4360ebde2e5fd953fa1f43ddabc3
 ---
 
@@ -53,16 +53,71 @@ Markdown source-of-truth model.
 | Item | Verified state | Evidence |
 |---|---|---|
 | Source repository | `MarcoPorcellato/logseq-matryca-parser` | `origin/main` fetched 2026-08-16 |
-| Source base | `8ecb6e37c1ebc01a2e79eb999599eb3ecb7babc6` | clean isolated worktree and [GitHub commit](https://github.com/MarcoPorcellato/logseq-matryca-parser/commit/8ecb6e37c1ebc01a2e79eb999599eb3ecb7babc6) |
+| Source base | `e2a3f9a8d190fd115028d0ad344c31fded0357d9` | clean `agent/parser-assurance-m1` checkout matching `origin/main` on 2026-08-16 and [GitHub commit](https://github.com/MarcoPorcellato/logseq-matryca-parser/commit/e2a3f9a8d190fd115028d0ad344c31fded0357d9) |
 | Source license | Apache License 2.0 | [`LICENSE`](../LICENSE) |
 | Reference repository | `martinkoutecky/lsdoc` release `v0.5.5` | [reference commit `c79cb059`](https://github.com/martinkoutecky/lsdoc/commit/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3) |
 | Reference license | `AGPL-3.0-only` | [`Cargo.toml`](https://github.com/martinkoutecky/lsdoc/blob/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3/Cargo.toml) and [`LICENSE`](https://github.com/martinkoutecky/lsdoc/blob/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3/LICENSE) |
 | Parent roadmap | current repository-wide quality SSOT | [stellar roadmap](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) |
-| Existing delivery anchors | #87, #103, #104, #108, #111 are open | live GitHub issue reads on 2026-08-16 |
-| Current milestone | M0 plan publication in delivery | branch `agent/lsdoc-reference-study`; pull request pending |
+| M0 publication | merged as [PR #159](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/159) | source head `a6056413`, squash merge `30946446`, terminal validation recorded in the PR |
+| Existing delivery anchors | #87, #103, #104, #108, #111 are open; #106 and #113 are closed | live GitHub issue reads on 2026-08-16 |
+| Current milestone | M1-A local freeze and exact-head qualification | branch `agent/parser-assurance-m1`; push, PR, and hosted exact-head checks remain unproven |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
 publication, or qualification.
+
+### 2.1 M1 independent-review reconciliation
+
+An independent review on 2026-08-16 found the M1 direction sound but the
+initial review package incomplete. The review was treated as advisory input and
+rechecked against the source tree, [#104](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/104),
+its audit-reconciliation comment, and the parent roadmap before acceptance.
+
+The live #104 comment expands the issue to include the depth matrix from closed
+#113, incremental-versus-cold-load snapshots owned by open #103, and filesystem
+abuse cases linked to closed #106. M1 therefore delivers **#104-A**, the
+project-owned projection and compatibility-corpus foundation. It does not claim
+to close #104. The remaining generated-malformed, graph snapshot, and broader
+filesystem-assurance work stays dependency-ordered under M3, #103, and the
+existing security contracts.
+
+The review established these M1-A decisions:
+
+1. Use one private, test-owned projector with two versioned profiles; do not add
+   a root-package export or a new public API.
+2. `exact_parse_v1` captures deterministic `StackMachineParser.parse()` output.
+   It includes page title, namespace, configured tab size, declared timestamps,
+   page properties/order/references, and every node's content, clean text,
+   properties/order, references, task data, UUID/source UUID/synthetic marker,
+   hierarchy, parent/left relations, path, outline path, indentation, line
+   ranges, declared timestamps, and ordered children. It excludes filesystem
+   context. The manifest stores the source SHA-256, while the test directly
+   proves `page.raw_content == source` instead of duplicating source text in
+   JSON.
+3. `semantic_roundtrip_v1` compares parse -> serialize -> parse semantics. It
+   includes title, namespace, normalized properties and their declared order,
+   outline order, meaningful content/clean text, references, tasks, declared
+   timestamps, source UUIDs, and structural parent/left locators. It excludes
+   raw source text, absolute paths, graph root, filesystem-derived timestamps,
+   byte formatting, and universal line-number equality. Direct synthetic UUID
+   equality is enforced only when the fixture identity policy requires it.
+4. Identity policy is an object, not an ambiguous label: `synthetic_uuid` is
+   `stable` or `recomputed`; `source_uuid` is `preserve` or `absent`; and
+   `relations` is `direct_ids` or `outline_paths`. All fixtures separately prove
+   UUID uniqueness, same-input determinism, and valid ordered parent/left links.
+5. File-entrypoint behavior uses bounded assertions rather than a third snapshot
+   profile. Paths are compared through normalized or relative relationships,
+   never frozen host-specific absolute values.
+6. The manifest records top-level corpus and snapshot schema versions. Every
+   entry also records `fixture_schema_version`, `snapshot_schema_version`,
+   fixture ID, source path and SHA-256, provenance, license, parse
+   entrypoint/configuration, enabled profiles, expected outcome, protected
+   behaviors, identity policy, expected diagnostic codes, and notes.
+7. The review surface for M1-A includes the parent roadmap, clean architecture,
+   public exports and API-contract test, path helpers and tests, package/quality
+   gates, and repository license/notice in addition to parser and serializer
+   sources. Existing focused tests remain authoritative; corpus tests reuse
+   their behaviors and replace the private deep-refresh semantic tuple rather
+   than creating a third semantic definition.
 
 ## 3. Status vocabulary
 
@@ -271,35 +326,51 @@ converted into a pass or silently added to an allowlist.
 
 - No future implementation is authorized merely by publishing this plan.
 
-### M1 — Project-owned semantic projection and corpus manifest
+### M1 — #104-A project-owned semantic projection and corpus foundation
 
 **Outcome**
 
-- Expand [#104](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/104)
-  with a versioned projection defined from current consumers and invariants.
-- Each fixture records an ID, original source/provenance, license, input class,
-  protected invariant, expected diagnostics, and semantic snapshot version.
-- Projection covers hierarchy, content, properties, UUID/source UUID behavior,
-  ordering, parent/left relations, line ranges, task data, references, and
-  serialization-reparse equivalence where applicable.
+- Deliver the first explicit tranche of
+  [#104](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/104)
+  without closing the expanded parent issue.
+- Add one private projector producing `exact_parse_v1` and
+  `semantic_roundtrip_v1` under the field and identity contracts in section 2.1.
+- Add an original, offline, versioned corpus whose manifest records corpus,
+  fixture, and snapshot schema versions, source SHA-256/provenance/license,
+  parse configuration, protected behaviors, identity policy, expected outcome,
+  and expected diagnostic codes.
+- Preserve the closed #113 depth matrix and minimized regression as protected
+  corpus behavior while retaining focused unit tests as the narrow defect
+  owners.
+- Add bounded file-entrypoint assertions without freezing absolute host paths or
+  duplicating the symlink and `file://` security suites owned by #106.
 
 **Dependencies**
 
-- M0 merged; current API and semantic contracts re-verified.
+- M0 merged through PR #159; current API, architecture, path, package, license,
+  quality-gate, and semantic contracts re-verified.
+- #103 remains the owner of complete incremental/cold-load snapshot equivalence.
 
 **Exit evidence**
 
-- Original fixtures only; deterministic manifest validation; corpus tests in
-  the fast CI budget; `make all`; zero import cycles.
+- Original Apache-2.0 fixtures only; source hashes and manifest provenance
+  validated; discovery order cannot change canonical snapshots.
+- Exact-parse, semantic-roundtrip, identity, hierarchy, depth, and bounded
+  file-entrypoint tests remain in the fast CI budget.
+- The root export manifest is unchanged, no runtime/package dependency is added,
+  `make all` and `make vendor-name-check` pass, and `src/` has zero import cycles.
 
 **Impact**
 
-- Makes semantic drift reviewable without freezing incidental Pydantic or JSON
-  formatting details.
+- Makes semantic drift reviewable without freezing incidental Pydantic, JSON,
+  filesystem, or host-path details and without promoting a test oracle to the
+  stable public API.
 
 **Residual risk**
 
 - Project-owned invariants can share the same blind spots as the implementation.
+- M1-A alone does not satisfy #104's generated malformed-input,
+  incremental/cold-load, or complete filesystem-abuse acceptance criteria.
 
 ### M2 — External oracle feasibility and license gate
 
@@ -343,6 +414,8 @@ converted into a pass or silently added to an allowlist.
   large lines, and incremental/cold-load equivalence.
 - Every generated run has bounded size, deterministic replay information, and
   subprocess timeout protection.
+- Complete the remaining expanded #104 acceptance criteria without duplicating
+  the focused #103 snapshot owner or the established #106 security contracts.
 
 **Dependencies**
 
@@ -541,8 +614,13 @@ It must not replace the requirements in this plan.
 
 ## 17. Completion checklist
 
-- [ ] M0 is merged and publicly available.
-- [ ] #104 has an original, provenance-safe semantic projection and corpus.
+- [x] M0 is merged and publicly available through PR #159.
+- [x] #104-A is implemented and locally qualified on the working tree with an
+  original, provenance-safe projection and corpus foundation.
+- [ ] #104-A is committed, exact-head qualified, reviewed, merged, and covered
+  by terminal hosted validation.
+- [ ] The remaining expanded #104 acceptance criteria are proved through the
+  dependency-owned #103 and M3 evidence before #104 is closed.
 - [ ] The external-oracle decision is recorded, including a valid negative
   decision if license or process boundaries are unacceptable.
 - [ ] Adversarial and property-based tests have deterministic replay and bounded
@@ -562,3 +640,15 @@ It must not replace the requirements in this plan.
   claimed.
 
 Completion is unproven until every applicable item has authoritative evidence.
+
+## 18. Execution ledger
+
+| Date | Anchor | Result | Evidence and residual boundary |
+|---|---|---|---|
+| 2026-08-16 | M0 / PR #159 | merged | Source head `a6056413`, squash merge `30946446`; PR records 535 passing tests, 91.95% coverage, documentation/package/vendor gates, and zero cycles. No parser behavior changed. |
+| 2026-08-16 | M1 activation | verified | Clean `agent/parser-assurance-m1` at `e2a3f9a`, matching `origin/main`; no tracked M1 changes at activation. |
+| 2026-08-16 | Independent M1 review | reconciled | Accepted the larger review surface, two-profile/single-projector model, explicit identity policy, and manifest expansion after source and live-issue verification. M1 is #104-A; #104 remains open. |
+| 2026-08-16 | Low-cost inventories | advisory | Two Spark read-only inventories located reusable tests and model fields. Their proposals are not authority; only source-verified evidence is admitted to implementation. |
+| 2026-08-16 | M1-A implementation | local, uncommitted | Added one private two-profile projector, a strict versioned manifest, six original Apache-2.0 fixtures and exact snapshots, bounded file-entrypoint assertions, and reuse from the deep-refresh regression suite. No `src/`, root export, or runtime dependency changed; final qualification and publication remain separate gates. |
+| 2026-08-16 | M1-A implementation review | reconciled | A bounded Spark review found no P0/P1. Its valid non-atomic snapshot-write P2 was corrected; manifest-negative and snapshot-CLI contracts were added. Its `source_uuid` P2 was rejected after primary verification because the projection deliberately exposes source identity and the dedicated test applies each `preserve`/`absent` policy without masking drift. |
+| 2026-08-16 | M1-A working-tree qualification | provisional | `rtk uv run python scripts/update_compat_snapshots.py` passed in non-mutating freshness mode; `rtk make all` passed with 553 tests and 92.07% coverage; Ruff, mypy, documentation, vendor-name, and diff checks passed; audit code reported zero `src/` import cycles. `rtk uv run python scripts/update_compat_snapshots.py --write` is the only explicit regeneration mode, and stale snapshots make the default command exit nonzero. This is not E1/E2 because the qualified bytes were not yet committed. |

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -61,7 +61,7 @@ Markdown source-of-truth model.
 | M0 publication | merged as [PR #159](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/159) | source head `a6056413`, squash merge `30946446`, terminal validation recorded in the PR |
 | Existing delivery anchors | #87, #103, #104, #108, #111 are open; #106 and #113 are closed | live GitHub issue reads on 2026-08-16 |
 | Local implementation checkpoint | `8806205c35b104ed65d00a273acc9eeca572ae38` | clean local commit on `agent/parser-assurance-m1`; exact-head tests passed, but independent oracle review rejected publication |
-| Current milestone | M1-B corrective assurance hardening prepared; goal paused | [restart handoff](internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md); no push or PR |
+| Current milestone | M1-B evidence recorded locally; frozen Sol review pending | implementation `996c5a52b08f2670ecd80fb3f1515b65ae567465`; no push or PR |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
 publication, or qualification.
@@ -686,14 +686,15 @@ It must not replace the requirements in this plan.
 - [x] #104-A is implemented and locally qualified on the working tree with an
   initial original, provenance-safe projection and corpus foundation; the
   resulting commit is retained as rejected pre-correction evidence.
-- [ ] M1-B preserves authentic content wikilinks and canonicalizes all four
+- [x] M1-B preserves authentic content wikilinks and canonicalizes all four
   reference-property families with comma-aware, count-based semantics.
-- [ ] M1-B enforces LF corpus bytes, empty valid-fixture diagnostics, exact
+- [x] M1-B enforces LF corpus bytes, empty valid-fixture diagnostics, exact
   integer manifest fields, and snapshot-generator mypy coverage.
 - [ ] The corrective implementation commit is clean, exact-head qualified, and
-  independently reviewed without unresolved P0/P1/P2 findings.
-- [ ] A separate evidence commit records the implementation SHA and is covered
-  by terminal hosted validation before #104-A is merged.
+  has a frozen final diff ready for independent Sol review without unresolved
+  P0/P1/P2 findings.
+- [x] A separate local evidence commit records implementation `996c5a5`; hosted
+  validation remains deferred until an explicitly authorized push and PR.
 - [ ] The remaining expanded #104 acceptance criteria are proved through the
   dependency-owned #103 and M3 evidence before #104 is closed.
 - [ ] The external-oracle decision is recorded, including a valid negative
@@ -729,3 +730,4 @@ Completion is unproven until every applicable item has authoritative evidence.
 | 2026-08-16 | M1-A working-tree qualification | provisional | `rtk uv run python scripts/update_compat_snapshots.py` passed in non-mutating freshness mode; `rtk make all` passed with 553 tests and 92.07% coverage; Ruff, mypy, documentation, vendor-name, and diff checks passed; audit code reported zero `src/` import cycles. `rtk uv run python scripts/update_compat_snapshots.py --write` is the only explicit regeneration mode, and stale snapshots make the default command exit nonzero. This is not E1/E2 because the qualified bytes were not yet committed. |
 | 2026-08-16 | M1-A local commit `8806205` | exact-head tests passed; publication rejected | Clean local commit recorded 556 passing tests, 92.07% coverage, snapshot freshness, `make all`, vendor-name, diff, and zero-cycle checks. A later independent full-patch review found two oracle P1s: malformed multi-reference normalization and deletion of authentic content wikilinks. The commit must not be pushed as M1-A evidence. |
 | 2026-08-16 | M1-B corrective review | verified and prepared | Primary runtime probes reproduced both P1s and proved acceptance of non-empty unverified diagnostics and Boolean integer fields. Source review confirmed raw-byte hashes without LF checkout policy and omission of the snapshot generator from the maintained mypy command. Two bounded Spark inventories were advisory; the primary retained semantic and security decisions. The goal remains paused and no implementation, push, or PR is claimed. |
+| 2026-08-16 | M1-B corrective implementation `996c5a5` | locally qualified | Added comma-aware canonical reference-property sequences; reverse count-subtraction of property-origin wikilinks to preserve content-link order; LF fixture-byte policy; exact integer and empty-diagnostics manifest guards; and snapshot-generator mypy coverage. Focused tests, Ruff, and mypy passed; exact-head snapshot freshness, `make all` (572 tests and coverage gate), vendor-name check, documentation check, diff check, and zero-cycle audit passed. No `src/`, package, dependency, push, PR, merge, or release change occurred. Spark and Luna worker starts were blocked before execution by the local permission initializer, so no delegated output was accepted. |

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -29,12 +29,12 @@ delivery state. Continue through the dependency-ordered milestones until every
 applicable completion item has authoritative current evidence. Do not redo work
 already proved in the plan.
 
-The last verified local checkpoint is branch `agent/parser-assurance-m1` at
-`8806205c35b104ed65d00a273acc9eeca572ae38`, based on `e2a3f9a8d190fd115028d0ad344c31fded0357d9`.
-That commit passed local exact-head gates but failed independent oracle review
-and must not be pushed. When the paused goal is resumed, re-verify this anchor
-and execute M1-B from the
-[restart handoff](../internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md).
+The rejected historical checkpoint is `8806205c35b104ed65d00a273acc9eeca572ae38`,
+based on `e2a3f9a8d190fd115028d0ad344c31fded0357d9`; it must not be pushed.
+Corrective implementation `996c5a52b08f2670ecd80fb3f1515b65ae567465` passed its
+local exact-head validation without changing `src/`. Before any push, re-verify
+the live anchor, review the frozen final diff with GPT-5.6 Sol, and follow the
+[post-correction handoff](../internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md).
 
 Preserve the Apache-2.0 boundary: do not copy or adapt lsdoc code, tests,
 corpora, schemas, module structure, control flow, or documentation. Keep lsdoc

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -29,12 +29,22 @@ delivery state. Continue through the dependency-ordered milestones until every
 applicable completion item has authoritative current evidence. Do not redo work
 already proved in the plan.
 
-The rejected historical checkpoint is `8806205c35b104ed65d00a273acc9eeca572ae38`,
-based on `e2a3f9a8d190fd115028d0ad344c31fded0357d9`; it must not be pushed.
-Corrective implementation `996c5a52b08f2670ecd80fb3f1515b65ae567465` passed its
-local exact-head validation without changing `src/`. Before any push, re-verify
-the live anchor, review the frozen final diff with GPT-5.6 Sol, and follow the
+The initial checkpoint `8806205c35b104ed65d00a273acc9eeca572ae38` is rejected
+pre-correction evidence. Corrective implementation
+`996c5a52b08f2670ecd80fb3f1515b65ae567465` passed local exact-head checks, but
+its evidence head `6fcf4b274a3a04ef4c9783cf83149d6ef4aeeabb` was rejected by
+the first frozen Sol review and is now superseded. These historical checkpoints
+must not be presented or pushed independently as publication-ready evidence.
+Corrective implementation `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` is non-amending,
+changed only `CHANGELOG.md`, `tests/parser_assurance/projection.py`, and
+`tests/test_compat_corpus.py`, and passed exact-head local qualification on a
+clean worktree.
+Before any push, re-verify the live anchor, review the frozen full diff with GPT-5.6
+Sol again, and follow the
 [post-correction handoff](../internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md).
+The separate documentation-evidence commit containing this pointer must receive
+exact-head qualification. Then freeze the full diff, rerun a final GPT-5.6 Sol
+review, and stop before push.
 
 Preserve the Apache-2.0 boundary: do not copy or adapt lsdoc code, tests,
 corpora, schemas, module structure, control flow, or documentation. Keep lsdoc

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -35,16 +35,20 @@ pre-correction evidence. Corrective implementation
 its evidence head `6fcf4b274a3a04ef4c9783cf83149d6ef4aeeabb` was rejected by
 the first frozen Sol review and is now superseded. These historical checkpoints
 must not be presented or pushed independently as publication-ready evidence.
-Corrective implementation `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` is non-amending,
-changed only `CHANGELOG.md`, `tests/parser_assurance/projection.py`, and
-`tests/test_compat_corpus.py`, and passed exact-head local qualification on a
-clean worktree.
+Corrective implementation `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` passed local
+qualification but was superseded after frozen review head
+`5007dc357e05775c6221c8aa84f9a11edc695e0d` returned `NEEDS_CORRECTION` for
+unequal-backtick shielding parity. Non-amending corrective implementation
+`7870b84` changed only `tests/parser_assurance/projection.py` and
+`tests/test_compat_corpus.py` and passed exact-head local qualification with
+584 tests and 92.16% coverage on a clean worktree.
 Before any push, re-verify the live anchor, review the frozen full diff with GPT-5.6
 Sol again, and follow the
 [post-correction handoff](../internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md).
-The separate documentation-evidence commit containing this pointer must receive
-exact-head qualification. Then freeze the full diff, rerun a final GPT-5.6 Sol
-review, and stop before push.
+The refreshed documentation-evidence commit containing this pointer must
+receive exact-head qualification. Then freeze the raw full diff, record its
+unfiltered SHA-256 and line count, rerun a final GPT-5.6 Sol review, and stop
+before push.
 
 Preserve the Apache-2.0 boundary: do not copy or adapt lsdoc code, tests,
 corpora, schemas, module structure, control flow, or documentation. Keep lsdoc

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -29,6 +29,13 @@ delivery state. Continue through the dependency-ordered milestones until every
 applicable completion item has authoritative current evidence. Do not redo work
 already proved in the plan.
 
+The last verified local checkpoint is branch `agent/parser-assurance-m1` at
+`8806205c35b104ed65d00a273acc9eeca572ae38`, based on `e2a3f9a8d190fd115028d0ad344c31fded0357d9`.
+That commit passed local exact-head gates but failed independent oracle review
+and must not be pushed. When the paused goal is resumed, re-verify this anchor
+and execute M1-B from the
+[restart handoff](../internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md).
+
 Preserve the Apache-2.0 boundary: do not copy or adapt lsdoc code, tests,
 corpora, schemas, module structure, control flow, or documentation. Keep lsdoc
 out of runtime, build, package, and CI dependencies unless the plan's explicit

--- a/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
+++ b/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
@@ -6,7 +6,7 @@
 - Isolated worktree: none; the dedicated delivery branch is checked out in the
   primary repository directory.
 - Branch: `agent/parser-assurance-m1`
-- Corrective implementation: `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` (non-amending, files-only corrective pass)
+- Corrective implementation: `7870b84` (non-amending, test-oracle-only corrective pass)
 - Base and local `origin/main`: `e2a3f9a8d190fd115028d0ad344c31fded0357d9`
 - Remote branch: none; the delivery branch has not been pushed.
 - Pull request: none.
@@ -43,7 +43,7 @@
   equivalent HTML-comment, math, fence, query-macro, or query-region forms)
   could remove an authentic visible `[[Foo]]`; `#[[Foo]]` also projected as
   `[[Foo]]` instead of `Foo`.
-- Corrective implementation `9e8708e` repaired all reproduced defects without
+- Corrective implementation `9e8708e` repaired the first review's reproduced defects without
   modifying `src/`: the test oracle canonicalizes comma-separated references,
   subtracts property-origin wikilinks from the tail by multiplicity (including math,
   backtick/tilde fences, query macro, and query-region contexts), forces LF corpus
@@ -53,6 +53,18 @@
   and coverage gate, Ruff, mypy, documentation validation, vendor-name check, diff
   check, and zero-cycle audit. No source, package, dependency, API, or runtime
   behavior changed.
+- Separate documentation evidence commit `5007dc3` froze the next full-patch
+  review surface. Sol returned `NEEDS_CORRECTION`: unequal backtick runs still
+  made property-link accounting delete authentic visible content, and the
+  supplied patch hash/line receipt had been computed from token-filtered output
+  instead of raw Git diff bytes.
+- Corrective implementation `7870b84` repaired the reproduced mismatch with
+  exact delimiter-run matching and bounded closing logic for fences, query
+  regions, math, and comments. It added the exact mixed-backtick reproducer,
+  closed-region visible-link tests, and a 14-family direct differential probe.
+  Exact-head validation passed snapshot freshness, `make all` with 584 tests
+  and 92.16% coverage, Ruff, mypy, documentation, vendor-name, diff, and
+  zero-cycle checks. No runtime or package surface changed.
 
 ## Frozen scope and remaining gates
 
@@ -75,15 +87,18 @@
 | 3 | Primary quality gate | `Makefile`, `tests/test_quality_gate_contract.py` | Complete: snapshot generator appears in mypy and has a dry-run contract test. |
 | 4 | Spark scaffolding, primary integration | `tests/test_compat_corpus.py`, `tests/parser_assurance/projection.py` | Complete: Spark added bounded regressions for the first Sol findings; the primary extended the shielding matrix, implemented the correction, and retained all adjudication authority. |
 | 5 | Primary integration | `CHANGELOG.md`, `docs/log.md`, canonical plan, persistent goal | Complete in implementation/evidence commits; claims preserve historical failures and superseded receipts without presenting them as current qualification. |
-| 6 | Primary Git/evidence | local commits and exact-head receipts | Implementation exact-head qualification complete; this evidence commit then needs its own exact-head qualification and frozen Sol review. |
+| 6 | Primary second correction | `tests/parser_assurance/projection.py`, `tests/test_compat_corpus.py` | Complete: exact unequal-backtick and closed-region parity at `7870b84`; a failed Spark attempt was interrupted and its malformed scaffolding was removed before primary integration. |
+| 7 | Primary Git/evidence | local commits and exact-head receipts | Second corrective implementation exact-head qualification complete; this refreshed evidence commit then needs its own exact-head qualification and frozen Sol review. |
 
 No package or runtime source file belongs to these work packages.
 
 ## Active or stopped work
 
 - Workers: prior Spark inventories remain advisory.
-- M1-B sequence fact: Spark added the bounded regression-test scaffolding and the
-  primary integrated it. No Luna fallback was needed.
+- M1-B sequence fact: Spark added the first bounded regression-test scaffolding,
+  which the primary integrated. A second Spark attempt received shell-damaged
+  backtick input and was interrupted; none of its malformed test scaffolding
+  remains. No Luna fallback was needed.
 - Processes: none expected; verify before resuming.
 - Resource admission: not checked; no local-model or LM Studio work is allowed.
 
@@ -100,8 +115,10 @@ No package or runtime source file belongs to these work packages.
 
 1. Run `rtk git status --short --branch`, `rtk git rev-parse HEAD origin/main`,
    and qualify the separate evidence commit on its exact head.
-2. Freeze `git diff --binary origin/main...HEAD` and ask GPT-5.6 Sol to review
-   the whole patch against the M1-B contract, including documentation claims.
+2. Freeze raw `git --no-pager diff --no-ext-diff --binary --full-index
+   origin/main...HEAD` bytes, hash and count those exact bytes without an output
+   filter, and ask GPT-5.6 Sol to review the whole patch against the M1-B
+   contract, including documentation claims.
 3. Adjudicate every review finding with source and deterministic probes. If any
    correction is necessary, create a new local correction and repeat exact-head
    qualification; do not amend historical commits.

--- a/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
+++ b/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
@@ -6,7 +6,7 @@
 - Isolated worktree: none; the dedicated delivery branch is checked out in the
   primary repository directory.
 - Branch: `agent/parser-assurance-m1`
-- Corrective implementation: `996c5a52b08f2670ecd80fb3f1515b65ae567465`
+- Corrective implementation: `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` (non-amending, files-only corrective pass)
 - Base and local `origin/main`: `e2a3f9a8d190fd115028d0ad344c31fded0357d9`
 - Remote branch: none; the delivery branch has not been pushed.
 - Pull request: none.
@@ -36,13 +36,23 @@
 - Source inspection confirmed raw-byte fixture hashing without an LF checkout
   policy and omission of `scripts/update_compat_snapshots.py` from the Makefile
   mypy command.
-- Corrective implementation `996c5a5` repaired all reproduced defects without
+- Corrective implementation `996c5a5` passed its exact-head local checks, and
+  separate evidence commit `6fcf4b2` froze the first Sol review surface.
+- That Sol review returned `NEEDS_CORRECTION`: property-link extraction ignored
+  parser shielding, so a property literal such as ``note:: `[[Foo]]` `` (and
+  equivalent HTML-comment, math, fence, query-macro, or query-region forms)
+  could remove an authentic visible `[[Foo]]`; `#[[Foo]]` also projected as
+  `[[Foo]]` instead of `Foo`.
+- Corrective implementation `9e8708e` repaired all reproduced defects without
   modifying `src/`: the test oracle canonicalizes comma-separated references,
-  subtracts property-origin wikilinks from the tail by multiplicity, forces LF
-  corpus bytes, rejects non-empty valid-fixture diagnostics and Boolean integer
-  values, and type-checks the snapshot generator. Exact-head validation passed:
-  focused tests, snapshot freshness, `make all` with 572 tests and its coverage
-  gate, vendor-name and documentation checks, diff check, and zero import cycles.
+  subtracts property-origin wikilinks from the tail by multiplicity (including math,
+  backtick/tilde fences, query macro, and query-region contexts), forces LF corpus
+  bytes, rejects non-empty valid-fixture diagnostics and Boolean integer values,
+  and type-checks the snapshot generator. Exact-head validation passed on a clean
+  worktree: seven focused regressions, snapshot freshness, `make all` with 579 tests
+  and coverage gate, Ruff, mypy, documentation validation, vendor-name check, diff
+  check, and zero-cycle audit. No source, package, dependency, API, or runtime
+  behavior changed.
 
 ## Frozen scope and remaining gates
 
@@ -50,7 +60,9 @@
   HEAD with GPT-5.6 Sol. Recheck every finding against source and deterministic
   evidence; do not treat a review request as an approval.
 - Refresh remote `origin/main`, rules, and GitHub state only after the user
-  authorizes publication. Do not push `8806205` or any successor implicitly.
+  authorizes publication. Do not publish `8806205`, `996c5a5`, or `6fcf4b2`
+  independently as qualified checkpoints; only the final reviewed branch may
+  be pushed, and only with explicit authorization.
 - Obtain terminal hosted checks and the user’s separate approval before opening
   a PR, merging, or releasing.
 
@@ -60,17 +72,18 @@
 |---|---|---|---|
 | 1 | Primary semantics | `tests/parser_assurance/projection.py`, `tests/test_compat_corpus.py` | Complete: comma-aware canonical sequences and reverse count-subtraction preserve authentic content links and order. |
 | 2 | Primary security | `.gitattributes`, `tests/parser_assurance/corpus.py`, `tests/test_compat_corpus.py` | Complete: raw-byte LF policy, empty valid diagnostics, and exact integer guards. |
-| 3 | Primary after unavailable worker start | `Makefile`, `tests/test_quality_gate_contract.py` | Complete: snapshot generator appears in mypy and has a dry-run contract test. Spark and Luna did not start because the local permission initializer timed out. |
-| 4 | Primary integration | `CHANGELOG.md`, `docs/log.md`, canonical plan, persistent goal | Complete in implementation/evidence commits; claims preserve `8806205` as rejected historical evidence. |
-| 5 | Primary Git/evidence | local commits and exact-head receipts | Implementation exact-head qualification complete; this evidence commit then needs its own exact-head qualification and frozen Sol review. |
+| 3 | Primary quality gate | `Makefile`, `tests/test_quality_gate_contract.py` | Complete: snapshot generator appears in mypy and has a dry-run contract test. |
+| 4 | Spark scaffolding, primary integration | `tests/test_compat_corpus.py`, `tests/parser_assurance/projection.py` | Complete: Spark added bounded regressions for the first Sol findings; the primary extended the shielding matrix, implemented the correction, and retained all adjudication authority. |
+| 5 | Primary integration | `CHANGELOG.md`, `docs/log.md`, canonical plan, persistent goal | Complete in implementation/evidence commits; claims preserve historical failures and superseded receipts without presenting them as current qualification. |
+| 6 | Primary Git/evidence | local commits and exact-head receipts | Implementation exact-head qualification complete; this evidence commit then needs its own exact-head qualification and frozen Sol review. |
 
 No package or runtime source file belongs to these work packages.
 
 ## Active or stopped work
 
-- Workers: prior Spark inventories remain advisory. The M1-B Spark and Luna
-  worker starts were blocked before execution by the local permission
-  initializer; no unreviewed worker output was accepted.
+- Workers: prior Spark inventories remain advisory.
+- M1-B sequence fact: Spark added the bounded regression-test scaffolding and the
+  primary integrated it. No Luna fallback was needed.
 - Processes: none expected; verify before resuming.
 - Resource admission: not checked; no local-model or LM Studio work is allowed.
 
@@ -97,7 +110,8 @@ No package or runtime source file belongs to these work packages.
 
 ## Boundaries that must survive the restart
 
-- Do not push or open a PR for `8806205`.
+- Do not publish historical checkpoints `8806205`, `996c5a5`, or `6fcf4b2`
+  independently as qualified evidence.
 - Do not modify `src/`, root package exports, package metadata, dependencies, or
   runtime behavior for M1-B.
 - Do not copy or adapt AGPL code, tests, corpus, schemas, or documentation.

--- a/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
+++ b/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
@@ -1,4 +1,4 @@
-# M1-A corrective hardening restart handoff — 2026-08-16
+# M1-B post-correction pre-push handoff — 2026-08-16
 
 ## Safe resume point
 
@@ -6,14 +6,15 @@
 - Isolated worktree: none; the dedicated delivery branch is checked out in the
   primary repository directory.
 - Branch: `agent/parser-assurance-m1`
-- HEAD: `8806205c35b104ed65d00a273acc9eeca572ae38`
+- Corrective implementation: `996c5a52b08f2670ecd80fb3f1515b65ae567465`
 - Base and local `origin/main`: `e2a3f9a8d190fd115028d0ad344c31fded0357d9`
 - Remote branch: none; the delivery branch has not been pushed.
 - Pull request: none.
-- Working tree after preparation: modified canonical plan, persistent goal, and
-  documentation log; this handoff is untracked. Re-verify the exact status
-  before editing.
-- Persistent goal state: paused; only the user may resume it.
+- Evidence commit: this handoff, the canonical plan, persistent goal, and
+  documentation log record the local result separately from the implementation.
+  Re-verify its exact SHA after committing before any review or publication.
+- Persistent goal state: active through frozen Sol review; push, PR, merge, and
+  release still require separate user authorization.
 
 ## Completed and terminally verified
 
@@ -35,35 +36,41 @@
 - Source inspection confirmed raw-byte fixture hashing without an LF checkout
   policy and omission of `scripts/update_compat_snapshots.py` from the Makefile
   mypy command.
+- Corrective implementation `996c5a5` repaired all reproduced defects without
+  modifying `src/`: the test oracle canonicalizes comma-separated references,
+  subtracts property-origin wikilinks from the tail by multiplicity, forces LF
+  corpus bytes, rejects non-empty valid-fixture diagnostics and Boolean integer
+  values, and type-checks the snapshot generator. Exact-head validation passed:
+  focused tests, snapshot freshness, `make all` with 572 tests and its coverage
+  gate, vendor-name and documentation checks, diff check, and zero import cycles.
 
-## Saved but not yet qualified
+## Frozen scope and remaining gates
 
-- `docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md` — M1-B contract,
-  gates, checklist, and ledger update.
-- `docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md` — exact rejected anchor and resume
-  pointer.
-- `docs/log.md` — documentation chronology for this correction checkpoint.
-- `docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md` — this
-  preparation checkpoint.
+- Review the frozen diff from `origin/main` through the exact evidence-commit
+  HEAD with GPT-5.6 Sol. Recheck every finding against source and deterministic
+  evidence; do not treat a review request as an approval.
+- Refresh remote `origin/main`, rules, and GitHub state only after the user
+  authorizes publication. Do not push `8806205` or any successor implicitly.
+- Obtain terminal hosted checks and the user’s separate approval before opening
+  a PR, merging, or releasing.
 
-Do not treat these uncommitted documentation changes as passed validation.
-
-## Corrective work packages
+## Completed corrective work packages
 
 | Order | Owner | Files | Required result |
 |---|---|---|---|
-| 1 | Primary semantics; Spark may scaffold tests | `tests/parser_assurance/projection.py`, `tests/test_compat_corpus.py` | Comma-aware canonical sequences for `tags`, `page-tags`, `alias`, and `aliases`; property-origin wikilinks removed by count; authentic matching content links preserved. |
-| 2 | Primary security; Spark may scaffold negative tests | `.gitattributes`, `tests/parser_assurance/corpus.py`, `tests/test_compat_corpus.py` | Raw-byte SHA remains truthful under forced LF; valid-only diagnostics must be empty; schema versions and tab size reject Boolean values. |
-| 3 | Spark mechanical edit; primary integration review | `Makefile`, `tests/test_quality_gate_contract.py` | Snapshot generator is explicitly included in mypy and protected by a contract test. |
-| 4 | Primary integration | `CHANGELOG.md`, `docs/log.md`, canonical plan, persistent goal | Claims match the corrected implementation and preserve `8806205` as rejected historical evidence. |
-| 5 | Primary Git/evidence | local commits and exact-head receipts | New corrective implementation commit, exact-head qualification and frozen review, then a separate evidence-only documentation commit. |
+| 1 | Primary semantics | `tests/parser_assurance/projection.py`, `tests/test_compat_corpus.py` | Complete: comma-aware canonical sequences and reverse count-subtraction preserve authentic content links and order. |
+| 2 | Primary security | `.gitattributes`, `tests/parser_assurance/corpus.py`, `tests/test_compat_corpus.py` | Complete: raw-byte LF policy, empty valid diagnostics, and exact integer guards. |
+| 3 | Primary after unavailable worker start | `Makefile`, `tests/test_quality_gate_contract.py` | Complete: snapshot generator appears in mypy and has a dry-run contract test. Spark and Luna did not start because the local permission initializer timed out. |
+| 4 | Primary integration | `CHANGELOG.md`, `docs/log.md`, canonical plan, persistent goal | Complete in implementation/evidence commits; claims preserve `8806205` as rejected historical evidence. |
+| 5 | Primary Git/evidence | local commits and exact-head receipts | Implementation exact-head qualification complete; this evidence commit then needs its own exact-head qualification and frozen Sol review. |
 
 No package or runtime source file belongs to these work packages.
 
 ## Active or stopped work
 
-- Workers: two Spark read-only inventories completed; no worker has write
-  ownership and their outputs are advisory only.
+- Workers: prior Spark inventories remain advisory. The M1-B Spark and Luna
+  worker starts were blocked before execution by the local permission
+  initializer; no unreviewed worker output was accepted.
 - Processes: none expected; verify before resuming.
 - Resource admission: not checked; no local-model or LM Studio work is allowed.
 
@@ -76,31 +83,17 @@ No package or runtime source file belongs to these work packages.
 - Human gate: resume of the paused goal; commit, push, PR, merge, and release
   remain separate gates.
 
-## Exact resume sequence
+## Exact pre-push sequence
 
 1. Run `rtk git status --short --branch`, `rtk git rev-parse HEAD origin/main`,
-   and verify the three prepared documentation files against this handoff.
-2. Re-read `AGENTS.md`, the canonical plan, the persistent goal, and this
-   handoff. Confirm that the goal has been resumed by the user.
-3. Implement work package 1 and first add regressions for:
-   `[[Foo]]` plus `tags:: Foo`; duplicate content/property occurrences;
-   `[[Project Authored]], [[Fixture]]`; and a comma inside `[[New York, NY]]`.
-4. Implement work package 2 with `tests/fixtures/compat/** text eol=lf`, strict
-   empty diagnostics, exact integer types, and negative tests.
-5. Implement work package 3 and prove its Makefile dry-run contract.
-6. Run the focused tests and targeted Ruff/mypy commands from the canonical
-   plan. Regenerate exact snapshots only if the exact profile changed; semantic
-   fixes alone must not rewrite them.
-7. Run `rtk make all`, `rtk make vendor-name-check`, the exact diff check, and
-   the zero-cycle audit. Review every change against #104-A scope.
-8. Create a new corrective implementation commit; do not amend or delete
-   `8806205`. Re-run every required gate on the clean exact commit.
-9. Delegate one frozen read-only review to Spark, then adjudicate every finding
-   against source and deterministic probes.
-10. Update the canonical ledger with the implementation SHA and evidence in a
-    separate documentation-only commit. Qualify that exact head locally.
-11. Stop before push. Refresh live `origin/main`, rules, and GitHub state only
-    when the user separately authorizes publication.
+   and qualify the separate evidence commit on its exact head.
+2. Freeze `git diff --binary origin/main...HEAD` and ask GPT-5.6 Sol to review
+   the whole patch against the M1-B contract, including documentation claims.
+3. Adjudicate every review finding with source and deterministic probes. If any
+   correction is necessary, create a new local correction and repeat exact-head
+   qualification; do not amend historical commits.
+4. Stop before push. Refresh live `origin/main`, rules, and GitHub state only
+   when the user separately authorizes publication.
 
 ## Boundaries that must survive the restart
 

--- a/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
+++ b/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
@@ -1,0 +1,118 @@
+# M1-A corrective hardening restart handoff — 2026-08-16
+
+## Safe resume point
+
+- Repository: `/Users/marco1/Documents/CODICE con VS CODE/logseq-matryca-parser`
+- Isolated worktree: none; the dedicated delivery branch is checked out in the
+  primary repository directory.
+- Branch: `agent/parser-assurance-m1`
+- HEAD: `8806205c35b104ed65d00a273acc9eeca572ae38`
+- Base and local `origin/main`: `e2a3f9a8d190fd115028d0ad344c31fded0357d9`
+- Remote branch: none; the delivery branch has not been pushed.
+- Pull request: none.
+- Working tree after preparation: modified canonical plan, persistent goal, and
+  documentation log; this handoff is untracked. Re-verify the exact status
+  before editing.
+- Persistent goal state: paused; only the user may resume it.
+
+## Completed and terminally verified
+
+- Commit `8806205` exists locally and was clean when qualified.
+- `rtk uv run python scripts/update_compat_snapshots.py` passed on `8806205`.
+- Focused parser-assurance tests passed: 32 tests before the independent
+  correction review.
+- `rtk make all` and a compact full-suite run passed on `8806205`: 556 tests,
+  92.07% coverage.
+- `rtk make vendor-name-check`, commit diff check, and audit-code cycle check
+  passed; `src/` had zero cycles.
+- A later independent full-patch review returned `NEEDS_CORRECTION`; therefore
+  the successful checks do not qualify `8806205` for publication.
+- Primary runtime probes reproduced both projector P1s:
+  `[[Foo]]` plus `tags:: Foo` loses the content wikilink, and
+  `[[Project Authored]], [[Fixture]]` becomes one malformed token.
+- Primary manifest probes proved that non-empty `expected_diagnostics`, Boolean
+  schema versions, and Boolean `tab_size` are accepted.
+- Source inspection confirmed raw-byte fixture hashing without an LF checkout
+  policy and omission of `scripts/update_compat_snapshots.py` from the Makefile
+  mypy command.
+
+## Saved but not yet qualified
+
+- `docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md` — M1-B contract,
+  gates, checklist, and ledger update.
+- `docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md` — exact rejected anchor and resume
+  pointer.
+- `docs/log.md` — documentation chronology for this correction checkpoint.
+- `docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md` — this
+  preparation checkpoint.
+
+Do not treat these uncommitted documentation changes as passed validation.
+
+## Corrective work packages
+
+| Order | Owner | Files | Required result |
+|---|---|---|---|
+| 1 | Primary semantics; Spark may scaffold tests | `tests/parser_assurance/projection.py`, `tests/test_compat_corpus.py` | Comma-aware canonical sequences for `tags`, `page-tags`, `alias`, and `aliases`; property-origin wikilinks removed by count; authentic matching content links preserved. |
+| 2 | Primary security; Spark may scaffold negative tests | `.gitattributes`, `tests/parser_assurance/corpus.py`, `tests/test_compat_corpus.py` | Raw-byte SHA remains truthful under forced LF; valid-only diagnostics must be empty; schema versions and tab size reject Boolean values. |
+| 3 | Spark mechanical edit; primary integration review | `Makefile`, `tests/test_quality_gate_contract.py` | Snapshot generator is explicitly included in mypy and protected by a contract test. |
+| 4 | Primary integration | `CHANGELOG.md`, `docs/log.md`, canonical plan, persistent goal | Claims match the corrected implementation and preserve `8806205` as rejected historical evidence. |
+| 5 | Primary Git/evidence | local commits and exact-head receipts | New corrective implementation commit, exact-head qualification and frozen review, then a separate evidence-only documentation commit. |
+
+No package or runtime source file belongs to these work packages.
+
+## Active or stopped work
+
+- Workers: two Spark read-only inventories completed; no worker has write
+  ownership and their outputs are advisory only.
+- Processes: none expected; verify before resuming.
+- Resource admission: not checked; no local-model or LM Studio work is allowed.
+
+## External state
+
+- Required checks: not applicable until a branch is pushed and a PR exists.
+- Remote freshness: local `origin/main` was `e2a3f9a`; live GitHub must be
+  refreshed immediately before publication.
+- Receipt: none.
+- Human gate: resume of the paused goal; commit, push, PR, merge, and release
+  remain separate gates.
+
+## Exact resume sequence
+
+1. Run `rtk git status --short --branch`, `rtk git rev-parse HEAD origin/main`,
+   and verify the three prepared documentation files against this handoff.
+2. Re-read `AGENTS.md`, the canonical plan, the persistent goal, and this
+   handoff. Confirm that the goal has been resumed by the user.
+3. Implement work package 1 and first add regressions for:
+   `[[Foo]]` plus `tags:: Foo`; duplicate content/property occurrences;
+   `[[Project Authored]], [[Fixture]]`; and a comma inside `[[New York, NY]]`.
+4. Implement work package 2 with `tests/fixtures/compat/** text eol=lf`, strict
+   empty diagnostics, exact integer types, and negative tests.
+5. Implement work package 3 and prove its Makefile dry-run contract.
+6. Run the focused tests and targeted Ruff/mypy commands from the canonical
+   plan. Regenerate exact snapshots only if the exact profile changed; semantic
+   fixes alone must not rewrite them.
+7. Run `rtk make all`, `rtk make vendor-name-check`, the exact diff check, and
+   the zero-cycle audit. Review every change against #104-A scope.
+8. Create a new corrective implementation commit; do not amend or delete
+   `8806205`. Re-run every required gate on the clean exact commit.
+9. Delegate one frozen read-only review to Spark, then adjudicate every finding
+   against source and deterministic probes.
+10. Update the canonical ledger with the implementation SHA and evidence in a
+    separate documentation-only commit. Qualify that exact head locally.
+11. Stop before push. Refresh live `origin/main`, rules, and GitHub state only
+    when the user separately authorizes publication.
+
+## Boundaries that must survive the restart
+
+- Do not push or open a PR for `8806205`.
+- Do not modify `src/`, root package exports, package metadata, dependencies, or
+  runtime behavior for M1-B.
+- Do not copy or adapt AGPL code, tests, corpus, schemas, or documentation.
+- Keep all fixtures original, offline, Apache-2.0, and free of private vault
+  content or host paths.
+- Do not weaken path, symlink, atomic-write, identity, determinism, diagnostics,
+  coverage, or documentation gates.
+- Do not close #104; M1-A remains only its compatibility-corpus foundation.
+- Do not call `8806205`, uncommitted preparation, or a non-hosted result E2/E4.
+
+This handoff is a preparation checkpoint, not a validation receipt.

--- a/docs/log.md
+++ b/docs/log.md
@@ -8,9 +8,9 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-08
-verified: 2026-08-08
-stale_after: 2027-02-04
+last_verified: 2026-08-16
+verified: 2026-08-16
+stale_after: 2027-02-12
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -21,6 +21,13 @@ superseded_by: null
 
 ## 2026-08-16
 
+- Implemented the local #104-A parser compatibility-corpus foundation: one
+  private, test-owned projector with exact-parse and semantic-roundtrip
+  profiles; six original Apache-2.0 Markdown fixtures; strict source hashes,
+  provenance, schema, parser configuration, protected behavior, diagnostics,
+  and identity-policy metadata; bounded file-entrypoint assertions; and shared
+  projection logic in the deep-refresh regression suite. This tranche does not
+  close #104 and does not change runtime code or the public package API.
 - Added the maintained
   [lsdoc reference study and parser assurance plan](LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md)
   as a subordinate extension of the stellar roadmap. It maps independently

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,16 +21,19 @@ superseded_by: null
 
 ## 2026-08-16
 
-- Implemented and locally qualified M1-B corrective assurance hardening in
-  `996c5a5`: the private test oracle now canonicalizes all four reference
-  property families without splitting commas inside page references, removes
-  property-origin wikilinks by occurrence while preserving content-link order,
-  enforces LF corpus bytes and stricter valid-fixture manifest fields, and
-  includes the snapshot generator in the maintained mypy contract. Exact-head
-  local validation passed snapshot freshness, focused tests, the full 572-test
-  `make all` suite and coverage gate, vendor-name/documentation/diff checks,
-  and zero import cycles. No runtime code, package surface, dependency, push,
-  PR, merge, or release changed; the frozen diff awaits independent Sol review.
+- Recorded the first frozen Sol review on `6fcf4b274a3a04ef4c9783cf83149d6ef4aeeabb` as `NEEDS_CORRECTION`.
+- Implemented non-amending corrective commit `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` in
+  `CHANGELOG.md`, `tests/parser_assurance/projection.py`, and
+  `tests/test_compat_corpus.py`. Exact-head validation on a clean worktree passed
+  snapshot freshness, `7` focused regressions, `make all` with `579` tests and
+  coverage gate, Ruff, mypy, documentation validation, vendor-name check, diff
+  check, and zero-cycle check. The implementation made property-link accounting
+  honor inline code, HTML comments, math, backtick/tilde fences, query macros,
+  and query regions; it also normalized `#[[Foo]]` as `Foo`. Spark supplied the
+  bounded regression scaffolding, which the primary extended and adjudicated;
+  no Luna fallback was needed. Historical `8806205`, `996c5a5`, and `6fcf4b2`
+  remain rejected or superseded receipts, not current publication evidence. No runtime
+  behavior, package, dependency, push, PR, merge, or release claim was made.
 - Reconciled an independent `NEEDS_CORRECTION` review of local M1-A commit
   `8806205`. The canonical parser-assurance plan now defines the M1-B corrective
   contract for reference-property semantics, content-wikilink preservation, LF

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,6 +21,16 @@ superseded_by: null
 
 ## 2026-08-16
 
+- Implemented and locally qualified M1-B corrective assurance hardening in
+  `996c5a5`: the private test oracle now canonicalizes all four reference
+  property families without splitting commas inside page references, removes
+  property-origin wikilinks by occurrence while preserving content-link order,
+  enforces LF corpus bytes and stricter valid-fixture manifest fields, and
+  includes the snapshot generator in the maintained mypy contract. Exact-head
+  local validation passed snapshot freshness, focused tests, the full 572-test
+  `make all` suite and coverage gate, vendor-name/documentation/diff checks,
+  and zero import cycles. No runtime code, package surface, dependency, push,
+  PR, merge, or release changed; the frozen diff awaits independent Sol review.
 - Reconciled an independent `NEEDS_CORRECTION` review of local M1-A commit
   `8806205`. The canonical parser-assurance plan now defines the M1-B corrective
   contract for reference-property semantics, content-wikilink preservation, LF

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,15 +21,30 @@ superseded_by: null
 
 ## 2026-08-16
 
+- Recorded the second frozen Sol review on
+  `5007dc357e05775c6221c8aa84f9a11edc695e0d` as `NEEDS_CORRECTION`: mixed
+  backtick runs still caused an authentic content wikilink to be removed, and
+  the supplied full-patch receipt had been computed from filtered rather than
+  raw Git diff bytes.
+- Implemented non-amending corrective commit `7870b84` only in
+  `tests/parser_assurance/projection.py` and `tests/test_compat_corpus.py`.
+  Exact backtick-run matching, closed fence/query boundaries, math closing, and
+  unclosed-comment parity now match parser-observable behavior. The exact Sol
+  reproducer, three post-region visible-link tests, and a 14-family direct
+  differential probe pass. Exact-head snapshot freshness and `make all` passed
+  with 584 tests and 92.16% coverage; Ruff, mypy, documentation, vendor-name,
+  diff, and zero-cycle checks also passed. No runtime, package, dependency,
+  push, PR, merge, or release change occurred.
 - Recorded the first frozen Sol review on `6fcf4b274a3a04ef4c9783cf83149d6ef4aeeabb` as `NEEDS_CORRECTION`.
 - Implemented non-amending corrective commit `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` in
   `CHANGELOG.md`, `tests/parser_assurance/projection.py`, and
   `tests/test_compat_corpus.py`. Exact-head validation on a clean worktree passed
   snapshot freshness, `7` focused regressions, `make all` with `579` tests and
   coverage gate, Ruff, mypy, documentation validation, vendor-name check, diff
-  check, and zero-cycle check. The implementation made property-link accounting
-  honor inline code, HTML comments, math, backtick/tilde fences, query macros,
-  and query regions; it also normalized `#[[Foo]]` as `Foo`. Spark supplied the
+  check, and zero-cycle check. The implementation covered the first review's
+  simple inline-code, HTML-comment, math, fence, query-macro, and query-region
+  cases; it also normalized `#[[Foo]]` as `Foo`. A later review found unequal
+  backtick parity incomplete. Spark supplied the
   bounded regression scaffolding, which the primary extended and adjudicated;
   no Luna fallback was needed. Historical `8806205`, `996c5a5`, and `6fcf4b2`
   remain rejected or superseded receipts, not current publication evidence. No runtime

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,6 +21,13 @@ superseded_by: null
 
 ## 2026-08-16
 
+- Reconciled an independent `NEEDS_CORRECTION` review of local M1-A commit
+  `8806205`. The canonical parser-assurance plan now defines the M1-B corrective
+  contract for reference-property semantics, content-wikilink preservation, LF
+  fixture bytes, strict diagnostics and integer fields, quality-gate coverage,
+  two-commit evidence sequencing, and separate publication approval. Updated
+  the persistent goal and added a restart handoff; no corrective implementation,
+  push, PR, or merge is claimed.
 - Implemented the local #104-A parser compatibility-corpus foundation: one
   private, test-owned projector with exact-parse and semantic-roundtrip
   profiles; six original Apache-2.0 Markdown fixtures; strict source hashes,

--- a/scripts/update_compat_snapshots.py
+++ b/scripts/update_compat_snapshots.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Check or explicitly regenerate exact parser compatibility snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from logseq_matryca_parser.logos_core import LogseqPage  # noqa: E402
+from logseq_matryca_parser.logos_parser import StackMachineParser  # noqa: E402
+from tests.parser_assurance.corpus import CORPUS_ROOT, load_corpus_entries  # noqa: E402
+from tests.parser_assurance.projection import project_page  # noqa: E402
+
+
+def _parse_entry(entry: dict[str, Any]) -> LogseqPage:
+    source_path = CORPUS_ROOT / entry["source"]["path"]
+    source = source_path.read_text(encoding="utf-8")
+    parse = entry["parse"]
+    parser = StackMachineParser(tab_size=parse["tab_size"])
+    if parse["entrypoint"] == "file":
+        return parser.parse_page_file(source_path)
+    return parser.parse(source, page_title=parse["page_title"])
+
+
+def _render_snapshot(entry: dict[str, Any]) -> str:
+    projection = project_page(_parse_entry(entry), profile="exact_parse_v1")
+    return json.dumps(projection, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="replace snapshots explicitly; the default only checks them",
+    )
+    args = parser.parse_args(argv)
+
+    stale: list[Path] = []
+    for entry in load_corpus_entries():
+        snapshot_path = CORPUS_ROOT / entry["profiles"]["exact_parse"]
+        expected = _render_snapshot(entry)
+        actual = snapshot_path.read_text(encoding="utf-8") if snapshot_path.is_file() else None
+        if actual == expected:
+            continue
+        stale.append(snapshot_path)
+        if args.write:
+            _atomic_write_text(snapshot_path, expected)
+
+    if stale and not args.write:
+        for path in stale:
+            print(f"stale compatibility snapshot: {path.relative_to(CORPUS_ROOT)}")
+        return 1
+    if args.write:
+        print(f"updated {len(stale)} compatibility snapshot(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Repository test package and private assurance support."""

--- a/tests/fixtures/compat/v1/deep-refresh-regression.md
+++ b/tests/fixtures/compat/v1/deep-refresh-regression.md
@@ -1,0 +1,6 @@
+- a
+  - b
+    - c
+      - d
+        - e
+          continuation-e

--- a/tests/fixtures/compat/v1/hierarchy-identity.md
+++ b/tests/fixtures/compat/v1/hierarchy-identity.md
@@ -1,0 +1,9 @@
+title:: Project tree baseline
+
+- Alpha
+  id:: 91e6b8c4-4bb4-4f9f-a4df-3e9c2f1d4c44
+  - Alpha child
+  - Alpha support
+- Beta
+  - Beta branch
+- Gamma

--- a/tests/fixtures/compat/v1/manifest.json
+++ b/tests/fixtures/compat/v1/manifest.json
@@ -1,0 +1,216 @@
+{
+  "corpus_schema_version": 1,
+  "snapshot_schema_version": 1,
+  "license": "Apache-2.0",
+  "fixtures": [
+    {
+      "id": "m1a-hierarchy-identity",
+      "fixture_schema_version": 1,
+      "snapshot_schema_version": 1,
+      "source": {
+        "path": "hierarchy-identity.md",
+        "sha256": "015ae41fa6d2089529494f1ae1b8501bc3ef833c44e440f5648dfff0454b61c6",
+        "provenance": "project-authored",
+        "license": "Apache-2.0"
+      },
+      "parse": {
+        "entrypoint": "text",
+        "page_title": "Project tree baseline",
+        "tab_size": 2
+      },
+      "profiles": {
+        "exact_parse": "snapshots/m1a-hierarchy-identity.exact.json",
+        "semantic_roundtrip": true
+      },
+      "expectation": {
+        "outcome": "valid",
+        "protected_behaviors": [
+          "sibling_order",
+          "parent_left_pointers"
+        ],
+        "identity_policy": {
+          "synthetic_uuid": "stable",
+          "source_uuid": "preserve",
+          "relations": "direct_ids"
+        },
+        "expected_diagnostics": []
+      },
+      "notes": "Covers hierarchy shape and sibling ordering with page identity."
+    },
+    {
+      "id": "m1a-properties-links-assets",
+      "fixture_schema_version": 1,
+      "snapshot_schema_version": 1,
+      "source": {
+        "path": "properties-and-links.md",
+        "sha256": "6e0051a27fdac9ee8749718817de3714ff45c182cc1cb93a9b6dc65f6b7dcfaf",
+        "provenance": "project-authored",
+        "license": "Apache-2.0"
+      },
+      "parse": {
+        "entrypoint": "text",
+        "page_title": "Properties, references, and assets",
+        "tab_size": 2
+      },
+      "profiles": {
+        "exact_parse": "snapshots/m1a-properties-links-assets.exact.json",
+        "semantic_roundtrip": true
+      },
+      "expectation": {
+        "outcome": "valid",
+        "protected_behaviors": [
+          "property_preservation",
+          "wikilink_and_block_ref_resolution",
+          "tag_capture",
+          "asset_path_capture"
+        ],
+        "identity_policy": {
+          "synthetic_uuid": "recomputed",
+          "source_uuid": "preserve",
+          "relations": "outline_paths"
+        },
+        "expected_diagnostics": []
+      },
+      "notes": "Covers page properties, block properties, tags, wikilinks, block references, and assets."
+    },
+    {
+      "id": "m1a-task-timing",
+      "fixture_schema_version": 1,
+      "snapshot_schema_version": 1,
+      "source": {
+        "path": "tasks-priority-time.md",
+        "sha256": "570f1b7e9516f190252823632ae035333e311d8ca9ec6ce1374f7d6dad7a53a3",
+        "provenance": "project-authored",
+        "license": "Apache-2.0"
+      },
+      "parse": {
+        "entrypoint": "text",
+        "page_title": "Task and schedule corpus",
+        "tab_size": 2
+      },
+      "profiles": {
+        "exact_parse": "snapshots/m1a-task-timing.exact.json",
+        "semantic_roundtrip": true
+      },
+      "expectation": {
+        "outcome": "valid",
+        "protected_behaviors": [
+          "task_markers",
+          "priority_capture",
+          "scheduled_deadline_repeater_fields"
+        ],
+        "identity_policy": {
+          "synthetic_uuid": "stable",
+          "source_uuid": "preserve",
+          "relations": "direct_ids"
+        },
+        "expected_diagnostics": []
+      },
+      "notes": "Covers task, priority, scheduled, deadline, and repeater metadata."
+    },
+    {
+      "id": "m1a-softbreak-logbook",
+      "fixture_schema_version": 1,
+      "snapshot_schema_version": 1,
+      "source": {
+        "path": "soft-breaks-properties-logbook.md",
+        "sha256": "48ca06121608f9a9313417f512e2b14ff20ba953ca50626413213b33d9008d5e",
+        "provenance": "project-authored",
+        "license": "Apache-2.0"
+      },
+      "parse": {
+        "entrypoint": "text",
+        "page_title": "Soft break and property log",
+        "tab_size": 2
+      },
+      "profiles": {
+        "exact_parse": "snapshots/m1a-softbreak-logbook.exact.json",
+        "semantic_roundtrip": true
+      },
+      "expectation": {
+        "outcome": "valid",
+        "protected_behaviors": [
+          "soft_breaks",
+          "list_properties",
+          "logbook_capture",
+          "yaml_frontmatter"
+        ],
+        "identity_policy": {
+          "synthetic_uuid": "recomputed",
+          "source_uuid": "absent",
+          "relations": "outline_paths"
+        },
+        "expected_diagnostics": []
+      },
+      "notes": "Covers soft breaks, list-scoped properties, logbook block, and YAML frontmatter."
+    },
+    {
+      "id": "m1a-deep-refresh",
+      "fixture_schema_version": 1,
+      "snapshot_schema_version": 1,
+      "source": {
+        "path": "deep-refresh-regression.md",
+        "sha256": "256d25ba33a666175c73da1da2471cc671825d3109adf006feb356788d689060",
+        "provenance": "project-authored",
+        "license": "Apache-2.0"
+      },
+      "parse": {
+        "entrypoint": "text",
+        "page_title": "Deep refresh minimized regression",
+        "tab_size": 2
+      },
+      "profiles": {
+        "exact_parse": "snapshots/m1a-deep-refresh.exact.json",
+        "semantic_roundtrip": true
+      },
+      "expectation": {
+        "outcome": "valid",
+        "protected_behaviors": [
+          "deep_refresh_stability",
+          "outline_rebuild",
+          "sibling_order"
+        ],
+        "identity_policy": {
+          "synthetic_uuid": "stable",
+          "source_uuid": "absent",
+          "relations": "direct_ids"
+        },
+        "expected_diagnostics": []
+      },
+      "notes": "Minimized regression fixture for deep-refresh stack behavior."
+    },
+    {
+      "id": "m1a-nested-entrypoint",
+      "fixture_schema_version": 1,
+      "snapshot_schema_version": 1,
+      "source": {
+        "path": "pages/nested-title-entrypoint.md",
+        "sha256": "f3077e211b61c1641e0fb2480a26756c0e311b2919c4de18fc100f6a8e0b5c0e",
+        "provenance": "project-authored",
+        "license": "Apache-2.0"
+      },
+      "parse": {
+        "entrypoint": "file",
+        "tab_size": 2
+      },
+      "profiles": {
+        "exact_parse": "snapshots/m1a-nested-entrypoint.exact.json",
+        "semantic_roundtrip": true
+      },
+      "expectation": {
+        "outcome": "valid",
+        "protected_behaviors": [
+          "title_resolution_from_path",
+          "graph_root_derivation_without_file_uri"
+        ],
+        "identity_policy": {
+          "synthetic_uuid": "stable",
+          "source_uuid": "absent",
+          "relations": "outline_paths"
+        },
+        "expected_diagnostics": []
+      },
+      "notes": "Nested fixture under pages/ for file-entrypoint title and graph-root derivation behavior."
+    }
+  ]
+}

--- a/tests/fixtures/compat/v1/pages/nested-title-entrypoint.md
+++ b/tests/fixtures/compat/v1/pages/nested-title-entrypoint.md
@@ -1,0 +1,2 @@
+- File entrypoint root
+  - Nested child

--- a/tests/fixtures/compat/v1/properties-and-links.md
+++ b/tests/fixtures/compat/v1/properties-and-links.md
@@ -1,0 +1,13 @@
+title:: Properties, references, and assets
+tags:: [[Project Authored]], [[Fixture]]
+alias:: Parser Fixture
+
+- Property block
+  id:: 7f7f66e8-2f66-4bf4-9b8f-1a1cb7e3af71
+  status:: active
+  owner:: Matryca team
+  - Linked child
+- Cross reference to [[Nested Entry]]
+- Mention page tag #properties
+- Insert an asset reference: ![matrix](../assets/matrix.png)
+- Link to the first block ((7f7f66e8-2f66-4bf4-9b8f-1a1cb7e3af71))

--- a/tests/fixtures/compat/v1/snapshots/m1a-deep-refresh.exact.json
+++ b/tests/fixtures/compat/v1/snapshots/m1a-deep-refresh.exact.json
@@ -1,0 +1,205 @@
+{
+  "page": {
+    "created_at": null,
+    "namespace_chain": [],
+    "properties": {},
+    "properties_order": [],
+    "refs": [],
+    "root_nodes": [
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [
+          {
+            "assets": [],
+            "block_refs": [],
+            "children": [
+              {
+                "assets": [],
+                "block_refs": [],
+                "children": [
+                  {
+                    "assets": [],
+                    "block_refs": [],
+                    "children": [
+                      {
+                        "assets": [],
+                        "block_refs": [],
+                        "children": [],
+                        "clean_text": "e\ncontinuation-e",
+                        "content": "e\n          continuation-e",
+                        "created_at": null,
+                        "deadline_at": null,
+                        "indent_level": 4,
+                        "left_id": null,
+                        "line_end": 6,
+                        "line_start": 5,
+                        "outline_path": [
+                          1,
+                          1,
+                          1,
+                          1,
+                          1
+                        ],
+                        "parent_id": "b832c742-827f-57aa-bb8e-9f0b954e3612",
+                        "path": [
+                          "19916508-7843-5a59-a454-9daadf803cf5",
+                          "415b380e-7e92-57cf-bc6d-2c8b91273ef5",
+                          "6debb3d5-48cd-5bde-9b2d-371c86c1e33e",
+                          "b832c742-827f-57aa-bb8e-9f0b954e3612",
+                          "2fc11381-6d72-552e-83e6-fe6906a1ea14"
+                        ],
+                        "properties": {},
+                        "properties_order": [],
+                        "refs": [],
+                        "repeater": null,
+                        "scheduled_at": null,
+                        "source_uuid": null,
+                        "synthetic_id": true,
+                        "tags": [],
+                        "task_priority": null,
+                        "task_status": null,
+                        "updated_at": null,
+                        "uuid": "2fc11381-6d72-552e-83e6-fe6906a1ea14",
+                        "wikilinks": []
+                      }
+                    ],
+                    "clean_text": "d",
+                    "content": "d",
+                    "created_at": null,
+                    "deadline_at": null,
+                    "indent_level": 3,
+                    "left_id": null,
+                    "line_end": 4,
+                    "line_start": 4,
+                    "outline_path": [
+                      1,
+                      1,
+                      1,
+                      1
+                    ],
+                    "parent_id": "6debb3d5-48cd-5bde-9b2d-371c86c1e33e",
+                    "path": [
+                      "19916508-7843-5a59-a454-9daadf803cf5",
+                      "415b380e-7e92-57cf-bc6d-2c8b91273ef5",
+                      "6debb3d5-48cd-5bde-9b2d-371c86c1e33e",
+                      "b832c742-827f-57aa-bb8e-9f0b954e3612"
+                    ],
+                    "properties": {},
+                    "properties_order": [],
+                    "refs": [],
+                    "repeater": null,
+                    "scheduled_at": null,
+                    "source_uuid": null,
+                    "synthetic_id": true,
+                    "tags": [],
+                    "task_priority": null,
+                    "task_status": null,
+                    "updated_at": null,
+                    "uuid": "b832c742-827f-57aa-bb8e-9f0b954e3612",
+                    "wikilinks": []
+                  }
+                ],
+                "clean_text": "c",
+                "content": "c",
+                "created_at": null,
+                "deadline_at": null,
+                "indent_level": 2,
+                "left_id": null,
+                "line_end": 3,
+                "line_start": 3,
+                "outline_path": [
+                  1,
+                  1,
+                  1
+                ],
+                "parent_id": "415b380e-7e92-57cf-bc6d-2c8b91273ef5",
+                "path": [
+                  "19916508-7843-5a59-a454-9daadf803cf5",
+                  "415b380e-7e92-57cf-bc6d-2c8b91273ef5",
+                  "6debb3d5-48cd-5bde-9b2d-371c86c1e33e"
+                ],
+                "properties": {},
+                "properties_order": [],
+                "refs": [],
+                "repeater": null,
+                "scheduled_at": null,
+                "source_uuid": null,
+                "synthetic_id": true,
+                "tags": [],
+                "task_priority": null,
+                "task_status": null,
+                "updated_at": null,
+                "uuid": "6debb3d5-48cd-5bde-9b2d-371c86c1e33e",
+                "wikilinks": []
+              }
+            ],
+            "clean_text": "b",
+            "content": "b",
+            "created_at": null,
+            "deadline_at": null,
+            "indent_level": 1,
+            "left_id": null,
+            "line_end": 2,
+            "line_start": 2,
+            "outline_path": [
+              1,
+              1
+            ],
+            "parent_id": "19916508-7843-5a59-a454-9daadf803cf5",
+            "path": [
+              "19916508-7843-5a59-a454-9daadf803cf5",
+              "415b380e-7e92-57cf-bc6d-2c8b91273ef5"
+            ],
+            "properties": {},
+            "properties_order": [],
+            "refs": [],
+            "repeater": null,
+            "scheduled_at": null,
+            "source_uuid": null,
+            "synthetic_id": true,
+            "tags": [],
+            "task_priority": null,
+            "task_status": null,
+            "updated_at": null,
+            "uuid": "415b380e-7e92-57cf-bc6d-2c8b91273ef5",
+            "wikilinks": []
+          }
+        ],
+        "clean_text": "a",
+        "content": "a",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": null,
+        "line_end": 1,
+        "line_start": 1,
+        "outline_path": [
+          1
+        ],
+        "parent_id": null,
+        "path": [
+          "19916508-7843-5a59-a454-9daadf803cf5"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "19916508-7843-5a59-a454-9daadf803cf5",
+        "wikilinks": []
+      }
+    ],
+    "tab_size": 2,
+    "title": "Deep refresh minimized regression",
+    "updated_at": null
+  },
+  "profile": "exact_parse_v1",
+  "snapshot_schema_version": 1
+}

--- a/tests/fixtures/compat/v1/snapshots/m1a-hierarchy-identity.exact.json
+++ b/tests/fixtures/compat/v1/snapshots/m1a-hierarchy-identity.exact.json
@@ -1,0 +1,230 @@
+{
+  "page": {
+    "created_at": null,
+    "namespace_chain": [],
+    "properties": {
+      "title": "Project tree baseline"
+    },
+    "properties_order": [
+      "title"
+    ],
+    "refs": [],
+    "root_nodes": [
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [
+          {
+            "assets": [],
+            "block_refs": [],
+            "children": [],
+            "clean_text": "Alpha child",
+            "content": "Alpha child",
+            "created_at": null,
+            "deadline_at": null,
+            "indent_level": 1,
+            "left_id": null,
+            "line_end": 5,
+            "line_start": 5,
+            "outline_path": [
+              1,
+              1
+            ],
+            "parent_id": "3bcccb17-9d4e-5e8d-938c-b3583d1c1fa5",
+            "path": [
+              "3bcccb17-9d4e-5e8d-938c-b3583d1c1fa5",
+              "4a581c12-cbaa-5712-9c77-baa1499bbcce"
+            ],
+            "properties": {},
+            "properties_order": [],
+            "refs": [],
+            "repeater": null,
+            "scheduled_at": null,
+            "source_uuid": null,
+            "synthetic_id": true,
+            "tags": [],
+            "task_priority": null,
+            "task_status": null,
+            "updated_at": null,
+            "uuid": "4a581c12-cbaa-5712-9c77-baa1499bbcce",
+            "wikilinks": []
+          },
+          {
+            "assets": [],
+            "block_refs": [],
+            "children": [],
+            "clean_text": "Alpha support",
+            "content": "Alpha support",
+            "created_at": null,
+            "deadline_at": null,
+            "indent_level": 1,
+            "left_id": "4a581c12-cbaa-5712-9c77-baa1499bbcce",
+            "line_end": 6,
+            "line_start": 6,
+            "outline_path": [
+              1,
+              2
+            ],
+            "parent_id": "3bcccb17-9d4e-5e8d-938c-b3583d1c1fa5",
+            "path": [
+              "3bcccb17-9d4e-5e8d-938c-b3583d1c1fa5",
+              "eeeee800-77e6-567d-8dbc-29917a1b2f12"
+            ],
+            "properties": {},
+            "properties_order": [],
+            "refs": [],
+            "repeater": null,
+            "scheduled_at": null,
+            "source_uuid": null,
+            "synthetic_id": true,
+            "tags": [],
+            "task_priority": null,
+            "task_status": null,
+            "updated_at": null,
+            "uuid": "eeeee800-77e6-567d-8dbc-29917a1b2f12",
+            "wikilinks": []
+          }
+        ],
+        "clean_text": "Alpha",
+        "content": "Alpha",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": null,
+        "line_end": 4,
+        "line_start": 3,
+        "outline_path": [
+          1
+        ],
+        "parent_id": null,
+        "path": [
+          "3bcccb17-9d4e-5e8d-938c-b3583d1c1fa5"
+        ],
+        "properties": {
+          "id": "91e6b8c4-4bb4-4f9f-a4df-3e9c2f1d4c44"
+        },
+        "properties_order": [
+          "id"
+        ],
+        "refs": [],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": "91e6b8c4-4bb4-4f9f-a4df-3e9c2f1d4c44",
+        "synthetic_id": false,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "3bcccb17-9d4e-5e8d-938c-b3583d1c1fa5",
+        "wikilinks": []
+      },
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [
+          {
+            "assets": [],
+            "block_refs": [],
+            "children": [],
+            "clean_text": "Beta branch",
+            "content": "Beta branch",
+            "created_at": null,
+            "deadline_at": null,
+            "indent_level": 1,
+            "left_id": null,
+            "line_end": 8,
+            "line_start": 8,
+            "outline_path": [
+              2,
+              1
+            ],
+            "parent_id": "8054902a-f794-5499-82cb-b9bc0290c80d",
+            "path": [
+              "8054902a-f794-5499-82cb-b9bc0290c80d",
+              "43d5bcb3-fbd1-5bad-9c73-75cb9f5e55a2"
+            ],
+            "properties": {},
+            "properties_order": [],
+            "refs": [],
+            "repeater": null,
+            "scheduled_at": null,
+            "source_uuid": null,
+            "synthetic_id": true,
+            "tags": [],
+            "task_priority": null,
+            "task_status": null,
+            "updated_at": null,
+            "uuid": "43d5bcb3-fbd1-5bad-9c73-75cb9f5e55a2",
+            "wikilinks": []
+          }
+        ],
+        "clean_text": "Beta",
+        "content": "Beta",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": "3bcccb17-9d4e-5e8d-938c-b3583d1c1fa5",
+        "line_end": 7,
+        "line_start": 7,
+        "outline_path": [
+          2
+        ],
+        "parent_id": null,
+        "path": [
+          "8054902a-f794-5499-82cb-b9bc0290c80d"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "8054902a-f794-5499-82cb-b9bc0290c80d",
+        "wikilinks": []
+      },
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [],
+        "clean_text": "Gamma",
+        "content": "Gamma",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": "8054902a-f794-5499-82cb-b9bc0290c80d",
+        "line_end": 9,
+        "line_start": 9,
+        "outline_path": [
+          3
+        ],
+        "parent_id": null,
+        "path": [
+          "84401ff8-0da2-5e91-995e-039b46220008"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "84401ff8-0da2-5e91-995e-039b46220008",
+        "wikilinks": []
+      }
+    ],
+    "tab_size": 2,
+    "title": "Project tree baseline",
+    "updated_at": null
+  },
+  "profile": "exact_parse_v1",
+  "snapshot_schema_version": 1
+}

--- a/tests/fixtures/compat/v1/snapshots/m1a-nested-entrypoint.exact.json
+++ b/tests/fixtures/compat/v1/snapshots/m1a-nested-entrypoint.exact.json
@@ -1,0 +1,85 @@
+{
+  "page": {
+    "created_at": null,
+    "namespace_chain": [],
+    "properties": {},
+    "properties_order": [],
+    "refs": [],
+    "root_nodes": [
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [
+          {
+            "assets": [],
+            "block_refs": [],
+            "children": [],
+            "clean_text": "Nested child",
+            "content": "Nested child",
+            "created_at": null,
+            "deadline_at": null,
+            "indent_level": 1,
+            "left_id": null,
+            "line_end": 2,
+            "line_start": 2,
+            "outline_path": [
+              1,
+              1
+            ],
+            "parent_id": "69686838-b432-5f13-92fd-358566957a9e",
+            "path": [
+              "69686838-b432-5f13-92fd-358566957a9e",
+              "a3f59f7f-481f-5d5b-8605-7fbe711d1cc5"
+            ],
+            "properties": {},
+            "properties_order": [],
+            "refs": [],
+            "repeater": null,
+            "scheduled_at": null,
+            "source_uuid": null,
+            "synthetic_id": true,
+            "tags": [],
+            "task_priority": null,
+            "task_status": null,
+            "updated_at": null,
+            "uuid": "a3f59f7f-481f-5d5b-8605-7fbe711d1cc5",
+            "wikilinks": []
+          }
+        ],
+        "clean_text": "File entrypoint root",
+        "content": "File entrypoint root",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": null,
+        "line_end": 1,
+        "line_start": 1,
+        "outline_path": [
+          1
+        ],
+        "parent_id": null,
+        "path": [
+          "69686838-b432-5f13-92fd-358566957a9e"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "69686838-b432-5f13-92fd-358566957a9e",
+        "wikilinks": []
+      }
+    ],
+    "tab_size": 2,
+    "title": "nested-title-entrypoint",
+    "updated_at": null
+  },
+  "profile": "exact_parse_v1",
+  "snapshot_schema_version": 1
+}

--- a/tests/fixtures/compat/v1/snapshots/m1a-properties-links-assets.exact.json
+++ b/tests/fixtures/compat/v1/snapshots/m1a-properties-links-assets.exact.json
@@ -1,0 +1,251 @@
+{
+  "page": {
+    "created_at": null,
+    "namespace_chain": [],
+    "properties": {
+      "alias": "Parser Fixture",
+      "tags": "[[Project Authored]], [[Fixture]]",
+      "title": "Properties, references, and assets"
+    },
+    "properties_order": [
+      "title",
+      "tags",
+      "alias"
+    ],
+    "refs": [
+      "Nested Entry",
+      "properties",
+      "Project Authored",
+      "Fixture",
+      "Parser Fixture"
+    ],
+    "root_nodes": [
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [
+          {
+            "assets": [],
+            "block_refs": [],
+            "children": [],
+            "clean_text": "Linked child",
+            "content": "Linked child",
+            "created_at": null,
+            "deadline_at": null,
+            "indent_level": 1,
+            "left_id": null,
+            "line_end": 9,
+            "line_start": 9,
+            "outline_path": [
+              1,
+              1
+            ],
+            "parent_id": "0e865189-dfa7-57c2-b314-c4f0bf5d5654",
+            "path": [
+              "0e865189-dfa7-57c2-b314-c4f0bf5d5654",
+              "436f9dc2-4026-5b6e-9856-a88074578aca"
+            ],
+            "properties": {},
+            "properties_order": [],
+            "refs": [],
+            "repeater": null,
+            "scheduled_at": null,
+            "source_uuid": null,
+            "synthetic_id": true,
+            "tags": [],
+            "task_priority": null,
+            "task_status": null,
+            "updated_at": null,
+            "uuid": "436f9dc2-4026-5b6e-9856-a88074578aca",
+            "wikilinks": []
+          }
+        ],
+        "clean_text": "Property block",
+        "content": "Property block",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": null,
+        "line_end": 8,
+        "line_start": 5,
+        "outline_path": [
+          1
+        ],
+        "parent_id": null,
+        "path": [
+          "0e865189-dfa7-57c2-b314-c4f0bf5d5654"
+        ],
+        "properties": {
+          "id": "7f7f66e8-2f66-4bf4-9b8f-1a1cb7e3af71",
+          "owner": "Matryca team",
+          "status": "active"
+        },
+        "properties_order": [
+          "id",
+          "status",
+          "owner"
+        ],
+        "refs": [],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": "7f7f66e8-2f66-4bf4-9b8f-1a1cb7e3af71",
+        "synthetic_id": false,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "0e865189-dfa7-57c2-b314-c4f0bf5d5654",
+        "wikilinks": []
+      },
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [],
+        "clean_text": "Cross reference to [[Nested Entry]]",
+        "content": "Cross reference to [[Nested Entry]]",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": "0e865189-dfa7-57c2-b314-c4f0bf5d5654",
+        "line_end": 10,
+        "line_start": 10,
+        "outline_path": [
+          2
+        ],
+        "parent_id": null,
+        "path": [
+          "8f4cf6b3-3d53-5e3f-a2d7-a0ed8f66ba9a"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [
+          "Nested Entry"
+        ],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "8f4cf6b3-3d53-5e3f-a2d7-a0ed8f66ba9a",
+        "wikilinks": [
+          "Nested Entry"
+        ]
+      },
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [],
+        "clean_text": "Mention page tag #properties",
+        "content": "Mention page tag #properties",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": "8f4cf6b3-3d53-5e3f-a2d7-a0ed8f66ba9a",
+        "line_end": 11,
+        "line_start": 11,
+        "outline_path": [
+          3
+        ],
+        "parent_id": null,
+        "path": [
+          "691f2fc1-2015-5fff-8d4e-7884b1364c75"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [
+          "properties"
+        ],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [
+          "properties"
+        ],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "691f2fc1-2015-5fff-8d4e-7884b1364c75",
+        "wikilinks": []
+      },
+      {
+        "assets": [
+          "../assets/matrix.png"
+        ],
+        "block_refs": [],
+        "children": [],
+        "clean_text": "Insert an asset reference: ![matrix](../assets/matrix.png)",
+        "content": "Insert an asset reference: ![matrix](../assets/matrix.png)",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": "691f2fc1-2015-5fff-8d4e-7884b1364c75",
+        "line_end": 12,
+        "line_start": 12,
+        "outline_path": [
+          4
+        ],
+        "parent_id": null,
+        "path": [
+          "c548a358-0e34-5151-94e9-a6801c73cb8d"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "c548a358-0e34-5151-94e9-a6801c73cb8d",
+        "wikilinks": []
+      },
+      {
+        "assets": [],
+        "block_refs": [
+          "7f7f66e8-2f66-4bf4-9b8f-1a1cb7e3af71"
+        ],
+        "children": [],
+        "clean_text": "Link to the first block",
+        "content": "Link to the first block ((7f7f66e8-2f66-4bf4-9b8f-1a1cb7e3af71))",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": "c548a358-0e34-5151-94e9-a6801c73cb8d",
+        "line_end": 13,
+        "line_start": 13,
+        "outline_path": [
+          5
+        ],
+        "parent_id": null,
+        "path": [
+          "002949a8-e18d-57ac-a171-e7ae64d72bad"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "002949a8-e18d-57ac-a171-e7ae64d72bad",
+        "wikilinks": []
+      }
+    ],
+    "tab_size": 2,
+    "title": "Properties, references, and assets",
+    "updated_at": null
+  },
+  "profile": "exact_parse_v1",
+  "snapshot_schema_version": 1
+}

--- a/tests/fixtures/compat/v1/snapshots/m1a-softbreak-logbook.exact.json
+++ b/tests/fixtures/compat/v1/snapshots/m1a-softbreak-logbook.exact.json
@@ -1,0 +1,187 @@
+{
+  "page": {
+    "created_at": null,
+    "namespace_chain": [],
+    "properties": {
+      "tags": "fixture, compat",
+      "title": "Soft break and property log"
+    },
+    "properties_order": [
+      "title",
+      "tags"
+    ],
+    "refs": [
+      "Fixture",
+      "Compatibility",
+      "A",
+      "fixture",
+      "compat"
+    ],
+    "root_nodes": [
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [],
+        "clean_text": "A soft break starts here\nand remains in the same logical block.",
+        "content": "A soft break starts here\n  and remains in the same logical block.",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": null,
+        "line_end": 7,
+        "line_start": 6,
+        "outline_path": [
+          1
+        ],
+        "parent_id": null,
+        "path": [
+          "ed703cf5-be7a-54c9-9586-dfa99199c985"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "ed703cf5-be7a-54c9-9586-dfa99199c985",
+        "wikilinks": []
+      },
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [
+          {
+            "assets": [],
+            "block_refs": [],
+            "children": [],
+            "clean_text": "Child after the list property",
+            "content": "Child after the list property",
+            "created_at": null,
+            "deadline_at": null,
+            "indent_level": 1,
+            "left_id": null,
+            "line_end": 12,
+            "line_start": 12,
+            "outline_path": [
+              2,
+              1
+            ],
+            "parent_id": "349e13cc-8dc4-566e-8388-6dfa809c8ec9",
+            "path": [
+              "349e13cc-8dc4-566e-8388-6dfa809c8ec9",
+              "648f6bf8-14f8-53d5-a906-e9c5ed4fe57f"
+            ],
+            "properties": {},
+            "properties_order": [],
+            "refs": [],
+            "repeater": null,
+            "scheduled_at": null,
+            "source_uuid": null,
+            "synthetic_id": true,
+            "tags": [],
+            "task_priority": null,
+            "task_status": null,
+            "updated_at": null,
+            "uuid": "648f6bf8-14f8-53d5-a906-e9c5ed4fe57f",
+            "wikilinks": []
+          }
+        ],
+        "clean_text": "List property block",
+        "content": "List property block",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": "ed703cf5-be7a-54c9-9586-dfa99199c985",
+        "line_end": 12,
+        "line_start": 8,
+        "outline_path": [
+          2
+        ],
+        "parent_id": null,
+        "path": [
+          "349e13cc-8dc4-566e-8388-6dfa809c8ec9"
+        ],
+        "properties": {
+          "tags": [
+            "[[Fixture]]",
+            "[[Compatibility]]"
+          ]
+        },
+        "properties_order": [
+          "tags"
+        ],
+        "refs": [
+          "Fixture",
+          "Compatibility"
+        ],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [
+          "Fixture",
+          "Compatibility"
+        ],
+        "task_priority": null,
+        "task_status": null,
+        "updated_at": null,
+        "uuid": "349e13cc-8dc4-566e-8388-6dfa809c8ec9",
+        "wikilinks": [
+          "Fixture",
+          "Compatibility"
+        ]
+      },
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [],
+        "clean_text": "Logged task",
+        "content": "DONE [#A] Logged task",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": "349e13cc-8dc4-566e-8388-6dfa809c8ec9",
+        "line_end": 15,
+        "line_start": 13,
+        "outline_path": [
+          3
+        ],
+        "parent_id": null,
+        "path": [
+          "8e505f1a-4ea6-5e77-a233-874cf374a215"
+        ],
+        "properties": {
+          "logbook": [
+            "CLOCK: [2026-08-15 Sat 09:00]--[2026-08-15 Sat 09:15]"
+          ]
+        },
+        "properties_order": [],
+        "refs": [
+          "A"
+        ],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [
+          "A"
+        ],
+        "task_priority": "A",
+        "task_status": "DONE",
+        "updated_at": null,
+        "uuid": "8e505f1a-4ea6-5e77-a233-874cf374a215",
+        "wikilinks": []
+      }
+    ],
+    "tab_size": 2,
+    "title": "Soft break and property log",
+    "updated_at": null
+  },
+  "profile": "exact_parse_v1",
+  "snapshot_schema_version": 1
+}

--- a/tests/fixtures/compat/v1/snapshots/m1a-task-timing.exact.json
+++ b/tests/fixtures/compat/v1/snapshots/m1a-task-timing.exact.json
@@ -1,0 +1,156 @@
+{
+  "page": {
+    "created_at": null,
+    "namespace_chain": [],
+    "properties": {
+      "title": "Task and schedule corpus"
+    },
+    "properties_order": [
+      "title"
+    ],
+    "refs": [
+      "A",
+      "B",
+      "C"
+    ],
+    "root_nodes": [
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [],
+        "clean_text": "Draft regression list",
+        "content": "TODO [#A] Draft regression list SCHEDULED: <2026-08-20 Thu 09:00 ++1w> DEADLINE: <2026-08-22 Sat>",
+        "created_at": null,
+        "deadline_at": 1787356800,
+        "indent_level": 0,
+        "left_id": null,
+        "line_end": 4,
+        "line_start": 3,
+        "outline_path": [
+          1
+        ],
+        "parent_id": null,
+        "path": [
+          "a1ba83a1-8e81-5739-8353-e2ebe7070da9"
+        ],
+        "properties": {
+          "deadline": "<2026-08-22 Sat>",
+          "deadline_iso": "2026-08-22T00:00:00",
+          "deadline_journal_day": 20260822,
+          "id": "6f4f2ed1-bf8a-447a-b4aa-0a4b4ffbe5f4",
+          "repeater": "++1w",
+          "scheduled": "<2026-08-20 Thu 09:00 ++1w>",
+          "scheduled_iso": "2026-08-20T09:00:00",
+          "scheduled_journal_day": 20260820
+        },
+        "properties_order": [
+          "id"
+        ],
+        "refs": [
+          "A"
+        ],
+        "repeater": "++1w",
+        "scheduled_at": 1787216400,
+        "source_uuid": "6f4f2ed1-bf8a-447a-b4aa-0a4b4ffbe5f4",
+        "synthetic_id": false,
+        "tags": [
+          "A"
+        ],
+        "task_priority": "A",
+        "task_status": "TODO",
+        "updated_at": null,
+        "uuid": "a1ba83a1-8e81-5739-8353-e2ebe7070da9",
+        "wikilinks": []
+      },
+      {
+        "assets": [],
+        "block_refs": [],
+        "children": [
+          {
+            "assets": [],
+            "block_refs": [],
+            "children": [],
+            "clean_text": "Confirm semantic profile",
+            "content": "TODO [#C] Confirm semantic profile SCHEDULED: <2026-08-21 Fri> DEADLINE: <2026-08-24 Mon>",
+            "created_at": null,
+            "deadline_at": 1787529600,
+            "indent_level": 1,
+            "left_id": null,
+            "line_end": 6,
+            "line_start": 6,
+            "outline_path": [
+              2,
+              1
+            ],
+            "parent_id": "9208d1cf-31eb-5ff6-8031-a8164e905227",
+            "path": [
+              "9208d1cf-31eb-5ff6-8031-a8164e905227",
+              "cbc37dfb-da44-5bc7-a69d-8467814fe3bd"
+            ],
+            "properties": {
+              "deadline": "<2026-08-24 Mon>",
+              "deadline_iso": "2026-08-24T00:00:00",
+              "deadline_journal_day": 20260824,
+              "scheduled": "<2026-08-21 Fri>",
+              "scheduled_iso": "2026-08-21T00:00:00",
+              "scheduled_journal_day": 20260821
+            },
+            "properties_order": [],
+            "refs": [
+              "C"
+            ],
+            "repeater": null,
+            "scheduled_at": 1787270400,
+            "source_uuid": null,
+            "synthetic_id": true,
+            "tags": [
+              "C"
+            ],
+            "task_priority": "C",
+            "task_status": "TODO",
+            "updated_at": null,
+            "uuid": "cbc37dfb-da44-5bc7-a69d-8467814fe3bd",
+            "wikilinks": []
+          }
+        ],
+        "clean_text": "Validate fixture hashes",
+        "content": "DOING [#B] Validate fixture hashes",
+        "created_at": null,
+        "deadline_at": null,
+        "indent_level": 0,
+        "left_id": "a1ba83a1-8e81-5739-8353-e2ebe7070da9",
+        "line_end": 5,
+        "line_start": 5,
+        "outline_path": [
+          2
+        ],
+        "parent_id": null,
+        "path": [
+          "9208d1cf-31eb-5ff6-8031-a8164e905227"
+        ],
+        "properties": {},
+        "properties_order": [],
+        "refs": [
+          "B"
+        ],
+        "repeater": null,
+        "scheduled_at": null,
+        "source_uuid": null,
+        "synthetic_id": true,
+        "tags": [
+          "B"
+        ],
+        "task_priority": "B",
+        "task_status": "DOING",
+        "updated_at": null,
+        "uuid": "9208d1cf-31eb-5ff6-8031-a8164e905227",
+        "wikilinks": []
+      }
+    ],
+    "tab_size": 2,
+    "title": "Task and schedule corpus",
+    "updated_at": null
+  },
+  "profile": "exact_parse_v1",
+  "snapshot_schema_version": 1
+}

--- a/tests/fixtures/compat/v1/soft-breaks-properties-logbook.md
+++ b/tests/fixtures/compat/v1/soft-breaks-properties-logbook.md
@@ -1,0 +1,16 @@
+---
+title: Soft break and property log
+tags: fixture, compat
+---
+
+- A soft break starts here
+  and remains in the same logical block.
+- List property block
+  tags::
+    - [[Fixture]]
+    - [[Compatibility]]
+  - Child after the list property
+- DONE [#A] Logged task
+  :LOGBOOK:
+  CLOCK: [2026-08-15 Sat 09:00]--[2026-08-15 Sat 09:15]
+  :END:

--- a/tests/fixtures/compat/v1/tasks-priority-time.md
+++ b/tests/fixtures/compat/v1/tasks-priority-time.md
@@ -1,0 +1,6 @@
+title:: Task and schedule corpus
+
+- TODO [#A] Draft regression list SCHEDULED: <2026-08-20 Thu 09:00 ++1w> DEADLINE: <2026-08-22 Sat>
+  id:: 6f4f2ed1-bf8a-447a-b4aa-0a4b4ffbe5f4
+- DOING [#B] Validate fixture hashes
+  - TODO [#C] Confirm semantic profile SCHEDULED: <2026-08-21 Fri> DEADLINE: <2026-08-24 Mon>

--- a/tests/parser_assurance/__init__.py
+++ b/tests/parser_assurance/__init__.py
@@ -1,0 +1,1 @@
+"""Private test support for parser assurance contracts."""

--- a/tests/parser_assurance/corpus.py
+++ b/tests/parser_assurance/corpus.py
@@ -10,6 +10,11 @@ from typing import Any
 CORPUS_ROOT = Path(__file__).parents[1] / "fixtures" / "compat" / "v1"
 
 
+def _is_exact_int(value: object) -> bool:
+    """Reject Boolean values, which Python otherwise accepts as integers."""
+    return type(value) is int
+
+
 def _keys(
     value: dict[str, Any],
     *,
@@ -72,7 +77,12 @@ def _validate_entry(entry: object, *, root: Path) -> dict[str, Any]:
     fixture_id = entry["id"]
     if not isinstance(fixture_id, str) or not fixture_id:
         raise ValueError("fixture id must be a non-empty string")
-    if entry["fixture_schema_version"] != 1 or entry["snapshot_schema_version"] != 1:
+    if (
+        not _is_exact_int(entry["fixture_schema_version"])
+        or entry["fixture_schema_version"] != 1
+        or not _is_exact_int(entry["snapshot_schema_version"])
+        or entry["snapshot_schema_version"] != 1
+    ):
         raise ValueError(f"{fixture_id}: unsupported fixture or snapshot schema version")
 
     source = entry["source"]
@@ -92,7 +102,7 @@ def _validate_entry(entry: object, *, root: Path) -> dict[str, Any]:
     _keys(parse, required={"entrypoint", "tab_size"}, optional={"page_title"})
     if parse["entrypoint"] not in {"text", "file"}:
         raise ValueError(f"{fixture_id}: unsupported parse entrypoint")
-    if not isinstance(parse["tab_size"], int) or parse["tab_size"] < 1:
+    if not _is_exact_int(parse["tab_size"]) or parse["tab_size"] < 1:
         raise ValueError(f"{fixture_id}: tab_size must be a positive integer")
     if parse["entrypoint"] == "text" and not isinstance(parse.get("page_title"), str):
         raise ValueError(f"{fixture_id}: text entrypoint requires page_title")
@@ -131,6 +141,8 @@ def _validate_entry(entry: object, *, root: Path) -> dict[str, Any]:
     diagnostics = expectation["expected_diagnostics"]
     if not isinstance(diagnostics, list) or not all(isinstance(item, str) for item in diagnostics):
         raise ValueError(f"{fixture_id}: expected_diagnostics must be strings")
+    if diagnostics:
+        raise ValueError(f"{fixture_id}: M1-B valid fixtures require no expected diagnostics")
     identity = expectation["identity_policy"]
     if not isinstance(identity, dict):
         raise ValueError(f"{fixture_id}: identity_policy must be an object")
@@ -156,7 +168,12 @@ def validate_manifest(manifest: object, *, root: Path = CORPUS_ROOT) -> tuple[di
         manifest,
         required={"corpus_schema_version", "snapshot_schema_version", "license", "fixtures"},
     )
-    if manifest["corpus_schema_version"] != 1 or manifest["snapshot_schema_version"] != 1:
+    if (
+        not _is_exact_int(manifest["corpus_schema_version"])
+        or manifest["corpus_schema_version"] != 1
+        or not _is_exact_int(manifest["snapshot_schema_version"])
+        or manifest["snapshot_schema_version"] != 1
+    ):
         raise ValueError("unsupported corpus or snapshot schema version")
     if manifest["license"] != "Apache-2.0":
         raise ValueError("corpus license must be Apache-2.0")

--- a/tests/parser_assurance/corpus.py
+++ b/tests/parser_assurance/corpus.py
@@ -1,0 +1,189 @@
+"""Strict loader for the offline, versioned parser compatibility corpus."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+CORPUS_ROOT = Path(__file__).parents[1] / "fixtures" / "compat" / "v1"
+
+
+def _keys(
+    value: dict[str, Any],
+    *,
+    required: set[str],
+    optional: set[str] | None = None,
+) -> None:
+    optional_keys = optional or set()
+    missing = required - value.keys()
+    unknown = value.keys() - required - optional_keys
+    if missing or unknown:
+        raise ValueError(f"manifest keys missing={sorted(missing)} unknown={sorted(unknown)}")
+
+
+def _relative_file(root: Path, raw_path: object, *, must_exist: bool = True) -> Path:
+    if not isinstance(raw_path, str) or not raw_path:
+        raise ValueError("manifest path must be a non-empty string")
+    relative = Path(raw_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"manifest path escapes corpus root: {raw_path}")
+    candidate = (root / relative).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError as error:
+        raise ValueError(f"manifest path escapes corpus root: {raw_path}") from error
+    if must_exist and not candidate.is_file():
+        raise ValueError(f"manifest file does not exist: {raw_path}")
+    return candidate
+
+
+def _snapshot_file(root: Path, raw_path: object, *, must_exist: bool = True) -> Path:
+    if not isinstance(raw_path, str):
+        raise ValueError("snapshot path must be a string")
+    relative = Path(raw_path)
+    if len(relative.parts) < 2 or relative.parts[0] != "snapshots" or relative.suffix != ".json":
+        raise ValueError(f"snapshot path must be a JSON file under snapshots/: {raw_path}")
+    candidate = _relative_file(root, raw_path, must_exist=must_exist)
+    try:
+        candidate.relative_to((root / "snapshots").resolve())
+    except ValueError as error:
+        raise ValueError(f"snapshot path escapes snapshots directory: {raw_path}") from error
+    return candidate
+
+
+def _validate_entry(entry: object, *, root: Path) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise ValueError("each fixture entry must be an object")
+    _keys(
+        entry,
+        required={
+            "id",
+            "fixture_schema_version",
+            "snapshot_schema_version",
+            "source",
+            "parse",
+            "profiles",
+            "expectation",
+            "notes",
+        },
+    )
+    fixture_id = entry["id"]
+    if not isinstance(fixture_id, str) or not fixture_id:
+        raise ValueError("fixture id must be a non-empty string")
+    if entry["fixture_schema_version"] != 1 or entry["snapshot_schema_version"] != 1:
+        raise ValueError(f"{fixture_id}: unsupported fixture or snapshot schema version")
+
+    source = entry["source"]
+    if not isinstance(source, dict):
+        raise ValueError(f"{fixture_id}: source must be an object")
+    _keys(source, required={"path", "sha256", "provenance", "license"})
+    source_path = _relative_file(root, source["path"])
+    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    if source["sha256"] != digest:
+        raise ValueError(f"{fixture_id}: source SHA-256 mismatch")
+    if source["provenance"] != "project-authored" or source["license"] != "Apache-2.0":
+        raise ValueError(f"{fixture_id}: unsupported source provenance or license")
+
+    parse = entry["parse"]
+    if not isinstance(parse, dict):
+        raise ValueError(f"{fixture_id}: parse must be an object")
+    _keys(parse, required={"entrypoint", "tab_size"}, optional={"page_title"})
+    if parse["entrypoint"] not in {"text", "file"}:
+        raise ValueError(f"{fixture_id}: unsupported parse entrypoint")
+    if not isinstance(parse["tab_size"], int) or parse["tab_size"] < 1:
+        raise ValueError(f"{fixture_id}: tab_size must be a positive integer")
+    if parse["entrypoint"] == "text" and not isinstance(parse.get("page_title"), str):
+        raise ValueError(f"{fixture_id}: text entrypoint requires page_title")
+    if parse["entrypoint"] == "file" and "page_title" in parse:
+        raise ValueError(f"{fixture_id}: file entrypoint derives page_title")
+
+    profiles = entry["profiles"]
+    if not isinstance(profiles, dict):
+        raise ValueError(f"{fixture_id}: profiles must be an object")
+    _keys(profiles, required={"exact_parse", "semantic_roundtrip"})
+    _snapshot_file(root, profiles["exact_parse"], must_exist=False)
+    if profiles["semantic_roundtrip"] is not True:
+        raise ValueError(f"{fixture_id}: semantic round-trip profile must be enabled")
+
+    expectation = entry["expectation"]
+    if not isinstance(expectation, dict):
+        raise ValueError(f"{fixture_id}: expectation must be an object")
+    _keys(
+        expectation,
+        required={
+            "outcome",
+            "protected_behaviors",
+            "identity_policy",
+            "expected_diagnostics",
+        },
+    )
+    if expectation["outcome"] != "valid":
+        raise ValueError(f"{fixture_id}: M1-A accepts only valid fixtures")
+    behaviors = expectation["protected_behaviors"]
+    if (
+        not isinstance(behaviors, list)
+        or not behaviors
+        or not all(isinstance(item, str) and item for item in behaviors)
+    ):
+        raise ValueError(f"{fixture_id}: protected_behaviors must be non-empty strings")
+    diagnostics = expectation["expected_diagnostics"]
+    if not isinstance(diagnostics, list) or not all(isinstance(item, str) for item in diagnostics):
+        raise ValueError(f"{fixture_id}: expected_diagnostics must be strings")
+    identity = expectation["identity_policy"]
+    if not isinstance(identity, dict):
+        raise ValueError(f"{fixture_id}: identity_policy must be an object")
+    _keys(identity, required={"synthetic_uuid", "source_uuid", "relations"})
+    if identity["synthetic_uuid"] not in {"stable", "recomputed"}:
+        raise ValueError(f"{fixture_id}: invalid synthetic UUID policy")
+    if identity["source_uuid"] not in {"preserve", "absent"}:
+        raise ValueError(f"{fixture_id}: invalid source UUID policy")
+    if identity["relations"] not in {"direct_ids", "outline_paths"}:
+        raise ValueError(f"{fixture_id}: invalid relation policy")
+    if identity["synthetic_uuid"] == "recomputed" and identity["relations"] == "direct_ids":
+        raise ValueError(f"{fixture_id}: recomputed UUIDs require outline-path relations")
+    if not isinstance(entry["notes"], str):
+        raise ValueError(f"{fixture_id}: notes must be a string")
+    return entry
+
+
+def validate_manifest(manifest: object, *, root: Path = CORPUS_ROOT) -> tuple[dict[str, Any], ...]:
+    """Validate manifest structure and return entries in deterministic ID order."""
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest must be an object")
+    _keys(
+        manifest,
+        required={"corpus_schema_version", "snapshot_schema_version", "license", "fixtures"},
+    )
+    if manifest["corpus_schema_version"] != 1 or manifest["snapshot_schema_version"] != 1:
+        raise ValueError("unsupported corpus or snapshot schema version")
+    if manifest["license"] != "Apache-2.0":
+        raise ValueError("corpus license must be Apache-2.0")
+    fixtures = manifest["fixtures"]
+    if not isinstance(fixtures, list):
+        raise ValueError("fixtures must be a list")
+    entries = tuple(_validate_entry(entry, root=root) for entry in fixtures)
+    ids = [entry["id"] for entry in entries]
+    if len(ids) != len(set(ids)):
+        raise ValueError("fixture ids must be unique")
+    sources = [_relative_file(root, entry["source"]["path"]) for entry in entries]
+    snapshots = [
+        _snapshot_file(root, entry["profiles"]["exact_parse"], must_exist=False)
+        for entry in entries
+    ]
+    if len(snapshots) != len(set(snapshots)):
+        raise ValueError("exact snapshot destinations must be unique")
+    if set(sources).intersection(snapshots):
+        raise ValueError("source and snapshot paths must not collide")
+    return tuple(sorted(entries, key=lambda entry: entry["id"]))
+
+
+def load_corpus_entries(*, root: Path = CORPUS_ROOT) -> tuple[dict[str, Any], ...]:
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    return validate_manifest(manifest, root=root)
+
+
+def load_exact_snapshot(entry: dict[str, Any], *, root: Path = CORPUS_ROOT) -> object:
+    snapshot_path = _snapshot_file(root, entry["profiles"]["exact_parse"])
+    return json.loads(snapshot_path.read_text(encoding="utf-8"))

--- a/tests/parser_assurance/projection.py
+++ b/tests/parser_assurance/projection.py
@@ -1,0 +1,225 @@
+"""Versioned, test-only semantic projections for the compatibility corpus."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any, Literal, TypedDict, cast
+
+from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
+
+ProjectionProfile = Literal["exact_parse_v1", "semantic_roundtrip_v1"]
+
+
+class IdentityPolicy(TypedDict):
+    """Fixture-specific identity guarantees used by the round-trip profile."""
+
+    synthetic_uuid: Literal["stable", "recomputed"]
+    source_uuid: Literal["preserve", "absent"]
+    relations: Literal["direct_ids", "outline_paths"]
+
+
+_CREATED_AT_KEYS = frozenset({"created_at", "created-at", "createdat"})
+_UPDATED_AT_KEYS = frozenset({"updated_at", "updated-at", "updatedat"})
+_REF_PROPERTY_KEYS = frozenset({"tags", "page-tags", "alias", "aliases"})
+
+
+def _canonical_value(value: Any) -> Any:
+    """Return a JSON-safe value without preserving incidental mapping order."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _canonical_value(value[key]) for key in sorted(value, key=str)}
+    if isinstance(value, (list, tuple)):
+        return [_canonical_value(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        canonical = [_canonical_value(item) for item in value]
+        return sorted(canonical, key=lambda item: json.dumps(item, sort_keys=True))
+    raise TypeError(f"unsupported projection value: {type(value).__name__}")
+
+
+def _page_timestamp(page: LogseqPage, keys: frozenset[str], value: int | None) -> int | None:
+    """Keep a page timestamp only when it was declared in Markdown properties."""
+    return value if keys.intersection(page.properties) else None
+
+
+def _normalize_ref_token(value: object) -> object:
+    if not isinstance(value, str):
+        return _canonical_value(value)
+    token = value.strip()
+    if token.startswith("[[") and token.endswith("]]"):
+        token = token[2:-2]
+    return token.lstrip("#")
+
+
+def _semantic_properties(properties: Mapping[str, Any]) -> dict[str, Any]:
+    projected: dict[str, Any] = {}
+    for key in sorted(properties):
+        value = properties[key]
+        if key not in _REF_PROPERTY_KEYS:
+            projected[key] = _canonical_value(value)
+        elif isinstance(value, (set, frozenset)):
+            normalized = [_normalize_ref_token(item) for item in value]
+            projected[key] = sorted(
+                normalized,
+                key=lambda item: json.dumps(item, sort_keys=True),
+            )
+        elif isinstance(value, (list, tuple)):
+            projected[key] = [_normalize_ref_token(item) for item in value]
+        else:
+            projected[key] = _normalize_ref_token(value)
+    return projected
+
+
+def _declared_tag_tokens(properties: Mapping[str, Any]) -> set[str]:
+    """Return only tag tokens introduced by tag properties."""
+    tokens: set[str] = set()
+    semantic = _semantic_properties(properties)
+    for key in ("tags", "page-tags"):
+        value = semantic.get(key)
+        values = value if isinstance(value, list) else [value]
+        for item in values:
+            if not isinstance(item, str):
+                continue
+            tokens.update(part.strip() for part in item.split(",") if part.strip())
+    return tokens
+
+
+def _exact_node(node: LogseqNode) -> dict[str, Any]:
+    return {
+        "uuid": node.uuid,
+        "source_uuid": node.source_uuid,
+        "synthetic_id": node.synthetic_id,
+        "content": node.content,
+        "clean_text": node.clean_text,
+        "indent_level": node.indent_level,
+        "properties": _canonical_value(node.properties),
+        "properties_order": list(node.properties_order),
+        "wikilinks": list(node.wikilinks),
+        "tags": list(node.tags),
+        "assets": list(node.assets),
+        "block_refs": list(node.block_refs),
+        "refs": list(node.refs),
+        "task_status": node.task_status,
+        "task_priority": node.task_priority,
+        "scheduled_at": node.scheduled_at,
+        "deadline_at": node.deadline_at,
+        "repeater": node.repeater,
+        "parent_id": node.parent_id,
+        "left_id": node.left_id,
+        "path": list(node.path),
+        "line_start": node.line_start,
+        "line_end": node.line_end,
+        "outline_path": list(node.outline_path),
+        "created_at": node.created_at,
+        "updated_at": node.updated_at,
+        "children": [_exact_node(child) for child in node.children],
+    }
+
+
+def _index_outline_paths(page: LogseqPage) -> dict[str, list[int]]:
+    index: dict[str, list[int]] = {}
+
+    def visit(node: LogseqNode) -> None:
+        index[node.uuid] = list(node.outline_path)
+        for child in node.children:
+            visit(child)
+
+    for root in page.root_nodes:
+        visit(root)
+    return index
+
+
+def _semantic_node(
+    node: LogseqNode,
+    *,
+    identity_policy: IdentityPolicy,
+    outline_index: Mapping[str, list[int]],
+) -> dict[str, Any]:
+    property_tag_tokens = _declared_tag_tokens(node.properties)
+    projected: dict[str, Any] = {
+        "source_uuid": node.source_uuid,
+        "synthetic_id": node.synthetic_id,
+        "content": node.content,
+        "clean_text": node.clean_text,
+        "indent_level": node.indent_level,
+        "properties": _semantic_properties(node.properties),
+        "properties_order": list(node.properties_order),
+        "wikilinks": [token for token in node.wikilinks if token not in property_tag_tokens],
+        "tags": list(node.tags),
+        "assets": list(node.assets),
+        "block_refs": list(node.block_refs),
+        "refs": list(node.refs),
+        "task_status": node.task_status,
+        "task_priority": node.task_priority,
+        "scheduled_at": node.scheduled_at,
+        "deadline_at": node.deadline_at,
+        "repeater": node.repeater,
+        "outline_path": list(node.outline_path),
+        "created_at": node.created_at,
+        "updated_at": node.updated_at,
+    }
+    if identity_policy["synthetic_uuid"] == "stable":
+        projected["uuid"] = node.uuid
+    if identity_policy["relations"] == "direct_ids":
+        projected["parent_id"] = node.parent_id
+        projected["left_id"] = node.left_id
+        projected["path"] = list(node.path)
+    else:
+        projected["parent_outline_path"] = (
+            outline_index.get(node.parent_id) if node.parent_id is not None else None
+        )
+        projected["left_outline_path"] = (
+            outline_index.get(node.left_id) if node.left_id is not None else None
+        )
+    projected["children"] = [
+        _semantic_node(
+            child,
+            identity_policy=identity_policy,
+            outline_index=outline_index,
+        )
+        for child in node.children
+    ]
+    return projected
+
+
+def project_page(
+    page: LogseqPage,
+    *,
+    profile: ProjectionProfile,
+    identity_policy: IdentityPolicy | None = None,
+) -> dict[str, Any]:
+    """Project a parsed page under one explicit, versioned assurance profile."""
+    base: dict[str, Any] = {
+        "profile": profile,
+        "snapshot_schema_version": 1,
+        "page": {
+            "title": page.title,
+            "properties": _canonical_value(page.properties),
+            "properties_order": list(page.properties_order),
+            "refs": list(page.refs),
+            "created_at": _page_timestamp(page, _CREATED_AT_KEYS, page.created_at),
+            "updated_at": _page_timestamp(page, _UPDATED_AT_KEYS, page.updated_at),
+            "namespace_chain": list(page.namespace_chain),
+            "tab_size": page.tab_size,
+        },
+    }
+    projected_page = cast(dict[str, Any], base["page"])
+    if profile == "exact_parse_v1":
+        projected_page["root_nodes"] = [_exact_node(node) for node in page.root_nodes]
+        return base
+    if profile != "semantic_roundtrip_v1":
+        raise ValueError(f"unsupported projection profile: {profile}")
+    if identity_policy is None:
+        raise ValueError("semantic_roundtrip_v1 requires an identity policy")
+    projected_page["properties"] = _semantic_properties(page.properties)
+    outline_index = _index_outline_paths(page)
+    projected_page["root_nodes"] = [
+        _semantic_node(
+            node,
+            identity_policy=identity_policy,
+            outline_index=outline_index,
+        )
+        for node in page.root_nodes
+    ]
+    return base

--- a/tests/parser_assurance/projection.py
+++ b/tests/parser_assurance/projection.py
@@ -47,10 +47,10 @@ def _page_timestamp(page: LogseqPage, keys: frozenset[str], value: int | None) -
 def _normalize_ref_token(value: object) -> object:
     if not isinstance(value, str):
         return _canonical_value(value)
-    token = value.strip()
+    token = value.strip().lstrip("#")
     if token.startswith("[[") and token.endswith("]]"):
         token = token[2:-2]
-    return token.lstrip("#")
+    return token.strip()
 
 
 def _split_reference_segments(value: str) -> list[str]:
@@ -99,11 +99,59 @@ def _reference_property_sequence(value: object) -> list[object]:
     return [_normalize_ref_token(fragment) for fragment in _reference_property_fragments(value)]
 
 
+def _literal_span_end(value: str, index: int) -> int | None:
+    """Return the end of a parser-shielded literal starting at ``index``."""
+    if index == 0 or value[index - 1] == "\n":
+        line_end = value.find("\n", index)
+        line_end = len(value) if line_end < 0 else line_end
+        stripped_line = value[index:line_end].strip()
+        if stripped_line.upper().startswith("#+BEGIN_QUERY"):
+            return len(value)
+        if stripped_line:
+            fence_char = stripped_line[0]
+            fence_length = len(stripped_line) - len(stripped_line.lstrip(fence_char))
+            if fence_char in {"`", "~"} and fence_length >= 3:
+                return len(value)
+
+    if value.startswith("<!--", index):
+        close = value.find("-->", index + 4)
+        return len(value) if close < 0 else close + 3
+
+    if value.startswith("{{", index):
+        close = value.find("}}", index + 2)
+        if close >= 0:
+            macro = value[index + 2 : close].lstrip().lower()
+            if macro.startswith("query ") or macro.startswith("advancedquery "):
+                return close + 2
+
+    if value.startswith("$$", index):
+        close = value.find("$$", index + 2)
+        return len(value) if close < 0 else close + 2
+
+    if value[index] == "$":
+        close = value.find("$", index + 1)
+        return len(value) if close < 0 else close + 1
+
+    if value[index] == "`":
+        delimiter_end = index
+        while delimiter_end < len(value) and value[delimiter_end] == "`":
+            delimiter_end += 1
+        delimiter = value[index:delimiter_end]
+        close = value.find(delimiter, delimiter_end)
+        return len(value) if close < 0 else close + len(delimiter)
+
+    return None
+
+
 def _explicit_wikilinks(value: str) -> list[str]:
-    """Independently collect unescaped ``[[target]]`` references from one fragment."""
+    """Independently collect visible ``[[target]]`` references from one fragment."""
     tokens: list[str] = []
     index = 0
     while index < len(value):
+        literal_end = _literal_span_end(value, index)
+        if literal_end is not None:
+            index = literal_end
+            continue
         if value.startswith("[[", index) and (index == 0 or value[index - 1] != "\\"):
             end = value.find("]]", index + 2)
             if end >= 0:

--- a/tests/parser_assurance/projection.py
+++ b/tests/parser_assurance/projection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 from collections.abc import Mapping
 from typing import Any, Literal, TypedDict, cast
 
@@ -52,37 +53,110 @@ def _normalize_ref_token(value: object) -> object:
     return token.lstrip("#")
 
 
+def _split_reference_segments(value: str) -> list[str]:
+    """Split comma-separated property references without splitting ``[[...]]``."""
+    segments: list[str] = []
+    start = 0
+    reference_depth = 0
+    index = 0
+    while index < len(value):
+        if value.startswith("[[", index):
+            reference_depth += 1
+            index += 2
+            continue
+        if reference_depth and value.startswith("]]", index):
+            reference_depth -= 1
+            index += 2
+            continue
+        if value[index] == "," and not reference_depth:
+            segments.append(value[start:index])
+            start = index + 1
+        index += 1
+    segments.append(value[start:])
+    return [segment for segment in segments if segment.strip()]
+
+
+def _reference_property_fragments(value: object) -> list[object]:
+    """Return deterministic raw segments from a reference-shaped value."""
+    if isinstance(value, (set, frozenset)):
+        values: list[object] = sorted(
+            value,
+            key=lambda item: json.dumps(_canonical_value(item), sort_keys=True),
+        )
+    elif isinstance(value, (list, tuple)):
+        values = list(value)
+    else:
+        values = [value]
+
+    fragments: list[object] = []
+    for item in values:
+        fragments.extend(_split_reference_segments(item) if isinstance(item, str) else [item])
+    return fragments
+
+
+def _reference_property_sequence(value: object) -> list[object]:
+    """Return a deterministic canonical sequence for a reference-shaped value."""
+    return [_normalize_ref_token(fragment) for fragment in _reference_property_fragments(value)]
+
+
+def _explicit_wikilinks(value: str) -> list[str]:
+    """Independently collect unescaped ``[[target]]`` references from one fragment."""
+    tokens: list[str] = []
+    index = 0
+    while index < len(value):
+        if value.startswith("[[", index) and (index == 0 or value[index - 1] != "\\"):
+            end = value.find("]]", index + 2)
+            if end >= 0:
+                target = value[index + 2 : end].split("#", 1)[0]
+                if target:
+                    tokens.append(target)
+                index = end + 2
+                continue
+        index += 1
+    return tokens
+
+
+def _property_wikilink_occurrences(properties: Mapping[str, Any]) -> Counter[str]:
+    """Count graph wikilinks attributable to properties without parser helper reuse."""
+    occurrences: Counter[str] = Counter()
+    for key, value in properties.items():
+        if key in _REF_PROPERTY_KEYS:
+            for fragment in _reference_property_fragments(value):
+                if not isinstance(fragment, str):
+                    continue
+                token = _normalize_ref_token(fragment)
+                if key in {"alias", "aliases"} and isinstance(token, str) and token:
+                    occurrences[token] += 1
+                occurrences.update(_explicit_wikilinks(fragment))
+            continue
+        fragments = [value] if isinstance(value, str) else value if isinstance(value, list) else []
+        for fragment in fragments:
+            if isinstance(fragment, str):
+                occurrences.update(_explicit_wikilinks(fragment))
+    return occurrences
+
+
 def _semantic_properties(properties: Mapping[str, Any]) -> dict[str, Any]:
     projected: dict[str, Any] = {}
     for key in sorted(properties):
         value = properties[key]
         if key not in _REF_PROPERTY_KEYS:
             projected[key] = _canonical_value(value)
-        elif isinstance(value, (set, frozenset)):
-            normalized = [_normalize_ref_token(item) for item in value]
-            projected[key] = sorted(
-                normalized,
-                key=lambda item: json.dumps(item, sort_keys=True),
-            )
-        elif isinstance(value, (list, tuple)):
-            projected[key] = [_normalize_ref_token(item) for item in value]
         else:
-            projected[key] = _normalize_ref_token(value)
+            projected[key] = _reference_property_sequence(value)
     return projected
 
 
-def _declared_tag_tokens(properties: Mapping[str, Any]) -> set[str]:
-    """Return only tag tokens introduced by tag properties."""
-    tokens: set[str] = set()
-    semantic = _semantic_properties(properties)
-    for key in ("tags", "page-tags"):
-        value = semantic.get(key)
-        values = value if isinstance(value, list) else [value]
-        for item in values:
-            if not isinstance(item, str):
-                continue
-            tokens.update(part.strip() for part in item.split(",") if part.strip())
-    return tokens
+def _content_wikilinks(node: LogseqNode) -> list[str]:
+    """Remove only counted property-origin links, preserving equal content links."""
+    property_occurrences = _property_wikilink_occurrences(node.properties)
+    content_reversed: list[str] = []
+    for token in reversed(node.wikilinks):
+        if property_occurrences[token]:
+            property_occurrences[token] -= 1
+        else:
+            content_reversed.append(token)
+    return list(reversed(content_reversed))
 
 
 def _exact_node(node: LogseqNode) -> dict[str, Any]:
@@ -136,7 +210,6 @@ def _semantic_node(
     identity_policy: IdentityPolicy,
     outline_index: Mapping[str, list[int]],
 ) -> dict[str, Any]:
-    property_tag_tokens = _declared_tag_tokens(node.properties)
     projected: dict[str, Any] = {
         "source_uuid": node.source_uuid,
         "synthetic_id": node.synthetic_id,
@@ -145,7 +218,7 @@ def _semantic_node(
         "indent_level": node.indent_level,
         "properties": _semantic_properties(node.properties),
         "properties_order": list(node.properties_order),
-        "wikilinks": [token for token in node.wikilinks if token not in property_tag_tokens],
+        "wikilinks": _content_wikilinks(node),
         "tags": list(node.tags),
         "assets": list(node.assets),
         "block_refs": list(node.block_refs),

--- a/tests/parser_assurance/projection.py
+++ b/tests/parser_assurance/projection.py
@@ -99,29 +99,89 @@ def _reference_property_sequence(value: object) -> list[object]:
     return [_normalize_ref_token(fragment) for fragment in _reference_property_fragments(value)]
 
 
+def _line_region_end(value: str, marker: str, index: int) -> int:
+    """Return the end of the line containing ``marker`` or the input end."""
+    marker_index = value.find(marker, index)
+    if marker_index < 0:
+        return len(value)
+    line_end = value.find("\n", marker_index)
+    return len(value) if line_end < 0 else line_end + 1
+
+
+def _fence_region_end(value: str, index: int, fence_char: str, fence_length: int) -> int:
+    """Return the end of a line-oriented fenced region."""
+    opening_line_end = value.find("\n", index)
+    if opening_line_end < 0:
+        return len(value)
+    line_start = opening_line_end + 1
+    while line_start < len(value):
+        line_end = value.find("\n", line_start)
+        line_end = len(value) if line_end < 0 else line_end
+        stripped = value[line_start:line_end].strip()
+        run_length = len(stripped) - len(stripped.lstrip(fence_char))
+        if run_length >= fence_length and not stripped[run_length:].strip():
+            return len(value) if line_end == len(value) else line_end + 1
+        line_start = line_end + 1
+    return len(value)
+
+
+def _exact_backtick_close(value: str, body_start: int, delimiter_length: int) -> int:
+    """Find the parser-equivalent exact backtick run, including overlapping suffixes."""
+    cursor = body_start
+    while cursor < len(value):
+        if value[cursor] == "`":
+            run_end = cursor
+            while run_end < len(value) and value[run_end] == "`":
+                run_end += 1
+            if run_end - cursor == delimiter_length:
+                return run_end
+        cursor += 1
+    return len(value)
+
+
+def _inline_math_close(value: str, body_start: int) -> int:
+    """Find a single-dollar close while skipping double-dollar runs."""
+    cursor = body_start
+    while cursor < len(value):
+        if value[cursor] == "$":
+            if cursor + 1 < len(value) and value[cursor + 1] == "$":
+                cursor += 2
+                continue
+            return cursor + 1
+        cursor += 1
+    return len(value)
+
+
 def _literal_span_end(value: str, index: int) -> int | None:
     """Return the end of a parser-shielded literal starting at ``index``."""
     if index == 0 or value[index - 1] == "\n":
         line_end = value.find("\n", index)
         line_end = len(value) if line_end < 0 else line_end
         stripped_line = value[index:line_end].strip()
-        if stripped_line.upper().startswith("#+BEGIN_QUERY"):
-            return len(value)
+        if stripped_line == "#+BEGIN_QUERY" or stripped_line.startswith("#+BEGIN_QUERY "):
+            return _line_region_end(value, "#+END_QUERY", index)
         if stripped_line:
             fence_char = stripped_line[0]
             fence_length = len(stripped_line) - len(stripped_line.lstrip(fence_char))
             if fence_char in {"`", "~"} and fence_length >= 3:
-                return len(value)
+                return _fence_region_end(value, index, fence_char, fence_length)
 
     if value.startswith("<!--", index):
         close = value.find("-->", index + 4)
-        return len(value) if close < 0 else close + 3
+        return None if close < 0 else close + 3
 
     if value.startswith("{{", index):
-        close = value.find("}}", index + 2)
+        line_end = value.find("\n", index)
+        line_end = len(value) if line_end < 0 else line_end
+        close = value.find("}}", index + 2, line_end)
         if close >= 0:
             macro = value[index + 2 : close].lstrip().lower()
-            if macro.startswith("query ") or macro.startswith("advancedquery "):
+            if any(
+                macro.startswith(keyword)
+                and len(macro) > len(keyword)
+                and macro[len(keyword)].isspace()
+                for keyword in ("query", "advancedquery")
+            ):
                 return close + 2
 
     if value.startswith("$$", index):
@@ -129,16 +189,13 @@ def _literal_span_end(value: str, index: int) -> int | None:
         return len(value) if close < 0 else close + 2
 
     if value[index] == "$":
-        close = value.find("$", index + 1)
-        return len(value) if close < 0 else close + 1
+        return _inline_math_close(value, index + 1)
 
     if value[index] == "`":
         delimiter_end = index
         while delimiter_end < len(value) and value[delimiter_end] == "`":
             delimiter_end += 1
-        delimiter = value[index:delimiter_end]
-        close = value.find(delimiter, delimiter_end)
-        return len(value) if close < 0 else close + len(delimiter)
+        return _exact_backtick_close(value, delimiter_end, delimiter_end - index)
 
     return None
 

--- a/tests/test_compat_corpus.py
+++ b/tests/test_compat_corpus.py
@@ -268,6 +268,57 @@ def test_semantic_projection_preserves_content_wikilink_matching_property_tag() 
     assert projected["page"]["root_nodes"][0]["wikilinks"] == ["Foo"]
 
 
+@pytest.mark.parametrize(
+    ("property_line",),
+    [
+        ("note:: `[[Foo]]`",),
+        ("note:: ~~~[[Foo]]~~~",),
+        ("note:: <!-- [[Foo]] -->",),
+        ("note:: $\\text{[[Foo]]}$",),
+        ("note:: {{query [[Foo]]}}",),
+        ("note:: #+BEGIN_QUERY [[Foo]]",),
+    ],
+)
+def test_semantic_projection_preserves_shielded_property_references(property_line: str) -> None:
+    page = StackMachineParser().parse(
+        f"- [[Foo]]\n  {property_line}\n",
+        page_title="Shielded property references",
+    )
+    node = page.root_nodes[0]
+
+    projected = project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy={
+            "synthetic_uuid": "stable",
+            "source_uuid": "absent",
+            "relations": "direct_ids",
+        },
+    )
+
+    assert node.wikilinks == ["Foo"]
+    assert projected["page"]["root_nodes"][0]["wikilinks"] == ["Foo"]
+
+
+def test_semantic_projection_canonicalizes_hash_tags_to_target() -> None:
+    page = StackMachineParser().parse(
+        "tags:: #[[Foo]]\n",
+        page_title="Hashed tag property",
+    )
+
+    projected = project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy={
+            "synthetic_uuid": "stable",
+            "source_uuid": "absent",
+            "relations": "direct_ids",
+        },
+    )
+
+    assert projected["page"]["properties"]["tags"] == ["Foo"]
+
+
 def test_semantic_projection_count_subtracts_duplicate_property_wikilinks() -> None:
     page = StackMachineParser().parse(
         "- [[Foo]] [[Foo]]\n  tags:: [[Foo]]\n",

--- a/tests/test_compat_corpus.py
+++ b/tests/test_compat_corpus.py
@@ -23,6 +23,8 @@ from tests.parser_assurance.corpus import (
 )
 from tests.parser_assurance.projection import IdentityPolicy, project_page
 
+ROOT = Path(__file__).resolve().parents[1]
+
 
 def _parse_entry(entry: dict[str, Any]) -> tuple[str, LogseqPage]:
     source_path = CORPUS_ROOT / entry["source"]["path"]
@@ -85,6 +87,44 @@ def test_manifest_rejects_unknown_schema_versions() -> None:
     manifest["fixtures"][0]["fixture_schema_version"] = 2
     with pytest.raises(ValueError, match="unsupported fixture or snapshot schema version"):
         validate_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    ("path", "error"),
+    [
+        (("corpus_schema_version",), "unsupported corpus or snapshot schema version"),
+        (("snapshot_schema_version",), "unsupported corpus or snapshot schema version"),
+        (("fixtures", 0, "fixture_schema_version"), "unsupported fixture or snapshot schema version"),
+        (("fixtures", 0, "snapshot_schema_version"), "unsupported fixture or snapshot schema version"),
+        (("fixtures", 0, "parse", "tab_size"), "tab_size must be a positive integer"),
+    ],
+)
+def test_manifest_rejects_boolean_integer_fields(
+    path: tuple[str | int, ...],
+    error: str,
+) -> None:
+    manifest = _manifest_copy()
+    target: Any = manifest
+    for segment in path[:-1]:
+        target = target[segment]
+    target[path[-1]] = True
+
+    with pytest.raises(ValueError, match=error):
+        validate_manifest(manifest)
+
+
+def test_manifest_rejects_unverified_valid_fixture_diagnostics() -> None:
+    manifest = _manifest_copy()
+    manifest["fixtures"][0]["expectation"]["expected_diagnostics"] = ["unexpected"]
+
+    with pytest.raises(ValueError, match="require no expected diagnostics"):
+        validate_manifest(manifest)
+
+
+def test_compatibility_fixture_bytes_are_forced_to_lf() -> None:
+    attributes = (ROOT / ".gitattributes").read_text(encoding="utf-8")
+
+    assert "tests/fixtures/compat/** text eol=lf" in attributes
 
 
 def test_manifest_rejects_source_hash_drift() -> None:
@@ -169,6 +209,103 @@ def test_snapshot_cli_fails_closed_and_writes_only_when_requested(
     assert "updated 1 compatibility snapshot(s)" in capsys.readouterr().out
 
     assert update_compat_snapshots.main([]) == 0
+
+
+@pytest.mark.parametrize("property_key", ("tags", "page-tags", "alias", "aliases"))
+def test_semantic_projection_canonicalizes_reference_property_sequences(property_key: str) -> None:
+    page = StackMachineParser().parse(
+        f"{property_key}:: [[Project Authored]], [[Fixture]]\n",
+        page_title="Reference properties",
+    )
+
+    projected = project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy={
+            "synthetic_uuid": "stable",
+            "source_uuid": "absent",
+            "relations": "direct_ids",
+        },
+    )
+
+    assert projected["page"]["properties"][property_key] == ["Project Authored", "Fixture"]
+
+
+def test_semantic_projection_preserves_commas_inside_wikilink_references() -> None:
+    page = StackMachineParser().parse(
+        "tags:: [[New York, NY]], Tech\n",
+        page_title="Reference commas",
+    )
+
+    projected = project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy={
+            "synthetic_uuid": "stable",
+            "source_uuid": "absent",
+            "relations": "direct_ids",
+        },
+    )
+
+    assert projected["page"]["properties"]["tags"] == ["New York, NY", "Tech"]
+
+
+def test_semantic_projection_preserves_content_wikilink_matching_property_tag() -> None:
+    page = StackMachineParser().parse("- [[Foo]]\n  tags:: Foo\n", page_title="Content link")
+    node = page.root_nodes[0]
+
+    projected = project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy={
+            "synthetic_uuid": "stable",
+            "source_uuid": "absent",
+            "relations": "direct_ids",
+        },
+    )
+
+    assert node.wikilinks == ["Foo"]
+    assert projected["page"]["root_nodes"][0]["wikilinks"] == ["Foo"]
+
+
+def test_semantic_projection_count_subtracts_duplicate_property_wikilinks() -> None:
+    page = StackMachineParser().parse(
+        "- [[Foo]] [[Foo]]\n  tags:: [[Foo]]\n",
+        page_title="Duplicate links",
+    )
+    node = page.root_nodes[0]
+
+    projected = project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy={
+            "synthetic_uuid": "stable",
+            "source_uuid": "absent",
+            "relations": "direct_ids",
+        },
+    )
+
+    assert node.wikilinks == ["Foo", "Foo", "Foo"]
+    assert projected["page"]["root_nodes"][0]["wikilinks"] == ["Foo", "Foo"]
+
+
+def test_semantic_projection_preserves_content_wikilink_order() -> None:
+    page = StackMachineParser().parse(
+        "- [[First]] [[Second]]\n  tags:: [[First]]\n",
+        page_title="Ordered links",
+    )
+
+    projected = project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy={
+            "synthetic_uuid": "stable",
+            "source_uuid": "absent",
+            "relations": "direct_ids",
+        },
+    )
+
+    assert projected["page"]["root_nodes"][0]["wikilinks"] == ["First", "Second"]
 
 
 @pytest.mark.parametrize("entry", load_corpus_entries(), ids=lambda entry: entry["id"])

--- a/tests/test_compat_corpus.py
+++ b/tests/test_compat_corpus.py
@@ -1,0 +1,234 @@
+"""Contract tests for the offline, versioned Logseq compatibility corpus."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
+from logseq_matryca_parser.logos_parser import StackMachineParser
+from logseq_matryca_parser.logseq_markdown import serialize_logseq_page
+from scripts import update_compat_snapshots
+from tests.parser_assurance.corpus import (
+    CORPUS_ROOT,
+    load_corpus_entries,
+    load_exact_snapshot,
+    validate_manifest,
+)
+from tests.parser_assurance.projection import IdentityPolicy, project_page
+
+
+def _parse_entry(entry: dict[str, Any]) -> tuple[str, LogseqPage]:
+    source_path = CORPUS_ROOT / entry["source"]["path"]
+    source = source_path.read_text(encoding="utf-8")
+    parse = entry["parse"]
+    parser = StackMachineParser(tab_size=parse["tab_size"])
+    if parse["entrypoint"] == "file":
+        return source, parser.parse_page_file(source_path)
+    return source, parser.parse(source, page_title=parse["page_title"])
+
+
+def _walk(nodes: list[LogseqNode]) -> Iterator[LogseqNode]:
+    for node in nodes:
+        yield node
+        yield from _walk(node.children)
+
+
+def _assert_tree_invariants(page: LogseqPage) -> None:
+    nodes = list(_walk(page.root_nodes))
+    assert len({node.uuid for node in nodes}) == len(nodes)
+
+    def visit(siblings: list[LogseqNode], parent: LogseqNode | None) -> None:
+        for index, node in enumerate(siblings):
+            assert node.parent_id == (parent.uuid if parent is not None else None)
+            assert node.left_id == (siblings[index - 1].uuid if index else None)
+            expected_path = [node.uuid] if parent is None else [*parent.path, node.uuid]
+            assert node.path == expected_path
+            expected_outline = [index + 1] if parent is None else [*parent.outline_path, index + 1]
+            assert node.outline_path == expected_outline
+            visit(node.children, node)
+
+    visit(page.root_nodes, None)
+
+
+def _identity_policy(entry: dict[str, Any]) -> IdentityPolicy:
+    return cast(IdentityPolicy, entry["expectation"]["identity_policy"])
+
+
+def test_manifest_is_strict_provenance_safe_and_deterministic() -> None:
+    entries = load_corpus_entries()
+    assert entries
+    assert [entry["id"] for entry in entries] == sorted(entry["id"] for entry in entries)
+    assert all(entry["fixture_schema_version"] == 1 for entry in entries)
+    assert all(entry["snapshot_schema_version"] == 1 for entry in entries)
+
+    manifest = json.loads((CORPUS_ROOT / "manifest.json").read_text(encoding="utf-8"))
+    reversed_manifest = copy.deepcopy(manifest)
+    reversed_manifest["fixtures"].reverse()
+    assert [entry["id"] for entry in validate_manifest(reversed_manifest)] == [
+        entry["id"] for entry in entries
+    ]
+
+
+def _manifest_copy() -> dict[str, Any]:
+    return json.loads((CORPUS_ROOT / "manifest.json").read_text(encoding="utf-8"))
+
+
+def test_manifest_rejects_unknown_schema_versions() -> None:
+    manifest = _manifest_copy()
+    manifest["fixtures"][0]["fixture_schema_version"] = 2
+    with pytest.raises(ValueError, match="unsupported fixture or snapshot schema version"):
+        validate_manifest(manifest)
+
+
+def test_manifest_rejects_source_hash_drift() -> None:
+    manifest = _manifest_copy()
+    manifest["fixtures"][0]["source"]["sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="source SHA-256 mismatch"):
+        validate_manifest(manifest)
+
+
+def test_manifest_rejects_escaping_paths_and_unknown_keys() -> None:
+    escaping = _manifest_copy()
+    escaping["fixtures"][0]["source"]["path"] = "../outside.md"
+    with pytest.raises(ValueError, match="escapes corpus root"):
+        validate_manifest(escaping)
+
+    unknown = _manifest_copy()
+    unknown["fixtures"][0]["unexpected"] = True
+    with pytest.raises(ValueError, match=r"unknown=\['unexpected'\]"):
+        validate_manifest(unknown)
+
+
+def test_manifest_confines_and_deduplicates_snapshot_destinations() -> None:
+    outside_snapshots = _manifest_copy()
+    outside_snapshots["fixtures"][0]["profiles"]["exact_parse"] = "manifest.json"
+    with pytest.raises(ValueError, match="under snapshots"):
+        validate_manifest(outside_snapshots)
+
+    duplicate_snapshots = _manifest_copy()
+    duplicate_snapshots["fixtures"][1]["profiles"]["exact_parse"] = duplicate_snapshots[
+        "fixtures"
+    ][0]["profiles"]["exact_parse"]
+    with pytest.raises(ValueError, match="destinations must be unique"):
+        validate_manifest(duplicate_snapshots)
+
+
+def test_manifest_rejects_snapshot_symlink_escape(tmp_path: Path) -> None:
+    root = tmp_path / "corpus"
+    root.mkdir()
+    source = CORPUS_ROOT / "hierarchy-identity.md"
+    (root / source.name).write_bytes(source.read_bytes())
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / "snapshots").symlink_to(outside, target_is_directory=True)
+    manifest = _manifest_copy()
+    manifest["fixtures"] = [manifest["fixtures"][0]]
+
+    with pytest.raises(ValueError, match="escapes corpus root"):
+        validate_manifest(manifest, root=root)
+
+
+def test_manifest_rejects_source_snapshot_collision() -> None:
+    manifest = _manifest_copy()
+    manifest["fixtures"] = [manifest["fixtures"][0]]
+    entry = manifest["fixtures"][0]
+    snapshot_path = CORPUS_ROOT / entry["profiles"]["exact_parse"]
+    entry["source"]["path"] = entry["profiles"]["exact_parse"]
+    entry["source"]["sha256"] = hashlib.sha256(snapshot_path.read_bytes()).hexdigest()
+
+    with pytest.raises(ValueError, match="source and snapshot paths must not collide"):
+        validate_manifest(manifest)
+
+
+def test_snapshot_cli_fails_closed_and_writes_only_when_requested(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    snapshot = tmp_path / "snapshots" / "fixture.exact.json"
+    entry = {"profiles": {"exact_parse": "snapshots/fixture.exact.json"}}
+    expected = '{"snapshot_schema_version": 1}\n'
+    monkeypatch.setattr(update_compat_snapshots, "CORPUS_ROOT", tmp_path)
+    monkeypatch.setattr(update_compat_snapshots, "load_corpus_entries", lambda: (entry,))
+    monkeypatch.setattr(update_compat_snapshots, "_render_snapshot", lambda _entry: expected)
+
+    assert update_compat_snapshots.main([]) == 1
+    assert not snapshot.exists()
+    assert "stale compatibility snapshot" in capsys.readouterr().out
+
+    assert update_compat_snapshots.main(["--write"]) == 0
+    assert snapshot.read_text(encoding="utf-8") == expected
+    assert not list(snapshot.parent.glob(".*.tmp"))
+    assert "updated 1 compatibility snapshot(s)" in capsys.readouterr().out
+
+    assert update_compat_snapshots.main([]) == 0
+
+
+@pytest.mark.parametrize("entry", load_corpus_entries(), ids=lambda entry: entry["id"])
+def test_exact_parse_snapshot_and_same_input_determinism(entry: dict[str, Any]) -> None:
+    source, page = _parse_entry(entry)
+    _, repeated = _parse_entry(entry)
+
+    assert page.raw_content == source
+    _assert_tree_invariants(page)
+    projected = project_page(page, profile="exact_parse_v1")
+    assert projected == load_exact_snapshot(entry)
+    assert project_page(repeated, profile="exact_parse_v1") == projected
+
+
+@pytest.mark.parametrize("entry", load_corpus_entries(), ids=lambda entry: entry["id"])
+def test_semantic_roundtrip_profile(entry: dict[str, Any]) -> None:
+    _, page = _parse_entry(entry)
+    policy = _identity_policy(entry)
+    rendered = serialize_logseq_page(page)
+    reparsed = StackMachineParser(tab_size=page.tab_size).parse(rendered, page_title=page.title)
+    repeated_reparse = StackMachineParser(tab_size=page.tab_size).parse(
+        rendered,
+        page_title=page.title,
+    )
+
+    _assert_tree_invariants(reparsed)
+    _assert_tree_invariants(repeated_reparse)
+    assert project_page(repeated_reparse, profile="exact_parse_v1") == project_page(
+        reparsed,
+        profile="exact_parse_v1",
+    )
+    assert project_page(
+        reparsed,
+        profile="semantic_roundtrip_v1",
+        identity_policy=policy,
+    ) == project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy=policy,
+    )
+    original_source_uuids = [node.source_uuid for node in _walk(page.root_nodes)]
+    reparsed_source_uuids = [node.source_uuid for node in _walk(reparsed.root_nodes)]
+    if policy["source_uuid"] == "preserve":
+        assert any(value is not None for value in original_source_uuids)
+        assert reparsed_source_uuids == original_source_uuids
+    else:
+        assert all(value is None for value in original_source_uuids)
+        assert all(value is None for value in reparsed_source_uuids)
+
+
+def test_file_entrypoint_context_uses_relative_assertions() -> None:
+    entry = next(
+        fixture for fixture in load_corpus_entries() if fixture["parse"]["entrypoint"] == "file"
+    )
+    _, page = _parse_entry(entry)
+    assert page.source_path is not None
+    assert page.graph_root is not None
+    relative_source = Path(page.source_path).relative_to(Path(page.graph_root))
+    assert relative_source.parts[0] == "pages"
+    assert page.title == "/".join(relative_source.with_suffix("").parts[1:])
+    snapshot_text = json.dumps(project_page(page, profile="exact_parse_v1"), sort_keys=True)
+    assert page.source_path not in snapshot_text
+    assert page.graph_root not in snapshot_text

--- a/tests/test_compat_corpus.py
+++ b/tests/test_compat_corpus.py
@@ -21,7 +21,7 @@ from tests.parser_assurance.corpus import (
     load_exact_snapshot,
     validate_manifest,
 )
-from tests.parser_assurance.projection import IdentityPolicy, project_page
+from tests.parser_assurance.projection import IdentityPolicy, _explicit_wikilinks, project_page
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -298,6 +298,44 @@ def test_semantic_projection_preserves_shielded_property_references(property_lin
 
     assert node.wikilinks == ["Foo"]
     assert projected["page"]["root_nodes"][0]["wikilinks"] == ["Foo"]
+
+
+def test_semantic_projection_reconciles_mixed_backtick_runs_reference_counters() -> None:
+    page = StackMachineParser().parse(
+        "- [[V]]\n  note:: `a `` [[X]] ` [[V]]\n",
+        page_title="Backtick mix",
+    )
+    node = page.root_nodes[0]
+
+    projected = project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy={
+            "synthetic_uuid": "stable",
+            "source_uuid": "absent",
+            "relations": "direct_ids",
+        },
+    )
+
+    assert node.properties["note"] == "`a `` [[X]] ` [[V]]"
+    assert node.wikilinks == ["V", "X"]
+    assert projected["page"]["root_nodes"][0]["wikilinks"] == ["V"]
+
+
+@pytest.mark.parametrize(
+    ("property_value",),
+    [
+        ("```python\n[[Hidden]]\n```\n[[Visible]]",),
+        ("~~~python\n[[Hidden]]\n~~~\n[[Visible]]",),
+        ("#+BEGIN_QUERY\n[[Hidden]]\n#+END_QUERY\n[[Visible]]",),
+    ],
+)
+def test_property_oracle_preserves_visible_links_after_closed_regions(property_value: str) -> None:
+    assert _explicit_wikilinks(property_value) == ["Visible"]
+
+
+def test_property_oracle_matches_parser_for_unclosed_html_comment() -> None:
+    assert _explicit_wikilinks("<!-- [[Visible]]") == ["Visible"]
 
 
 def test_semantic_projection_canonicalizes_hash_tags_to_target() -> None:

--- a/tests/test_parser_deep_refresh.py
+++ b/tests/test_parser_deep_refresh.py
@@ -9,6 +9,13 @@ import pytest
 from logseq_matryca_parser.logos_core import LogseqNode
 from logseq_matryca_parser.logos_parser import StackMachineParser
 from logseq_matryca_parser.logseq_markdown import serialize_logseq_page
+from tests.parser_assurance.projection import IdentityPolicy, project_page
+
+_DEEP_IDENTITY_POLICY = IdentityPolicy(
+    synthetic_uuid="stable",
+    source_uuid="absent",
+    relations="direct_ids",
+)
 
 
 def _nested_source(depth: int, tail: list[tuple[int, str]]) -> str:
@@ -29,22 +36,6 @@ def _walk(node: LogseqNode) -> Iterator[LogseqNode]:
     yield node
     for child in node.children:
         yield from _walk(child)
-
-
-def _semantic_snapshot(node: LogseqNode) -> tuple[object, ...]:
-    return (
-        node.uuid,
-        node.content,
-        node.clean_text,
-        node.properties,
-        node.properties_order,
-        node.wikilinks,
-        node.tags,
-        node.block_refs,
-        node.parent_id,
-        node.left_id,
-        tuple(_semantic_snapshot(child) for child in node.children),
-    )
 
 
 @pytest.mark.parametrize("depth", [1, 2, 3, 4, 8, 32])
@@ -130,6 +121,13 @@ def test_deep_refresh_families_survive_roundtrip(
         assert [node.uuid for node in _branch(reparsed.root_nodes[0])] == [
             node.uuid for node in _branch(page.root_nodes[0])
         ]
-    else:
-        assert _semantic_snapshot(reparsed.root_nodes[0]) == _semantic_snapshot(page.root_nodes[0])
+    assert project_page(
+        reparsed,
+        profile="semantic_roundtrip_v1",
+        identity_policy=_DEEP_IDENTITY_POLICY,
+    ) == project_page(
+        page,
+        profile="semantic_roundtrip_v1",
+        identity_policy=_DEEP_IDENTITY_POLICY,
+    )
     assert len(list(_walk(reparsed.root_nodes[0]))) == 8

--- a/tests/test_quality_gate_contract.py
+++ b/tests/test_quality_gate_contract.py
@@ -32,6 +32,13 @@ def test_all_uses_only_non_mutating_ruff_targets() -> None:
     assert "uv run ruff check . --fix" not in commands
 
 
+def test_check_type_checks_compatibility_snapshot_generator() -> None:
+    commands = _dry_run("check")
+
+    mypy_command = next(command for command in commands if command.startswith("uv run mypy "))
+    assert "scripts/update_compat_snapshots.py" in mypy_command
+
+
 def test_ci_finishes_with_clean_checkout_assertion() -> None:
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

This PR adds a versioned compatibility corpus and a deterministic parser-assurance oracle for Logseq properties, links, task timing, hierarchy identity, refresh behavior, and asset provenance.

It also hardens the oracle against the parser's shielding rules so that links inside property values, code spans and fences, queries, inline math, and HTML comments are classified consistently with production behavior.

## Why

The first assurance passes exposed oracle defects around protected content and mixed backtick runs. The follow-up corrections now preserve authentic visible links while excluding links that production intentionally shields.

## What changed

- Added six versioned compatibility fixtures and exact JSON snapshots.
- Added source SHA-256 provenance checks and UTF-8/LF validation.
- Added a projection oracle with parser-equivalent shielding and closure rules.
- Added regressions for mixed backtick runs, closed fences, query regions, inline math, HTML comments, link order, multiplicity, and property normalization.
- Added durable English documentation describing the evidence trail, superseded checkpoints, and publication gates.
- Kept production code, public APIs, dependencies, packaging, licenses, workflows, and runtime behavior unchanged.

## Validation

- make all: 584 tests passed, 92.16% coverage.
- Ruff and mypy passed.
- Documentation and vendor-name checks passed.
- Snapshot freshness and fixture provenance checks passed.
- Zero import cycles.
- Final independent Sol review: PASS, no P0/P1/P2 findings.
- Expanded differential shielding probe: 185 cases matched production behavior.

The raw local receipt for the exact reviewed patch is:

- HEAD: bcd8d023d2ec68ea6c934dfa922d0c357231d7cf
- Base: e2a3f9a8d190fd115028d0ad344c31fded0357d9
- Diff SHA-256: 3840bc3b92d10fd8edc77554a3b1611d0aecbd7376c18570a7ae6ab55ddf3710
- Diff lines: 3,352

Hosted checks are intentionally the next gate and must qualify this exact remote commit before merge.