### PR TITLE
test(parser): add bounded adversarial assurance laboratory

### DIFF
--- a/.github/workflows/parser-adversarial.yml
+++ b/.github/workflows/parser-adversarial.yml
@@ -1,0 +1,37 @@
+name: Parser Adversarial Laboratory
+
+on:
+  schedule:
+    - cron: "17 4 * * 3"
+  workflow_dispatch:
+
+concurrency:
+  group: parser-adversarial-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  bounded-generated-assurance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: uv sync --all-extras
+
+      - name: Run bounded broad profile
+        run: uv run python -m tests.parser_assurance.adversarial --profile broad
+
+      - name: Verify checkout unchanged
+        run: make verify-clean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Deterministic adversarial parser laboratory (#104 M3)** — added original,
+  bounded generators for parser depth, malformed fences, escapes and delimiters,
+  properties and references, Unicode/newline variants, large lines, and strict
+  unresolved references. Each case runs in a fresh subprocess with a parent
+  timeout, safe replay receipt, classification-preserving minimization, tree
+  invariants, and semantic round-trip checks for valid inputs. The fixed profile
+  runs with the ordinary suite; an offline scheduled broad profile expands only
+  deterministic seeds and case counts. No parser runtime, public API, package
+  dependency, #103 snapshot-equivalence, or #111 performance claim changes.
 - **Parser compatibility corpus foundation (#104-A)** — added six original,
   offline Apache-2.0 fixtures with source hashes and strict provenance, schema,
   parser-configuration, behavior, diagnostics, and identity-policy metadata;

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -16,7 +16,7 @@ okf_spec_version: null
 supersedes: null
 superseded_by: null
 parent_plan: docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
-source_commit: e2a3f9a8d190fd115028d0ad344c31fded0357d9
+source_commit: 5b0a73eb052cdbfb624b016223545c693fd6d40e
 reference_commit: c79cb059da5b4360ebde2e5fd953fa1f43ddabc3
 ---
 
@@ -53,7 +53,7 @@ Markdown source-of-truth model.
 | Item | Verified state | Evidence |
 |---|---|---|
 | Source repository | `MarcoPorcellato/logseq-matryca-parser` | `origin/main` fetched 2026-08-16 |
-| Source base | `e2a3f9a8d190fd115028d0ad344c31fded0357d9` | clean `agent/parser-assurance-m1` checkout matching `origin/main` on 2026-08-16 and [GitHub commit](https://github.com/MarcoPorcellato/logseq-matryca-parser/commit/e2a3f9a8d190fd115028d0ad344c31fded0357d9) |
+| Source base | `5b0a73eb052cdbfb624b016223545c693fd6d40e` | live `origin/main` verified on 2026-08-16 after [PR #161](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/161) merged |
 | Source license | Apache License 2.0 | [`LICENSE`](../LICENSE) |
 | Reference repository | `martinkoutecky/lsdoc` release `v0.5.5` | [reference commit `c79cb059`](https://github.com/martinkoutecky/lsdoc/commit/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3) |
 | Reference license | `AGPL-3.0-only` | [`Cargo.toml`](https://github.com/martinkoutecky/lsdoc/blob/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3/Cargo.toml) and [`LICENSE`](https://github.com/martinkoutecky/lsdoc/blob/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3/LICENSE) |
@@ -61,7 +61,8 @@ Markdown source-of-truth model.
 | M0 publication | merged as [PR #159](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/159) | source head `a6056413`, squash merge `30946446`, terminal validation recorded in the PR |
 | Existing delivery anchors | #87, #103, #104, #108, #111 are open; #106 and #113 are closed | live GitHub issue reads on 2026-08-16 |
 | Local implementation checkpoint | `8806205c35b104ed65d00a273acc9eeca572ae38` | clean local commit on `agent/parser-assurance-m1`; exact-head tests passed, but independent oracle review rejected publication |
-| Current milestone | M1-B second corrective implementation locally qualified; refreshed documentation evidence and final frozen Sol review pending | second frozen Sol review on `5007dc357e05775c6221c8aa84f9a11edc695e0d` returned `NEEDS_CORRECTION`; non-amending corrective implementation `7870b84` passed exact-head local qualification with 584 tests; no push or PR |
+| M1 delivery | merged | [PR #161](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/161) merged the project-owned compatibility-corpus foundation; it remains only the first #104 tranche |
+| Current milestone | M3 in delivery | isolated branch from the verified source base; original, test-only bounded generator laboratory only; no publication claim |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
 publication, or qualification.
@@ -468,21 +469,44 @@ converted into a pass or silently added to an allowlist.
 **Outcome**
 
 - Original generators cover indentation depth, malformed fences, escapes,
-  overlapping delimiters, properties, references, Unicode, CR/LF variants,
-  large lines, and incremental/cold-load equivalence.
-- Every generated run has bounded size, deterministic replay information, and
-  subprocess timeout protection.
-- Complete the remaining expanded #104 acceptance criteria without duplicating
-  the focused #103 snapshot owner or the established #106 security contracts.
+  overlapping delimiters, properties, references, Unicode, CR/LF variants, and
+  large lines.
+- Every generated run has an explicit byte budget, canonical case identity,
+  deterministic seed replay information, source-free receipts, and parent-
+  enforced fresh-subprocess timeout protection.
+- The laboratory classifies a successful parse, expected typed parser error,
+  unexpected exception, structural-invariant failure, semantic-roundtrip
+  failure, timeout, or runner failure. Tolerated malformed syntax is recorded
+  as malformed input with a successful parse; it is not misrepresented as a
+  parser error.
+- Valid generated cases prove parse/serialize/parse semantic equivalence using
+  an identity policy that allows synthetic UUID recomputation while preserving
+  semantic outline relationships. All generated cases prove tree invariants
+  whenever parsing succeeds.
+- A fixed small profile runs with ordinary tests. A separate offline scheduled
+  profile increases only deterministic seeds and bounded case counts; it is not
+  a benchmark, a release gate, or required for ordinary pull-request review.
+- Failure minimization is greedy and deterministic, preserves the exact outcome
+  classification and exception type, and records only minimized byte length and
+  hash. A maintainer must review any proposed regression fixture before adding
+  original Apache-2.0 source to the valid corpus.
+- #103 remains the sole owner of complete incremental-versus-cold-load snapshot
+  equivalence. M3 provides no such claim. #111 and #87 remain the owners of
+  scale, wall-time, percentile, memory, and performance conclusions; M3 uses a
+  fixed safety timeout only to establish no-hang classification.
 
 **Dependencies**
 
-- M1; optional M2 when accepted; #103 for complete incremental snapshot claims.
+- M1. M2 is not required because this laboratory has no external oracle. #103
+  is a boundary, not an M3 dependency, unless a future change seeks to claim
+  complete incremental snapshot equivalence.
 
 **Exit evidence**
 
-- Fixed-seed CI subset; scheduled broader run; minimized original regression
-  fixtures; no crash, hang, invariant loss, or unclassified failure.
+- Fixed-seed CI subset and a separately scheduled broader run; deterministic
+  seed/case replay command; source-free receipts; minimized original candidate
+  only after failure and review; no crash, hang, structural-invariant loss,
+  semantic-roundtrip mismatch, or unclassified failure in the selected matrix.
 
 **Impact**
 
@@ -754,3 +778,5 @@ Completion is unproven until every applicable item has authoritative evidence.
 | 2026-08-16 | M1-B corrective implementation `9e8708e` | locally qualified, then superseded | Corrected the first frozen review's simple shield cases and `#[[Foo]]` normalization. Exact-head qualification passed with 579 tests, but the next full-patch Sol review found incomplete parity for unequal backtick runs; this receipt is therefore historical, not publication-ready. |
 | 2026-08-16 | M1-B second frozen Sol review `5007dc3` | verified and unresolved | Review returned `NEEDS_CORRECTION`: valid mixed-backtick input still removed an authentic content wikilink, simple tests did not cover unequal delimiter runs, and the supplied patch hash/line receipt was invalid because it came from filtered rather than raw Git diff bytes. |
 | 2026-08-16 | M1-B second corrective implementation `7870b84` | locally qualified (non-amending) | Added parser-equivalent exact backtick-run matching, bounded fence/query-region closing, precise inline-math closing, unclosed-comment parity, the exact Sol reproducer, and post-region visible-link regressions. A 14-family direct differential probe found no parser/oracle wikilink mismatch. Exact-head snapshot freshness and `make all` passed with 584 tests and 92.16% coverage; Ruff, mypy, documentation, vendor-name, diff, and zero-cycle checks passed. No `src/`, package, API, dependency, push, PR, merge, or release change occurred. |
+| 2026-08-16 | M1 / PR #161 | merged | [PR #161](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/161) merged the first #104 compatibility-corpus tranche. Historical local M1 receipts remain historical only; the live `main` base is `5b0a73e`. |
+| 2026-08-16 | M3 laboratory | locally qualified, uncommitted | An isolated branch from `main@5b0a73e` adds only test, workflow, and documentation changes: seven original bounded generator families, fresh-subprocess timeout classification, source-free receipts, classification- and exception-preserving minimization, structural invariants, valid-input semantic round trips, a 21-case fixed profile, and a 63-case scheduled broad profile. Sol correction review added explicit unequal and overlapping delimiter cases and minimization-policy regression coverage. No public API, runtime dependency, #103, #111/#87, external-oracle, release, or publication claim is made; final exact-diff review remains a separate gate. |

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -24,31 +24,27 @@ Complete the license-safe parser assurance program defined in
 This goal is an execution pointer subordinate to the repository stellar roadmap
 and has no independent scope authority.
 
-First verify the live source revision, issue state, documentation policy, and
-delivery state. Continue through the dependency-ordered milestones until every
-applicable completion item has authoritative current evidence. Do not redo work
-already proved in the plan.
+M1 was merged through [PR #161](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/161).
+The active next step is M3 only: an original, test-only adversarial and
+property-based semantic laboratory based on the live `main` source revision.
+It must generate bounded original inputs for depth, fences, delimiters,
+properties, references, Unicode/newline variants, and large lines; run each
+case in a fresh subprocess with a parent timeout; support deterministic replay
+and classification-preserving minimization; verify structure and valid-case
+semantic round trips; keep a fixed CI subset and a separately scheduled broad
+profile; and emit source-free receipts.
 
-The initial checkpoint `8806205c35b104ed65d00a273acc9eeca572ae38` is rejected
-pre-correction evidence. Corrective implementation
-`996c5a52b08f2670ecd80fb3f1515b65ae567465` passed local exact-head checks, but
-its evidence head `6fcf4b274a3a04ef4c9783cf83149d6ef4aeeabb` was rejected by
-the first frozen Sol review and is now superseded. These historical checkpoints
-must not be presented or pushed independently as publication-ready evidence.
-Corrective implementation `9e8708eef9cfa63fd9f392f5b5a9e7df564072e7` passed local
-qualification but was superseded after frozen review head
-`5007dc357e05775c6221c8aa84f9a11edc695e0d` returned `NEEDS_CORRECTION` for
-unequal-backtick shielding parity. Non-amending corrective implementation
-`7870b84` changed only `tests/parser_assurance/projection.py` and
-`tests/test_compat_corpus.py` and passed exact-head local qualification with
-584 tests and 92.16% coverage on a clean worktree.
-Before any push, re-verify the live anchor, review the frozen full diff with GPT-5.6
-Sol again, and follow the
-[post-correction handoff](../internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md).
-The refreshed documentation-evidence commit containing this pointer must
-receive exact-head qualification. Then freeze the raw full diff, record its
-unfiltered SHA-256 and line count, rerun a final GPT-5.6 Sol review, and stop
-before push.
+M3 must not change parser runtime behavior, public APIs, package metadata,
+dependencies, or the valid-fixture manifest. It must not claim #103
+incremental/cold-load snapshot equivalence, #111/#87 performance evidence, an
+external-oracle result, or release qualification. A new regression fixture is
+allowed only after a minimized original input has been reviewed for provenance,
+privacy, and licensing.
+
+Before any push or pull request, re-verify the live base, freeze the raw full
+diff, qualify its exact head, obtain an independent GPT-5.6 Sol full-patch
+review, adjudicate every finding, and stop before publication unless separately
+authorized.
 
 Preserve the Apache-2.0 boundary: do not copy or adapt lsdoc code, tests,
 corpora, schemas, module structure, control flow, or documentation. Keep lsdoc

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,6 +21,14 @@ superseded_by: null
 
 ## 2026-08-16
 
+- Started the M3 parser-assurance laboratory from `main@5b0a73e` after
+  [PR #161](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/161)
+  merged M1. M3 is explicitly test-only: deterministic original generators,
+  source-free replay receipts, subprocess no-hang classification,
+  classification-preserving minimization, structural invariants, valid-case
+  semantic round trips, a fixed local subset, and a separately scheduled broad
+  profile. It does not claim #103 incremental/cold-load equivalence, #111/#87
+  performance evidence, external-oracle parity, a public API, or a release.
 - Recorded the second frozen Sol review on
   `5007dc357e05775c6221c8aa84f9a11edc695e0d` as `NEEDS_CORRECTION`: mixed
   backtick runs still caused an authentic content wikilink to be removed, and

--- a/tests/parser_assurance/adversarial.py
+++ b/tests/parser_assurance/adversarial.py
@@ -1,0 +1,584 @@
+"""Deterministic, test-only adversarial parser laboratory.
+
+The laboratory is deliberately independent of the valid-fixture manifest.  It
+generates original bounded inputs, executes each one in a fresh subprocess, and
+prints safe replay receipts instead of source text.  It is not a public API or
+a benchmark harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import random
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass, replace
+from typing import Final, Literal
+
+from logseq_matryca_parser.exceptions import LogseqParserError
+from logseq_matryca_parser.logos_parser import StackMachineParser
+from logseq_matryca_parser.logseq_markdown import serialize_logseq_page
+from tests.parser_assurance.invariants import assert_tree_invariants
+from tests.parser_assurance.projection import IdentityPolicy, project_page
+
+GENERATOR_SCHEMA_VERSION: Final = 1
+FAST_SEEDS: Final = (104,)
+BROAD_SEEDS: Final = (104, 417, 911)
+MAX_CASE_BYTES: Final = 16_384
+DEFAULT_TIMEOUT_SECONDS: Final = 3.0
+
+Classification = Literal[
+    "parsed",
+    "expected_parser_error",
+    "unexpected_exception",
+    "invariant_failure",
+    "semantic_roundtrip_failure",
+    "timeout",
+    "runner_failure",
+]
+InputKind = Literal["valid", "malformed"]
+
+IDENTITY_POLICY: Final[IdentityPolicy] = {
+    "synthetic_uuid": "recomputed",
+    "source_uuid": "absent",
+    "relations": "outline_paths",
+}
+
+
+@dataclass(frozen=True)
+class GeneratedCase:
+    """One original generated input and the contract expected of its execution."""
+
+    case_id: str
+    family: str
+    seed: int
+    index: int
+    source: str
+    input_kind: InputKind
+    strict_refs: bool
+    semantic_roundtrip: bool
+    expected_classifications: tuple[Classification, ...]
+
+    @property
+    def source_sha256(self) -> str:
+        return hashlib.sha256(self.source.encode("utf-8")).hexdigest()
+
+    @property
+    def source_bytes(self) -> int:
+        return len(self.source.encode("utf-8"))
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """A source-free classification receipt returned by the parent runner."""
+
+    case_id: str
+    family: str
+    seed: int
+    index: int
+    input_kind: InputKind
+    source_sha256: str
+    source_bytes: int
+    classification: Classification
+    exception_type: str | None
+    semantic_roundtrip_checked: bool
+    python_version: str
+    minimized_source_sha256: str | None = None
+    minimized_source_bytes: int | None = None
+
+    def is_expected_for(self, case: GeneratedCase) -> bool:
+        return self.classification in case.expected_classifications
+
+
+def _case_id(family: str, seed: int, index: int) -> str:
+    return f"m3-{family}-{seed}-{index}"
+
+
+def _bounded_case(
+    *,
+    family: str,
+    seed: int,
+    index: int,
+    source: str,
+    input_kind: InputKind,
+    strict_refs: bool = False,
+    semantic_roundtrip: bool = False,
+    expected_classifications: tuple[Classification, ...] = ("parsed",),
+) -> GeneratedCase:
+    if len(source.encode("utf-8")) > MAX_CASE_BYTES:
+        raise ValueError(f"generated {family} case exceeds {MAX_CASE_BYTES} byte budget")
+    return GeneratedCase(
+        case_id=_case_id(family, seed, index),
+        family=family,
+        seed=seed,
+        index=index,
+        source=source,
+        input_kind=input_kind,
+        strict_refs=strict_refs,
+        semantic_roundtrip=semantic_roundtrip,
+        expected_classifications=expected_classifications,
+    )
+
+
+def _indentation_case(seed: int, index: int, rng: random.Random) -> GeneratedCase:
+    depth = 2 + rng.randrange(5)
+    lines = [f"{'  ' * level}- depth-{level} [[Depth{level}]]" for level in range(depth)]
+    return _bounded_case(
+        family="indentation-depth",
+        seed=seed,
+        index=index,
+        source="\n".join(lines) + "\n",
+        input_kind="valid",
+        semantic_roundtrip=True,
+    )
+
+
+def _fence_case(seed: int, index: int, rng: random.Random) -> GeneratedCase:
+    fence = rng.choice(("```", "~~~"))
+    if index % 2 == 0:
+        source = f"- open-fence\n  {fence}text\n  [[LiteralOnly]]\n"
+        return _bounded_case(
+            family="fences",
+            seed=seed,
+            index=index,
+            source=source,
+            input_kind="malformed",
+        )
+    source = f"- closed-fence [[Visible]]\n  {fence}text\n  [[LiteralOnly]]\n  {fence}\n"
+    return _bounded_case(
+        family="fences",
+        seed=seed,
+        index=index,
+        source=source,
+        input_kind="valid",
+        semantic_roundtrip=True,
+    )
+
+
+def _delimiter_case(seed: int, index: int, rng: random.Random) -> GeneratedCase:
+    if index % 3 == 1:
+        return _bounded_case(
+            family="escapes-delimiters",
+            seed=seed,
+            index=index,
+            source="- mixed `a `` [[Hidden]] ` [[Visible]]\n",
+            input_kind="malformed",
+        )
+    if index % 3 == 2:
+        return _bounded_case(
+            family="escapes-delimiters",
+            seed=seed,
+            index=index,
+            source="- overlap ``outer `[[Hidden]]` [[Visible]]`` [[Tail]]\n",
+            input_kind="malformed",
+        )
+    delimiter = "`" * (1 + rng.randrange(3))
+    source = (
+        f"- escaped \\[[Hidden]] {delimiter}[[Literal]]{delimiter} [[Visible]]\n"
+        "  {{query [[MacroTarget]]}}\n"
+    )
+    return _bounded_case(
+        family="escapes-delimiters",
+        seed=seed,
+        index=index,
+        source=source,
+        input_kind="valid",
+        semantic_roundtrip=True,
+    )
+
+
+def _property_case(seed: int, index: int, rng: random.Random) -> GeneratedCase:
+    marker = rng.randrange(10_000)
+    source = (
+        f"tags:: [[Alpha {marker}]], [[Beta {marker}]]\n"
+        f"- properties [[Visible {marker}]]\n"
+        f"  aliases:: [[Alias {marker}]], Alias {marker}\n"
+        f"  - child #[[Tag {marker}]]\n"
+    )
+    return _bounded_case(
+        family="properties-references",
+        seed=seed,
+        index=index,
+        source=source,
+        input_kind="valid",
+        semantic_roundtrip=True,
+    )
+
+
+def _unicode_newline_case(seed: int, index: int, rng: random.Random) -> GeneratedCase:
+    newline = "\r\n" if index % 2 else "\n"
+    token = rng.choice(("caffè", "東京", "naïve", "🙂"))
+    source = newline.join(
+        (
+            f"- {token} [[Unicode {index}]]",
+            f"  - child {token} #[[Tag {index}]]",
+            "",
+        )
+    )
+    return _bounded_case(
+        family="unicode-newlines",
+        seed=seed,
+        index=index,
+        source=source,
+        input_kind="valid",
+        semantic_roundtrip=True,
+    )
+
+
+def _large_line_case(seed: int, index: int, rng: random.Random) -> GeneratedCase:
+    width = 1_024 + (rng.randrange(4) * 512)
+    source = f"- {'x' * width} [[LongLine {index}]]\n"
+    return _bounded_case(
+        family="large-lines",
+        seed=seed,
+        index=index,
+        source=source,
+        input_kind="valid",
+        semantic_roundtrip=True,
+    )
+
+
+def _strict_reference_case(seed: int, index: int, _rng: random.Random) -> GeneratedCase:
+    missing_uuid = f"{seed:08x}-aaaa-bbbb-cccc-{index:012x}"
+    source = f"- unresolved (({missing_uuid}))\n"
+    return _bounded_case(
+        family="strict-references",
+        seed=seed,
+        index=index,
+        source=source,
+        input_kind="malformed",
+        strict_refs=True,
+        expected_classifications=("expected_parser_error",),
+    )
+
+
+FAMILY_GENERATORS: Final = {
+    "delimiter-escapes": _delimiter_case,
+    "fences": _fence_case,
+    "indentation-depth": _indentation_case,
+    "large-lines": _large_line_case,
+    "properties-references": _property_case,
+    "strict-references": _strict_reference_case,
+    "unicode-newlines": _unicode_newline_case,
+}
+
+
+def generate_cases(
+    seed: int,
+    *,
+    cases_per_family: int,
+    families: Sequence[str] | None = None,
+) -> tuple[GeneratedCase, ...]:
+    """Generate a canonical sequence, independent of the caller's family order."""
+    if cases_per_family < 1:
+        raise ValueError("cases_per_family must be positive")
+    selected = tuple(sorted(set(families or tuple(FAMILY_GENERATORS))))
+    unknown = set(selected) - FAMILY_GENERATORS.keys()
+    if unknown:
+        raise ValueError(f"unknown generator families: {sorted(unknown)}")
+    cases: list[GeneratedCase] = []
+    for family in selected:
+        generator = FAMILY_GENERATORS[family]
+        for index in range(cases_per_family):
+            family_seed = int.from_bytes(
+                hashlib.sha256(f"{GENERATOR_SCHEMA_VERSION}:{seed}:{family}:{index}".encode()).digest()[:8],
+                "big",
+            )
+            cases.append(generator(seed, index, random.Random(family_seed)))
+    return tuple(cases)
+
+
+def cases_for_profile(profile: Literal["fast", "broad"]) -> tuple[GeneratedCase, ...]:
+    """Return the bounded fixed or scheduled case matrix."""
+    seeds = FAST_SEEDS if profile == "fast" else BROAD_SEEDS
+    cases_per_family = 3
+    return tuple(
+        case
+        for seed in seeds
+        for case in generate_cases(seed, cases_per_family=cases_per_family)
+    )
+
+
+def _worker_result(case: GeneratedCase) -> tuple[Classification, str | None, bool]:
+    """Parse one case in a child process and never emit source text."""
+    try:
+        page = StackMachineParser(strict_refs=case.strict_refs).parse(
+            case.source,
+            page_title=f"adversarial/{case.family}",
+        )
+        assert_tree_invariants(page)
+        if case.semantic_roundtrip:
+            rendered = serialize_logseq_page(page)
+            reparsed = StackMachineParser(strict_refs=case.strict_refs).parse(
+                rendered,
+                page_title=page.title,
+            )
+            assert_tree_invariants(reparsed)
+            if project_page(
+                reparsed,
+                profile="semantic_roundtrip_v1",
+                identity_policy=IDENTITY_POLICY,
+            ) != project_page(
+                page,
+                profile="semantic_roundtrip_v1",
+                identity_policy=IDENTITY_POLICY,
+            ):
+                return "semantic_roundtrip_failure", "SemanticRoundtripMismatch", True
+    except LogseqParserError as error:
+        return "expected_parser_error", type(error).__name__, False
+    except AssertionError:
+        return "invariant_failure", "AssertionError", False
+    except Exception as error:  # Defensive classification boundary for generated input.
+        return "unexpected_exception", type(error).__name__, False
+    return "parsed", None, case.semantic_roundtrip
+
+
+def _case_from_payload(payload: object) -> GeneratedCase:
+    if not isinstance(payload, dict):
+        raise ValueError("worker payload must be an object")
+    expected = payload.get("expected_classifications")
+    if not isinstance(expected, list) or not all(isinstance(item, str) for item in expected):
+        raise ValueError("worker expected classifications must be strings")
+    return GeneratedCase(
+        case_id=str(payload["case_id"]),
+        family=str(payload["family"]),
+        seed=int(payload["seed"]),
+        index=int(payload["index"]),
+        source=str(payload["source"]),
+        input_kind=payload["input_kind"],
+        strict_refs=bool(payload["strict_refs"]),
+        semantic_roundtrip=bool(payload["semantic_roundtrip"]),
+        expected_classifications=tuple(expected),
+    )
+
+
+def _worker_main() -> int:
+    """Read one case from stdin and print one source-free JSON result."""
+    try:
+        case = _case_from_payload(json.loads(sys.stdin.read()))
+        classification, exception_type, semantic_checked = _worker_result(case)
+        print(
+            json.dumps(
+                {
+                    "classification": classification,
+                    "exception_type": exception_type,
+                    "semantic_roundtrip_checked": semantic_checked,
+                },
+                sort_keys=True,
+            )
+        )
+    except Exception as error:  # A malformed worker protocol is a runner failure.
+        print(
+            json.dumps(
+                {
+                    "classification": "runner_failure",
+                    "exception_type": type(error).__name__,
+                    "semantic_roundtrip_checked": False,
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+def _base_result(
+    case: GeneratedCase,
+    *,
+    classification: Classification,
+    exception_type: str | None,
+    semantic_roundtrip_checked: bool,
+) -> CaseResult:
+    return CaseResult(
+        case_id=case.case_id,
+        family=case.family,
+        seed=case.seed,
+        index=case.index,
+        input_kind=case.input_kind,
+        source_sha256=case.source_sha256,
+        source_bytes=case.source_bytes,
+        classification=classification,
+        exception_type=exception_type,
+        semantic_roundtrip_checked=semantic_roundtrip_checked,
+        python_version=platform.python_version(),
+    )
+
+
+def run_case(case: GeneratedCase, *, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> CaseResult:
+    """Execute a case in a fresh process and classify timeout or runner failure."""
+    payload = asdict(case)
+    payload["expected_classifications"] = list(case.expected_classifications)
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-m", "tests.parser_assurance.adversarial", "--worker"],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        return _base_result(
+            case,
+            classification="timeout",
+            exception_type=None,
+            semantic_roundtrip_checked=False,
+        )
+    if completed.returncode != 0:
+        return _base_result(
+            case,
+            classification="runner_failure",
+            exception_type=f"exit-{completed.returncode}",
+            semantic_roundtrip_checked=False,
+        )
+    try:
+        payload_result = json.loads(completed.stdout)
+        classification = payload_result["classification"]
+        exception_type = payload_result["exception_type"]
+        semantic_checked = payload_result["semantic_roundtrip_checked"]
+    except (KeyError, TypeError, json.JSONDecodeError):
+        return _base_result(
+            case,
+            classification="runner_failure",
+            exception_type="InvalidWorkerReceipt",
+            semantic_roundtrip_checked=False,
+        )
+    if classification not in {
+        "parsed",
+        "expected_parser_error",
+        "unexpected_exception",
+        "invariant_failure",
+        "semantic_roundtrip_failure",
+        "timeout",
+        "runner_failure",
+    }:
+        return _base_result(
+            case,
+            classification="runner_failure",
+            exception_type="UnknownClassification",
+            semantic_roundtrip_checked=False,
+        )
+    if exception_type is not None and not isinstance(exception_type, str):
+        return _base_result(
+            case,
+            classification="runner_failure",
+            exception_type="InvalidExceptionType",
+            semantic_roundtrip_checked=False,
+        )
+    if not isinstance(semantic_checked, bool):
+        return _base_result(
+            case,
+            classification="runner_failure",
+            exception_type="InvalidSemanticFlag",
+            semantic_roundtrip_checked=False,
+        )
+    return _base_result(
+        case,
+        classification=classification,
+        exception_type=exception_type,
+        semantic_roundtrip_checked=semantic_checked,
+    )
+
+
+def minimize_source(
+    case: GeneratedCase,
+    *,
+    preserves_failure: Callable[[str], bool],
+) -> GeneratedCase:
+    """Greedily delete lines while an exact caller-defined failure persists."""
+    lines = case.source.splitlines(keepends=True)
+    changed = True
+    while changed and len(lines) > 1:
+        changed = False
+        for index in range(len(lines)):
+            candidate = "".join([*lines[:index], *lines[index + 1 :]])
+            if candidate and preserves_failure(candidate):
+                lines = candidate.splitlines(keepends=True)
+                changed = True
+                break
+    return replace(case, source="".join(lines))
+
+
+def _minimize_unexpected(case: GeneratedCase, result: CaseResult, timeout_seconds: float) -> CaseResult:
+    """Return a receipt with safe minimized-input metadata for a failing case."""
+
+    def preserves_failure(source: str) -> bool:
+        candidate = replace(case, source=source)
+        replay = run_case(candidate, timeout_seconds=timeout_seconds)
+        return (
+            replay.classification == result.classification
+            and replay.exception_type == result.exception_type
+        )
+
+    minimized = minimize_source(case, preserves_failure=preserves_failure)
+    return replace(
+        result,
+        minimized_source_sha256=minimized.source_sha256,
+        minimized_source_bytes=minimized.source_bytes,
+    )
+
+
+def run_profile(
+    profile: Literal["fast", "broad"],
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    case_id: str | None = None,
+) -> tuple[CaseResult, ...]:
+    """Run one reproducible profile and minimize only unexpected failures."""
+    cases = cases_for_profile(profile)
+    if case_id is not None:
+        cases = tuple(case for case in cases if case.case_id == case_id)
+        if not cases:
+            raise ValueError(f"case not found in {profile} profile: {case_id}")
+    results: list[CaseResult] = []
+    for case in cases:
+        result = run_case(case, timeout_seconds=timeout_seconds)
+        if not result.is_expected_for(case):
+            result = _minimize_unexpected(case, result, timeout_seconds)
+        results.append(result)
+    return tuple(results)
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the deterministic parser adversarial laboratory.")
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--profile", choices=("fast", "broad"), default="fast")
+    parser.add_argument("--case-id", help="Replay exactly one generated case from the selected profile.")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Positive parent-enforced subprocess timeout per case.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the requested profile and print deterministic, source-free receipts."""
+    args = _parse_args(argv)
+    if args.worker:
+        return _worker_main()
+    if args.timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+    results = run_profile(
+        args.profile,
+        timeout_seconds=args.timeout_seconds,
+        case_id=args.case_id,
+    )
+    receipt = {
+        "generator_schema_version": GENERATOR_SCHEMA_VERSION,
+        "profile": args.profile,
+        "results": [asdict(result) for result in results],
+    }
+    print(json.dumps(receipt, sort_keys=True))
+    cases = cases_for_profile(args.profile)
+    if args.case_id is not None:
+        cases = tuple(case for case in cases if case.case_id == args.case_id)
+    return 0 if all(result.is_expected_for(case) for case, result in zip(cases, results, strict=True)) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/parser_assurance/invariants.py
+++ b/tests/parser_assurance/invariants.py
@@ -1,0 +1,32 @@
+"""Test-only structural invariants shared by parser assurance suites."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
+
+
+def walk_nodes(nodes: list[LogseqNode]) -> Iterator[LogseqNode]:
+    """Yield nodes in deterministic pre-order."""
+    for node in nodes:
+        yield node
+        yield from walk_nodes(node.children)
+
+
+def assert_tree_invariants(page: LogseqPage) -> None:
+    """Assert the structural contract shared by parsed and reparsed pages."""
+    nodes = list(walk_nodes(page.root_nodes))
+    assert len({node.uuid for node in nodes}) == len(nodes)
+
+    def visit(siblings: list[LogseqNode], parent: LogseqNode | None) -> None:
+        for index, node in enumerate(siblings):
+            assert node.parent_id == (parent.uuid if parent is not None else None)
+            assert node.left_id == (siblings[index - 1].uuid if index else None)
+            expected_path = [node.uuid] if parent is None else [*parent.path, node.uuid]
+            assert node.path == expected_path
+            expected_outline = [index + 1] if parent is None else [*parent.outline_path, index + 1]
+            assert node.outline_path == expected_outline
+            visit(node.children, node)
+
+    visit(page.root_nodes, None)

--- a/tests/test_compat_corpus.py
+++ b/tests/test_compat_corpus.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
-from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
-from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
+from logseq_matryca_parser.logos_core import LogseqPage
 from logseq_matryca_parser.logos_parser import StackMachineParser
 from logseq_matryca_parser.logseq_markdown import serialize_logseq_page
 from scripts import update_compat_snapshots
@@ -21,6 +20,7 @@ from tests.parser_assurance.corpus import (
     load_exact_snapshot,
     validate_manifest,
 )
+from tests.parser_assurance.invariants import assert_tree_invariants, walk_nodes
 from tests.parser_assurance.projection import IdentityPolicy, _explicit_wikilinks, project_page
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -34,29 +34,6 @@ def _parse_entry(entry: dict[str, Any]) -> tuple[str, LogseqPage]:
     if parse["entrypoint"] == "file":
         return source, parser.parse_page_file(source_path)
     return source, parser.parse(source, page_title=parse["page_title"])
-
-
-def _walk(nodes: list[LogseqNode]) -> Iterator[LogseqNode]:
-    for node in nodes:
-        yield node
-        yield from _walk(node.children)
-
-
-def _assert_tree_invariants(page: LogseqPage) -> None:
-    nodes = list(_walk(page.root_nodes))
-    assert len({node.uuid for node in nodes}) == len(nodes)
-
-    def visit(siblings: list[LogseqNode], parent: LogseqNode | None) -> None:
-        for index, node in enumerate(siblings):
-            assert node.parent_id == (parent.uuid if parent is not None else None)
-            assert node.left_id == (siblings[index - 1].uuid if index else None)
-            expected_path = [node.uuid] if parent is None else [*parent.path, node.uuid]
-            assert node.path == expected_path
-            expected_outline = [index + 1] if parent is None else [*parent.outline_path, index + 1]
-            assert node.outline_path == expected_outline
-            visit(node.children, node)
-
-    visit(page.root_nodes, None)
 
 
 def _identity_policy(entry: dict[str, Any]) -> IdentityPolicy:
@@ -403,7 +380,7 @@ def test_exact_parse_snapshot_and_same_input_determinism(entry: dict[str, Any]) 
     _, repeated = _parse_entry(entry)
 
     assert page.raw_content == source
-    _assert_tree_invariants(page)
+    assert_tree_invariants(page)
     projected = project_page(page, profile="exact_parse_v1")
     assert projected == load_exact_snapshot(entry)
     assert project_page(repeated, profile="exact_parse_v1") == projected
@@ -420,8 +397,8 @@ def test_semantic_roundtrip_profile(entry: dict[str, Any]) -> None:
         page_title=page.title,
     )
 
-    _assert_tree_invariants(reparsed)
-    _assert_tree_invariants(repeated_reparse)
+    assert_tree_invariants(reparsed)
+    assert_tree_invariants(repeated_reparse)
     assert project_page(repeated_reparse, profile="exact_parse_v1") == project_page(
         reparsed,
         profile="exact_parse_v1",
@@ -435,8 +412,8 @@ def test_semantic_roundtrip_profile(entry: dict[str, Any]) -> None:
         profile="semantic_roundtrip_v1",
         identity_policy=policy,
     )
-    original_source_uuids = [node.source_uuid for node in _walk(page.root_nodes)]
-    reparsed_source_uuids = [node.source_uuid for node in _walk(reparsed.root_nodes)]
+    original_source_uuids = [node.source_uuid for node in walk_nodes(page.root_nodes)]
+    reparsed_source_uuids = [node.source_uuid for node in walk_nodes(reparsed.root_nodes)]
     if policy["source_uuid"] == "preserve":
         assert any(value is not None for value in original_source_uuids)
         assert reparsed_source_uuids == original_source_uuids

--- a/tests/test_parser_adversarial.py
+++ b/tests/test_parser_adversarial.py
@@ -1,0 +1,142 @@
+"""Contracts for the deterministic, subprocess-bounded parser laboratory."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tests.parser_assurance import adversarial
+
+
+def test_generated_cases_are_bounded_and_order_independent() -> None:
+    forward = adversarial.generate_cases(
+        104,
+        cases_per_family=3,
+        families=tuple(adversarial.FAMILY_GENERATORS),
+    )
+    reversed_families = adversarial.generate_cases(
+        104,
+        cases_per_family=3,
+        families=tuple(reversed(adversarial.FAMILY_GENERATORS)),
+    )
+
+    assert forward == reversed_families
+    assert len({case.case_id for case in forward}) == len(forward)
+    assert all(case.source_bytes <= adversarial.MAX_CASE_BYTES for case in forward)
+    delimiter_sources = [case.source for case in forward if case.family == "escapes-delimiters"]
+    assert any("`a ``" in source for source in delimiter_sources)
+    assert any("``outer `" in source for source in delimiter_sources)
+
+
+def test_fast_profile_has_expected_classifications_and_semantic_roundtrips() -> None:
+    cases = adversarial.cases_for_profile("fast")
+    results = [adversarial.run_case(case) for case in cases]
+
+    assert all(result.is_expected_for(case) for case, result in zip(cases, results, strict=True))
+    assert all(
+        result.semantic_roundtrip_checked
+        for case, result in zip(cases, results, strict=True)
+        if case.semantic_roundtrip
+    )
+    assert any(result.classification == "expected_parser_error" for result in results)
+
+
+def test_timeout_is_classified_without_accepting_a_partial_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = adversarial.cases_for_profile("fast")[0]
+
+    def timeout(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired("parser", 0.01)
+
+    monkeypatch.setattr(adversarial.subprocess, "run", timeout)
+    result = adversarial.run_case(case, timeout_seconds=0.01)
+
+    assert result.classification == "timeout"
+    assert result.semantic_roundtrip_checked is False
+
+
+def test_minimization_is_deterministic_and_preserves_the_given_predicate() -> None:
+    case = adversarial.GeneratedCase(
+        case_id="minimize",
+        family="test",
+        seed=1,
+        index=0,
+        source="- keep needle\n- discard one\n- discard two\n",
+        input_kind="malformed",
+        strict_refs=False,
+        semantic_roundtrip=False,
+        expected_classifications=("unexpected_exception",),
+    )
+
+    def predicate(source: str) -> bool:
+        return "needle" in source
+
+    minimized = adversarial.minimize_source(case, preserves_failure=predicate)
+
+    assert minimized.source == "- keep needle\n"
+    assert predicate(minimized.source)
+
+
+def test_unexpected_minimization_preserves_classification_and_exception_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = adversarial.GeneratedCase(
+        case_id="unexpected-minimize",
+        family="test",
+        seed=1,
+        index=0,
+        source="- keep-classification\n- keep-exception\n- discard\n",
+        input_kind="malformed",
+        strict_refs=False,
+        semantic_roundtrip=False,
+        expected_classifications=("parsed",),
+    )
+    original = adversarial._base_result(
+        case,
+        classification="unexpected_exception",
+        exception_type="ExpectedError",
+        semantic_roundtrip_checked=False,
+    )
+
+    observed_timeouts: list[float] = []
+
+    def replay(candidate: adversarial.GeneratedCase, *, timeout_seconds: float) -> adversarial.CaseResult:
+        observed_timeouts.append(timeout_seconds)
+        return adversarial._base_result(
+            candidate,
+            classification=(
+                "unexpected_exception"
+                if "keep-classification" in candidate.source
+                else "invariant_failure"
+            ),
+            exception_type=(
+                "ExpectedError" if "keep-exception" in candidate.source else "OtherError"
+            ),
+            semantic_roundtrip_checked=False,
+        )
+
+    monkeypatch.setattr(adversarial, "run_case", replay)
+    minimized = adversarial._minimize_unexpected(case, original, timeout_seconds=0.2)
+
+    expected_source = "- keep-classification\n- keep-exception\n"
+    assert observed_timeouts
+    assert set(observed_timeouts) == {0.2}
+    assert minimized.minimized_source_bytes == len(expected_source.encode("utf-8"))
+    assert minimized.minimized_source_sha256 == adversarial.GeneratedCase(
+        case_id=case.case_id,
+        family=case.family,
+        seed=case.seed,
+        index=case.index,
+        source=expected_source,
+        input_kind=case.input_kind,
+        strict_refs=case.strict_refs,
+        semantic_roundtrip=case.semantic_roundtrip,
+        expected_classifications=case.expected_classifications,
+    ).source_sha256
+
+
+def test_replay_rejects_unknown_case_id() -> None:
+    with pytest.raises(ValueError, match="case not found"):
+        adversarial.run_profile("fast", case_id="m3-missing")


### PR DESCRIPTION
## Summary

- Add an original, bounded adversarial parser-assurance laboratory for semantic and structural invariants.
- Keep the laboratory test-only, source-free, deterministic, and separate from runtime behavior and public APIs.
- Preserve issue ownership boundaries for #87, #103, #104, and #111.

## Validation

- `make all`
- bounded fixed and broad adversarial profiles
- exact-head review and source-free receipt checks

## Scope boundary

This PR does not add runtime dependencies, external parser code, external fixtures, private vault content, or a release claim. It is the first locally qualified layer of the parser-assurance stack and is intentionally opened as a draft for maintainer review.
