### PR TITLE
docs: align source bundle with official OKF v0.2

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Logseq Matryca Parser — Architecture (The Logos Protocol)
 
 **Audience:** contributors, integrators, and operators  

--- a/docs/BUG_HUNT_REPORT.md
+++ b/docs/BUG_HUNT_REPORT.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Bug Hunt Report — logseq-matryca-parser
 
 **Date:** 2026-06-23 (audit) · **Resolution:** 2026-06-23

--- a/docs/CODEQL.md
+++ b/docs/CODEQL.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # CodeQL code scanning
 
 **Logseq Matryca Parser** (v1.6.0+) uses **GitHub CodeQL default setup** for static analysis (SAST) on Python.

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Integration cookbook
 
 Copy-paste recipes for common **Logseq Matryca Parser** workflows. All snippets assume you installed the package and synced extras:

--- a/docs/GOOD_FIRST_ISSUES.md
+++ b/docs/GOOD_FIRST_ISSUES.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Good First Issues
 
 Welcome! These tasks are scoped for a **first pull request** — mostly tests and documentation, with a few small CLI/FORGE features. Each has clear acceptance criteria and avoids changes to `logos_core.py` without prior design discussion.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Release process
 
 **Logseq Matryca Parser** (The Logos Protocol · Marco Porcellato · [Matryca.ai](https://matryca.ai)) uses a **curated** [`CHANGELOG.md`](../CHANGELOG.md) (Keep a Changelog). Pushing a `v*` git tag triggers one ordered, fail-closed release workflow:

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,22 +1,3 @@
----
-type: DecisionIndex
-title: Architecture decision index
-description: Canonical registry of architectural decisions and required ADRs.
-status: draft
-classification: canonical
-audience: maintainers
-owner: logseq-matryca-parser
-authority: source_repository
-execution_mode: reviewed
-last_verified: 2026-08-16
-verified: 2026-08-16
-stale_after: 2027-02-02
-okf_profile: matryca_okf_inspired_quality
-okf_spec_version: null
-supersedes: null
-superseded_by: null
----
-
 # Architecture decision index
 
 The existing architecture guides remain authoritative while formal ADRs are

--- a/docs/design-docs/ARCHITECTURE_BLUEPRINT.md
+++ b/docs/design-docs/ARCHITECTURE_BLUEPRINT.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 > **Note for Contributors:** This document is part of the original *Document-Driven Development* phase. It was generated as a structural blueprint during the initial scaffolding of the Logos Protocol. It is preserved here for historical context and to explain the initial design intent. For the current, active architecture, please refer to the main `ARCHITECTURE.md` at the root of the `/docs` folder.
 
 # Logseq Sovereign Parser - Architectural Blueprint

--- a/docs/design-docs/CODE_SCAFFOLD.md
+++ b/docs/design-docs/CODE_SCAFFOLD.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 > **Note for Contributors:** This document is part of the original *Document-Driven Development* phase. It was generated as a structural blueprint during the initial scaffolding of the Logos Protocol. It is preserved here for historical context and to explain the initial design intent. For the current, active architecture, please refer to the main `ARCHITECTURE.md` at the root of the `/docs` folder.
 
 # 1. VISITOR INTERFACE (From Blueprint)

--- a/docs/design-docs/LOGSEQ_ASSET_RESOLUTION_SPEC.md
+++ b/docs/design-docs/LOGSEQ_ASSET_RESOLUTION_SPEC.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 > **Note for Contributors:** This document is part of the original *Document-Driven Development* phase. It was generated as a structural blueprint during the initial scaffolding of the Logos Protocol. It is preserved here for historical context and to explain the initial design intent. For the current, active architecture, please refer to the main `ARCHITECTURE.md` at the root of the `/docs` folder.
 >
 > **Implementation (v1.2.0+):** Runtime asset harvesting and resolution live in `LogseqNode.assets`, `LogseqPage.resolve_asset_path`, and `_extract_assets` in `logos_parser.py` — see [Architecture §3.1 — Asset extraction](../ARCHITECTURE.md#asset-extraction-and-path-resolution).

--- a/docs/design-docs/LOGSEQ_DATASCRIPT_MAPPING.md
+++ b/docs/design-docs/LOGSEQ_DATASCRIPT_MAPPING.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 > **Note for Contributors:** This document is part of the original *Document-Driven Development* phase. It was generated as a structural blueprint during the initial scaffolding of the Logos Protocol. It is preserved here for historical context and to explain the initial design intent. For the current, active architecture, please refer to the main `ARCHITECTURE.md` at the root of the `/docs` folder.
 
 # **LOGSEQ\_DATASCRIPT\_MAPPING.md**

--- a/docs/design-docs/LOGSEQ_TEMPORAL_ONTOLOGY.md
+++ b/docs/design-docs/LOGSEQ_TEMPORAL_ONTOLOGY.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 > **Note for Contributors:** This document is part of the original *Document-Driven Development* phase. It was generated as a structural blueprint during the initial scaffolding of the Logos Protocol. It is preserved here for historical context and to explain the initial design intent. For the current, active architecture, please refer to the main `ARCHITECTURE.md` at the root of the `/docs` folder.
 
 # **LOGSEQ\_TEMPORAL\_ONTOLOGY.md**

--- a/docs/design-docs/OFFICIAL_MLDOC_SPECS.md
+++ b/docs/design-docs/OFFICIAL_MLDOC_SPECS.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 > **Note for Contributors:** This document is part of the original *Document-Driven Development* phase. It was generated as a structural blueprint during the initial scaffolding of the Logos Protocol. It is preserved here for historical context and to explain the initial design intent. For the current, active architecture, please refer to the main `ARCHITECTURE.md` at the root of the `/docs` folder.
 
 # **LOGSEQ\_OFFICIAL\_TESTS.md**

--- a/docs/design-docs/README.md
+++ b/docs/design-docs/README.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 > ⚠️ **Notice:** For the active documentation index, please refer to the main [README.md](../../README.md).
 
 # Historical design documents

--- a/docs/design-docs/REFERENCE_SPEC.md
+++ b/docs/design-docs/REFERENCE_SPEC.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 > **Note for Contributors:** This document is part of the original *Document-Driven Development* phase. It was generated as a structural blueprint during the initial scaffolding of the Logos Protocol. It is preserved here for historical context and to explain the initial design intent. For the current, active architecture, please refer to the main `ARCHITECTURE.md` at the root of the `/docs` folder.
 
 # Technical Reference for Logos Parser (Extracted from Blueprint)

--- a/docs/error_log.md
+++ b/docs/error_log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## [2026-04-24] Static Analysis & Linter Refactoring (Mypy / Pylance / Ruff)
 
 ### Module: `kinetic.py`

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
 superseded_by: null
+okf_version: "0.2"
 ---
 
 # Logseq Matryca Parser knowledge bundle

--- a/docs/internal/LOCAL_CODE_STUDY.md
+++ b/docs/internal/LOCAL_CODE_STUDY.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Local Code Audit — Maintainer Runbook (audit code)
 
 **Audience:** repository maintainers with a local Cursor / MCP setup  

--- a/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
+++ b/docs/internal/M1A_CORRECTIVE_HARDENING_RESTART_HANDOFF_2026-08-16.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # M1-B post-correction pre-push handoff — 2026-08-16
 
 ## Safe resume point

--- a/docs/internal/STATIC_ANALYSIS_POLICY.md
+++ b/docs/internal/STATIC_ANALYSIS_POLICY.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Matryca.ai Policy: Ghost Tooling & Static Analysis
 
 ## 1. Context and Risk (Restrictive Licenses)

--- a/docs/logseq_ast_primer.md
+++ b/docs/logseq_ast_primer.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 🧠 Logseq AST Primer: Understanding Spatial Markdown and the Logos Protocol
 
 To contribute to or understand the **Logos Protocol**, you must first understand the idiosyncratic nature of Logseq's data structure. 

--- a/docs/quality/CLEAN_ARCH_BACKLOG.md
+++ b/docs/quality/CLEAN_ARCH_BACKLOG.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Clean Architecture — Residual Backlog
 
 **Status:** 2026-07-02 · post **v1.6.0** (structural v1 **complete**)  

--- a/docs/quality/GITHUB_CLEAN_ARCH_ROADMAP.md
+++ b/docs/quality/GITHUB_CLEAN_ARCH_ROADMAP.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub roadmap — Clean Architecture v1.6
 
 **Status:** 2026-07-02 · **v1.6.0 shipped** — close milestone after tag `v1.6.0`  

--- a/docs/quality/ISSUE_TRIAGE_2026-07.md
+++ b/docs/quality/ISSUE_TRIAGE_2026-07.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Issue triage — July 2026
 
 **Date:** 2026-07-02  

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,22 +1,3 @@
----
-type: ReferenceIndex
-title: Reference and provenance index
-description: Canonical external relations and immutable provenance for maintained documentation.
-status: stable
-classification: canonical
-audience: maintainers
-owner: logseq-matryca-parser
-authority: source_repository
-execution_mode: reviewed
-last_verified: 2026-08-07
-verified: 2026-08-07
-stale_after: 2027-02-02
-okf_profile: matryca_okf_inspired_quality
-okf_spec_version: null
-supersedes: null
-superseded_by: null
----
-
 # Reference and provenance index
 
 ## Matryca relations

--- a/docs/rfc/OLLAMA_RAG.md
+++ b/docs/rfc/OLLAMA_RAG.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # RFC: Ollama one-click local RAG
 
 > **Status:** Draft placeholder — full design tracked in [GitHub issue #34](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/34). Contributions welcome.

--- a/docs/roadmaps/ROADMAP_AGENT_NATIVE_XRAY.md
+++ b/docs/roadmaps/ROADMAP_AGENT_NATIVE_XRAY.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: Agent-Native "Printing Press" & X-Ray Mode
 
 **Contract Status:** Wave 11 — executed (suite green)

--- a/docs/roadmaps/ROADMAP_CLI_HYDRATION_AND_ENRICHMENT.md
+++ b/docs/roadmaps/ROADMAP_CLI_HYDRATION_AND_ENRICHMENT.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: CLI Graph Integration & Metadata Hydration
 
 **Contract Status:** Executed (Wave 5 — green pipeline)

--- a/docs/roadmaps/ROADMAP_CONTEXT_SYNTHESIS_AND_SCOPING.md
+++ b/docs/roadmaps/ROADMAP_CONTEXT_SYNTHESIS_AND_SCOPING.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: Context-Enriched Chunking & Scoping Priority Shadowing
 **Contract Status:** Wave 4 — executed
 **Target Stack:** Python 3.12+ | Pydantic V2 | Local-First No-DB

--- a/docs/roadmaps/ROADMAP_EMBED_EXPANSION_AND_FLUENT_QUERIES.md
+++ b/docs/roadmaps/ROADMAP_EMBED_EXPANSION_AND_FLUENT_QUERIES.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Architectural Contract: Recursive Embed Transclusion & Fluent Topological Queries
 
 **Contract Status:** Wave 6 — executed (suite green)

--- a/docs/roadmaps/ROADMAP_GRAPH_RAG_SEMANTICS.md
+++ b/docs/roadmaps/ROADMAP_GRAPH_RAG_SEMANTICS.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: Graph-Wide Backlinks & Property Inheritance
 **Contract Status:** Complete — Wave 2 executed (autonomous implementation verified)
 **Target Stack:** Python 3.12+ | Pydantic V2 (Strict/Frozen Models) | Local-First No-DB

--- a/docs/roadmaps/ROADMAP_HEADLESS_WRITER.md
+++ b/docs/roadmaps/ROADMAP_HEADLESS_WRITER.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: Headless Write Engine & AST Linters
 **Contract Status:** Wave 12 — executed (suite green)
 **Target Stack:** Python 3.12+ | Pydantic V2

--- a/docs/roadmaps/ROADMAP_INCREMENTAL_WATCHER.md
+++ b/docs/roadmaps/ROADMAP_INCREMENTAL_WATCHER.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: Live Incremental Invalidation & File Watcher
 **Contract Status:** Wave 7 — Implemented (incremental invalidation + lazy watchdog watcher)
 

--- a/docs/roadmaps/ROADMAP_INLINE_SHIELD_AND_NAMESPACES.md
+++ b/docs/roadmaps/ROADMAP_INLINE_SHIELD_AND_NAMESPACES.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: Inline Token Shielding & Namespace Hierarchy Resolution
 **Contract Status:** Executed (Wave 3 — green `make check` + pytest)
 **Target Stack:** Python 3.12+ | Pydantic V2 | Local-First No-DB

--- a/docs/roadmaps/ROADMAP_OBSIDIAN_ADAPTER.md
+++ b/docs/roadmaps/ROADMAP_OBSIDIAN_ADAPTER.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: Obsidian Vault Native Compiler
 
 **Contract Status:** Delivered (Wave 10)  

--- a/docs/roadmaps/ROADMAP_ROBUSTNESS_AND_SOFT_BREAKS.md
+++ b/docs/roadmaps/ROADMAP_ROBUSTNESS_AND_SOFT_BREAKS.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: Lenient Indentation & Multiline Soft-Breaks
 **Contract Status:** Wave 9 — Implemented (lenient indent + soft-break accumulator)
 **Target Stack:** Python 3.12+ | Pydantic V2 | Pytest

--- a/docs/roadmaps/ROADMAP_TOML_FIX_AND_PYPI_DISTRIBUTION.md
+++ b/docs/roadmaps/ROADMAP_TOML_FIX_AND_PYPI_DISTRIBUTION.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Architectural Contract: TOML Hotfix, Dynamic Versioning & PyPI Distribution Setup
 
 **Contract Status:** Completed (Wave 8 — validated locally)

--- a/docs/roadmaps/ROADMAP_UUID_AND_GRAPH_SUPERPOWERS.md
+++ b/docs/roadmaps/ROADMAP_UUID_AND_GRAPH_SUPERPOWERS.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # 📜 Architectural Contract: Synthetic UUID Hardening & Graph Orchestration Module
 **Contract Status:** Completed (Autonomous Execution)
 

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -206,6 +206,10 @@ def _validate_links(path: Path, root: Path, text: str, findings: list[Finding], 
                 findings.append(Finding(source, line_number, "DOC_ANCHOR_MISSING", f"local anchor does not exist: {raw}"))
 
 
+def _is_reserved_nested_index(relative: str, text: str) -> bool:
+    return relative.endswith("/index.md") and relative != "docs/index.md" and not text.lstrip().startswith("---")
+
+
 def check(root: Path, profile: Path, as_of: date) -> list[Finding]:
     root = root.resolve()
     documents, required = _profile(profile)
@@ -222,12 +226,15 @@ def check(root: Path, profile: Path, as_of: date) -> list[Finding]:
         if not path.is_file():
             findings.append(Finding(relative, 1, "DOC_PATH_MISSING", "maintained document is not a file"))
             continue
+        text = path.read_text(encoding="utf-8")
+        if _is_reserved_nested_index(relative, text):
+            _validate_links(path, root, text, findings, anchor_cache)
+            continue
         metadata = _frontmatter(path, root, findings)
         if metadata is None:
             continue
         source = _relative(path, root)
         _validate_metadata(metadata, source, required, as_of, findings)
-        text = path.read_text(encoding="utf-8")
         _validate_links(path, root, text, findings, anchor_cache)
         if metadata.get("classification") == "canonical" and (doc_type := metadata.get("type")):
             canonical.setdefault(doc_type, []).append(source)


### PR DESCRIPTION
## Summary\n- apply the deterministic official OKF v0.2 source migration\n- preserve document bodies and existing Matryca metadata\n- align the local documentation validator with reserved nested-index semantics\n\n## Evidence\n- exact head: b75d2a7\n- official OKF v0.2 and Matryca maintained-profile migration; docs-check PASS; diff-check PASS; reserved nested-index policy aligned\n\nSource repositories remain authoritative; generated Knowledge projections are refreshed only after merge.