### PR TITLE
docs: record external oracle boundary

### DIFF
--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -62,7 +62,7 @@ Markdown source-of-truth model.
 | Existing delivery anchors | #87, #103, #104, #108, #111 are open; #106 and #113 are closed | live GitHub issue reads on 2026-08-16 |
 | Local implementation checkpoint | `8806205c35b104ed65d00a273acc9eeca572ae38` | clean local commit on `agent/parser-assurance-m1`; exact-head tests passed, but independent oracle review rejected publication |
 | M1 delivery | merged | [PR #161](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/161) merged the project-owned compatibility-corpus foundation; it remains only the first #104 tranche |
-| Current milestone | M4 local qualification | code commit `65275cd` above qualified local M3; deterministic, test-only work-growth evidence only; no publication claim |
+| Current milestone | M2 decision recorded; M4 locally qualified | [ADR-001](decisions/ADR-001-external-oracle-boundary.md) records a negative external-oracle decision. M4 code commit `65275cd` and evidence head `19ac996` remain locally qualified test-only work; no publication claim |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
 publication, or qualification.
@@ -442,6 +442,15 @@ converted into a pass or silently added to an allowlist.
   project's intentionally different AST and graph responsibilities are typed.
 - Oracle errors, version drift, and unknown mappings fail closed.
 
+**Recorded decision**
+
+- [ADR-001](decisions/ADR-001-external-oracle-boundary.md) completes M2 with a
+  negative decision. Under the current Apache-2.0 project boundary, no external
+  `mldoc` executable is adopted, installed, invoked, pinned, or integrated.
+  This is a conservative engineering decision, not legal advice. M3 and M4
+  remain project-owned evidence; an M5 implementation may use only
+  project-owned invariants unless a future ADR supersedes this decision.
+
 **Dependencies**
 
 - M1 projection stable; dependency-license inventory; maintainer approval of the
@@ -450,10 +459,11 @@ converted into a pass or silently added to an allowlist.
 
 **Exit evidence**
 
-- Accepted ADR, exact oracle version/hash, documented installation boundary,
-  no package/runtime dependency, original comparison adapter and fixtures, and
-  a reproducible local proof. If rejected, the negative decision is the valid
-  milestone result and M3 continues without an external oracle.
+- If adoption is proposed, an accepted ADR, exact oracle version/hash,
+  documented installation boundary, no package/runtime dependency, original
+  comparison adapter and fixtures, and a reproducible local proof are required.
+  The accepted negative decision in ADR-001 is the current valid milestone
+  result; M3 continues without an external oracle.
 
 **Impact**
 
@@ -759,8 +769,9 @@ It must not replace the requirements in this plan.
   hosted validation and merge remain deferred until explicit user authorization.
 - [ ] The remaining expanded #104 acceptance criteria are proved through the
   dependency-owned #103 and M3 evidence before #104 is closed.
-- [ ] The external-oracle decision is recorded, including a valid negative
-  decision if license or process boundaries are unacceptable.
+- [x] The external-oracle decision is recorded in
+  [ADR-001](decisions/ADR-001-external-oracle-boundary.md): no external oracle
+  is adopted under the current boundary.
 - [x] Adversarial and property-based tests have deterministic replay and bounded
   execution through local exact-head M3 commit `3edbefb`; publication remains a
   separate explicit gate.

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -579,8 +579,9 @@ converted into a pass or silently added to an allowlist.
 
 **Outcome**
 
-- Optional local command evaluates project-owned invariants and, only if M2 is
-  accepted, differential overlap against the external oracle.
+- Optional local command evaluates project-owned invariants and, only if a
+  superseding ADR explicitly approves adoption, differential overlap against an
+  external oracle.
 - Default behavior uploads nothing, excludes graph content from reports, bounds
   files/bytes/time, stores only safe aggregates, and requires explicit opt-in to
   retain minimized snippets.

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ entry points.
 | [`LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md`](LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md) | Maintainers, parser contributors | License-safe comparative study and execution plan for semantic, complexity, and source-location assurance |
 | [`README_READABILITY_REPORT_2026-08-08.md`](README_READABILITY_REPORT_2026-08-08.md) | Maintainers | Measured human and AI README assessment with a phased simplification proposal |
 | [`quality/ISSUE_RECONCILIATION_2026-08-06.md`](quality/ISSUE_RECONCILIATION_2026-08-06.md) | Maintainers, contributors | Evidence-backed disposition of every issue open at the audit baseline |
-| [`decisions/index.md`](decisions/index.md) | Maintainers | Canonical decision registry and ADR gaps |
+| [`decisions/index.md`](decisions/index.md) | Maintainers | Canonical decision registry, including the external-oracle boundary |
 | [`reference/index.md`](reference/index.md) | Maintainers, integrators | Provenance and Matryca ecosystem relations |
 | [`reference/DIAGNOSTICS.md`](reference/DIAGNOSTICS.md) | Integrators, contributors | Stable diagnostic codes, payload schema, path safety, CLI rendering, and escalation |
 | [`reference/FILESYSTEM_SAFETY.md`](reference/FILESYSTEM_SAFETY.md) | Integrators, contributors | Vault containment, atomic replacement, dry-run, metadata, limits, and asset-read policy |

--- a/docs/decisions/ADR-001-external-oracle-boundary.md
+++ b/docs/decisions/ADR-001-external-oracle-boundary.md
@@ -1,0 +1,105 @@
+---
+type: ArchitectureDecisionRecord
+title: External oracle boundary for parser assurance
+description: Declines external mldoc-oracle adoption under the current Apache-2.0 project boundary while preserving project-owned assurance work.
+status: stable
+classification: canonical
+audience: maintainers
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+decision_date: 2026-08-16
+last_verified: 2026-08-16
+verified: 2026-08-16
+stale_after: 2027-02-12
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# ADR-001: External oracle boundary for parser assurance
+
+## Status
+
+Accepted on 2026-08-16. This is a negative M2 decision: the project will not
+adopt an external `mldoc` executable as a parser-assurance oracle under the
+current project boundary.
+
+## Context
+
+The parser-assurance plan permits a separate external oracle only after a
+decision records its license review, process isolation, dependency provenance,
+and publication policy. The project is Apache-2.0 and its assurance artifacts
+must remain project-owned, original, and reproducible without an unreviewed
+external executable.
+
+On 2026-08-16, the public `logseq/logseq` repository identified its license as
+`AGPL-3.0` and its exact `master` revision was
+[`bb096a8fbb991c2906b6f9703460d91fc935a408`](https://github.com/logseq/logseq/tree/bb096a8fbb991c2906b6f9703460d91fc935a408).
+Its [license text](https://github.com/logseq/logseq/blob/bb096a8fbb991c2906b6f9703460d91fc935a408/LICENSE.md)
+is a source observation, not a component-level compatibility determination.
+No exact external executable revision, dependency inventory, installation
+boundary, original adapter, fixture policy, or maintainer-approved process
+boundary has been established for this project.
+
+This ADR is an engineering and project-governance decision, not legal advice.
+It does not decide whether every possible isolated use of an external program
+would be lawful or compatible in every jurisdiction.
+
+## Decision
+
+Do not install, invoke, package, pin, or integrate an external `mldoc`
+executable for parser assurance at this time. In particular, the repository
+must not add:
+
+- an external-oracle runtime, build, package, CI, release, or service
+  dependency;
+- copied or adapted external source, fixtures, expected outputs, schemas,
+  control flow, or documentation; or
+- an external-parity, compatibility, or release-qualification claim.
+
+M2 is therefore complete with a negative decision. M3 and M4 remain valid
+project-owned assurance evidence and require no external oracle. Any future M5
+work may evaluate only project-owned invariants unless this ADR is superseded;
+the existing filesystem-safety and threat-model dependencies still apply.
+
+## Consequences
+
+- Differential evidence level E3 is unavailable. Project-owned corpus,
+  adversarial, and deterministic work-growth evidence remain available.
+- Differences from an external parser are not measured or interpreted by this
+  repository, and no behavioral parity is implied.
+- This decision does not close #104, #87, #103, #111, or #108 and does not
+  change their ownership boundaries.
+- No source code, package metadata, dependencies, CI configuration, tests, or
+  release artifacts change as a result of this ADR.
+
+## Reconsideration and rollback
+
+Supersede this ADR only through a new recorded decision that includes all of
+the following before any external executable is obtained or used:
+
+1. an exact upstream revision and a primary-source license and dependency
+   inventory;
+2. an explicit maintainer-approved process, installation, provenance,
+   privacy, retention, and publication boundary;
+3. original adapter and fixture designs that preserve the clean-room policy and
+   keep external material out of repository artifacts;
+4. a fail-closed treatment for unknown mappings, version drift, oracle errors,
+   and private-vault data; and
+5. qualified legal review if the proposal involves packaging, linking, service
+   deployment, source adaptation, or any other integration beyond the isolated
+   research boundary described in the assurance plan.
+
+Until then, reverting this ADR means returning to the same no-adoption state;
+it does not authorize a temporary local exception.
+
+## Verification evidence
+
+- The upstream repository metadata and license text were inspected read-only
+  at the exact revision named above on 2026-08-16.
+- No external executable was downloaded, installed, run, pinned, or added to
+  this repository.
+- M3 and M4 are preserved as separate, locally qualified, unpublished,
+  project-owned evidence; this ADR makes no publication claim.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -8,8 +8,8 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-07
-verified: 2026-08-07
+last_verified: 2026-08-16
+verified: 2026-08-16
 stale_after: 2027-02-02
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -30,7 +30,7 @@ introduced incrementally. Do not rewrite historical roadmaps into ADRs.
 | Writer/watcher concurrency | [Issue #103](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/103) | Proposed |
 | Filesystem confinement | [Issue #106](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/106) | Proposed |
 | Public API stability | [`reference/API_STABILITY.md`](../reference/API_STABILITY.md) | Contract recorded; wheel enforcement published in [PR #117](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/117) |
-| Parser assurance and external oracle boundary | [`LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md`](../LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md) | Execution boundary recorded; external-oracle ADR pending M2 |
+| Parser assurance and external oracle boundary | [`ADR-001-external-oracle-boundary.md`](ADR-001-external-oracle-boundary.md) | Accepted negative M2 decision; no external oracle under the current boundary |
 | Documentation lifecycle and MKQ | [`DOCUMENTATION_SYSTEM.md`](../DOCUMENTATION_SYSTEM.md) | Source contract recorded; MKQ-4 enforcement and private profile activation pending under issue #109 |
 
 Every future ADR must identify owner, status, decision date, supersession links,

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -42,6 +42,14 @@ release qualification. A new regression fixture is allowed only after a
 minimized original input has been reviewed for provenance, privacy, and
 licensing.
 
+M2 is complete through the accepted negative
+[ADR-001](../decisions/ADR-001-external-oracle-boundary.md): no external
+`mldoc` executable may be installed, invoked, pinned, packaged, or integrated
+under the current boundary. The ADR is a conservative engineering decision, not
+legal advice. M3 and M4 remain project-owned evidence. Any future M5 work may
+use only project-owned invariants unless a superseding ADR meets every listed
+reconsideration condition, including a maintainer-approved process boundary.
+
 Before any push or pull request, re-verify the live base, freeze the raw full
 diff, qualify its exact head, obtain an independent GPT-5.6 Sol full-patch
 review, adjudicate every finding, and stop before publication unless separately

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ navigation layers only.
 | [Parser assurance extension](LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md) | License-safe comparative study and dependency-ordered semantic and complexity plan |
 | [README readability report](README_READABILITY_REPORT_2026-08-08.md) | Measured human and AI readability assessment and phased proposal |
 | [Issue reconciliation](quality/ISSUE_RECONCILIATION_2026-08-06.md) | Current GitHub backlog decisions |
-| [Decision index](decisions/index.md) | Architectural decisions and missing ADRs |
+| [Decision index](decisions/index.md) | Architectural decisions, including the external-oracle boundary |
 | [Reference index](reference/index.md) | Provenance and external relations |
 | [Structured diagnostics](reference/DIAGNOSTICS.md) | Stable diagnostic schema, codes, path safety, rendering, and escalation |
 | [Filesystem safety](reference/FILESYSTEM_SAFETY.md) | Vault containment, atomic write, dry-run, metadata, and asset-read policy |

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,6 +21,15 @@ superseded_by: null
 
 ## 2026-08-16
 
+- Recorded accepted negative M2 decision
+  [ADR-001](decisions/ADR-001-external-oracle-boundary.md). The repository will
+  not install, invoke, pin, package, or integrate an external `mldoc`
+  executable under the current Apache-2.0 project boundary. The decision is a
+  conservative engineering and governance boundary, not legal advice; it
+  preserves M3/M4 as project-owned evidence and leaves M5 limited to
+  project-owned invariants unless a later ADR satisfies explicit reconsideration
+  conditions. No external executable was downloaded or run, and no source,
+  dependency, CI, release, issue-ownership, push, PR, or merge claim is made.
 - Started M4 from the locally qualified, unpublished M3 commit `3edbefb`.
   M4 is test-only and counts declared Python-owned parser operations across
   fixed size-scaled synthetic families. It treats platform-labelled elapsed

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -29,6 +29,7 @@ maintained_documents = [
   "docs/quality/ISSUE_RECONCILIATION_2026-08-06.md",
   "docs/quality/README.md",
   "docs/decisions/index.md",
+  "docs/decisions/ADR-001-external-oracle-boundary.md",
   "docs/reference/index.md",
   "docs/reference/API_STABILITY.md",
   "docs/reference/DIAGNOSTICS.md",


### PR DESCRIPTION
## Summary

- Record ADR-001 for the external parser-oracle boundary.
- Decline external `mldoc` adoption under the current Apache-2.0 project boundary.
- Preserve M3/M4 as project-owned evidence and define exact conditions for any future reconsideration.
- Align the parser-assurance plan, persistent goal, decision index, maintained-document registry, and documentation log.

## Validation

- `make all` — 600 tests passed
- documentation and vendor-name checks
- exact-head diff check
- zero source import cycles
- final GPT-5.6 Sol corrective re-review: `FINAL PASS`

## Scope boundary

This PR changes documentation only. It does not install or run an external oracle, add dependencies, alter runtime behavior, claim external parity, or qualify a release. It is stacked on draft PR #163 and should be reviewed after the lower layers.
