### PR TITLE
docs(parser): define source-location contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- Define and regress the existing one-based source-line contract across Unicode
+  text and CRLF input. The accepted M6 decision retains line-only
+  parse-snapshot locations and adds no offset API or parser behavior change.
 - Add a deterministic, test-only parser work-growth laboratory with fixed
   size-scaled synthetic cases, semantic and structural gates, source-free
   receipts, and non-gating platform observations. No runtime API or performance

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -608,13 +608,22 @@ converted into a pass or silently added to an allowlist.
 
 ### M6 — Source-location RFC and prototype
 
+**Recorded decision**
+
+- [`SOURCE_LOCATION_RFC.md`](rfc/SOURCE_LOCATION_RFC.md) accepts the existing
+  one-based logical line fields as the supported coordinate system and rejects
+  a new offset/source-map prototype for the current release line. The decision
+  is based on diagnostics, bounded writer splicing, and SYNAPSE lineage as the
+  concrete current consumers. It does not alter the stable API or parser.
+
 **Outcome**
 
 - Decide whether consumers need byte offsets, code-point offsets, line/column
   ranges, or a separate source-map object.
 - Define newline, Unicode, transformed text, provenance, serialization, and
   stale-range behavior.
-- Prototype behind an experimental API without changing stable node fields.
+- Do not prototype a new API unless the future admission gate in the RFC is
+  satisfied; retaining the existing line-only contract is the current outcome.
 
 **Dependencies**
 
@@ -622,8 +631,9 @@ converted into a pass or silently added to an allowlist.
 
 **Exit evidence**
 
-- Accepted or rejected RFC; non-ASCII and CR/LF tests; safe slicing behavior;
-  round-trip and writer compatibility; performance measurement.
+- Accepted or rejected RFC; non-ASCII and CR/LF line-contract tests; existing
+  safe writer slicing and consumer compatibility evidence; and a new measured
+  impact only if a future coordinate expansion is admitted.
 
 **Impact**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ entry points.
 | [`decisions/ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md`](decisions/ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md) | Maintainers, documentation reviewers | Decision to preserve the measured official OKF backlog until profile conflicts are resolved |
 | [`decisions/ADR-0003-AAIF-SUBMISSION-GATE.md`](decisions/ADR-0003-AAIF-SUBMISSION-GATE.md) | Maintainers, legal reviewers | Evidence-based NO-GO and reconsideration gate for any AAIF submission |
 | [`reference/LOCAL_GRAPH_ASSURANCE.md`](reference/LOCAL_GRAPH_ASSURANCE.md) | Integrators, maintainers | Bounded aggregate-only local vault assurance, report schema, and privacy boundary |
+| [`rfc/SOURCE_LOCATION_RFC.md`](rfc/SOURCE_LOCATION_RFC.md) | Maintainers, integrators | Accepted logical-line source-location contract and future expansion gate |
 | [`log.md`](log.md) | Maintainers | Maintained documentation chronology |
 | [`rfc/OLLAMA_RAG.md`](rfc/OLLAMA_RAG.md) | Integrators | Draft RFC for local Ollama RAG (issue [#34](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/34)) |
 | [`roadmaps/`](roadmaps/) | Historians | Executed architectural contracts (Waves 2–12) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ navigation layers only.
 | [Structured diagnostics](reference/DIAGNOSTICS.md) | Stable diagnostic schema, codes, path safety, rendering, and escalation |
 | [Filesystem safety](reference/FILESYSTEM_SAFETY.md) | Vault containment, atomic write, dry-run, metadata, and asset-read policy |
 | [Local graph assurance](reference/LOCAL_GRAPH_ASSURANCE.md) | Bounded aggregate-only vault checks with no report persistence or network operation |
+| [Source-location decision](rfc/SOURCE_LOCATION_RFC.md) | Accepted logical-line coordinate contract and offset-expansion admission gate |
 | [Documentation log](log.md) | Chronology of maintained knowledge changes |
 
 ## Root governance and support

--- a/docs/log.md
+++ b/docs/log.md
@@ -53,6 +53,13 @@ superseded_by: null
   workflow, settings, and release receipts remain separate gates.
 ## 2026-08-18
 
+- Recorded the accepted [source-location contract decision](rfc/SOURCE_LOCATION_RFC.md).
+  Existing one-based `line_start`/`line_end` fields remain the supported
+  parse-snapshot coordinates for diagnostics, bounded writer splicing, and
+  SYNAPSE lineage. CRLF and Unicode line behavior is now covered directly. No
+  byte, code-point, column, range, source-map, parser, public-API, dependency,
+  or release change is claimed; a future expansion needs the RFC admission
+  gate.
 - Recorded [ADR-002](decisions/ADR-002-local-graph-assurance-boundary.md) and
   the [local graph assurance reference](reference/LOCAL_GRAPH_ASSURANCE.md) for
   M5. The optional `matryca-parse assure` command is bounded and local-only: it

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -48,5 +48,6 @@ maintained_documents = [
   "docs/reference/FILESYSTEM_SAFETY.md",
    "docs/security/DAILY_METRICS_THREAT_MODEL.md",
    "docs/reference/LOCAL_GRAPH_ASSURANCE.md",
+   "docs/rfc/SOURCE_LOCATION_RFC.md",
   "docs/log.md",
 ]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -68,6 +68,7 @@ already been refreshed.
 - [Dependency, license, SBOM, and provenance policy](DEPENDENCY_LICENSE_POLICY.md)
 - [Daily metrics threat model](../security/DAILY_METRICS_THREAT_MODEL.md)
 - [Privacy-safe local graph assurance](LOCAL_GRAPH_ASSURANCE.md)
+- [Source-location decision](../rfc/SOURCE_LOCATION_RFC.md)
 - [Architecture](../CLEAN_CODE_ARCHITECTURE.md)
 - [AST primer](../logseq_ast_primer.md)
 - [Release process](../RELEASE_PROCESS.md)

--- a/docs/rfc/SOURCE_LOCATION_RFC.md
+++ b/docs/rfc/SOURCE_LOCATION_RFC.md
@@ -1,0 +1,94 @@
+---
+type: SourceLocationRFC
+title: Source-location contract decision
+description: Retains logical line locations as the supported source coordinate system and defers byte and column offsets until a named consumer requires them.
+status: stable
+classification: canonical
+audience: maintainers
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-08-18
+verified: 2026-08-18
+stale_after: 2027-02-18
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+decision_date: 2026-08-18
+---
+
+# Source-location contract decision
+
+## Status
+
+Accepted on 2026-08-18. M6 records a deliberately small source-location
+contract and rejects a new byte-, code-point-, or column-offset prototype for
+the current release line.
+
+## Context
+
+The parser already attaches `line_start` and `line_end` to every
+`LogseqNode`. Three maintained consumers rely on those logical line locations:
+
+- structured diagnostics expose a one-based `Diagnostic.line` while preserving
+  vault-relative path safety;
+- the bounded writer uses the deepest `line_end` to choose its safe splice
+  insertion point; and
+- SYNAPSE includes `line_start` in lineage metadata for downstream retrieval.
+
+These consumers need a stable human-readable position, not a character-level
+editor protocol. Adding offsets now would require resolving byte encoding,
+Unicode scalar/code-point/grapheme semantics, CR/LF normalization, transformed
+content, serialization drift, and stale-source behavior without a named
+consumer that can prove the added compatibility and maintenance cost.
+
+## Decision
+
+Retain the existing logical line model as the only supported source coordinate:
+
+| Field | Contract |
+|---|---|
+| `LogseqNode.line_start` | One-based inclusive logical line where the node begins. |
+| `LogseqNode.line_end` | One-based inclusive logical line through the node's parsed properties, continuation text, fenced/query regions, and other absorbed lines. |
+| `LogseqNode.source_path` | Parser-source path when the parse entry point has one; consumers exposing diagnostics must normalize it to a vault-relative POSIX path. |
+
+`StackMachineParser.parse()` enumerates logical input lines. CRLF is treated as
+one logical line break; Unicode content does not change line counting. These
+locations are parse-snapshot metadata, not durable editor anchors: after a
+source file changes, a consumer must reload/reparse before using a location.
+
+Do not add public byte offsets, code-point offsets, columns, ranges, or a
+source-map object in this milestone. The existing fields stay unchanged and
+their semantics are clarified by regression tests only; no package-root API,
+serialization schema, parser algorithm, or runtime dependency changes.
+
+## Evidence
+
+- `tests/test_logos_parser.py` proves one-based start/end lines across Unicode
+  content and CRLF input, including absorbed property and continuation lines.
+- Existing deep-refresh tests prove that `line_end` advances with soft breaks
+  and property families.
+- Existing writer tests prove that a parsed `line_end` drives a bounded child
+  splice, including a source lacking its final newline.
+- Existing diagnostics and SYNAPSE tests prove the current line metadata is
+  exposed to their respective consumers.
+
+## Non-goals and future admission gate
+
+This is not a promise of precise ranges into transformed `content` or
+`clean_text`, editor selection behavior, UTF-8 byte slicing, or stable
+locations across watcher refreshes and writes. A future expansion requires all
+of the following:
+
+1. a named downstream consumer with a concrete failure that line locations
+   cannot solve;
+2. an accepted successor RFC defining coordinates, newline and Unicode rules,
+   stale-range semantics, serialization provenance, and memory budget;
+3. focused non-ASCII, CRLF, malformed-input, parse/serialize/reparse, writer,
+   and consumer compatibility tests; and
+4. measured parser and graph impact with no regression of the existing line
+   contract.
+
+Until then, use node UUIDs and outline paths for identity and `line_start` /
+`line_end` only for the parse snapshot that produced them.

--- a/tests/test_logos_parser.py
+++ b/tests/test_logos_parser.py
@@ -1323,6 +1323,24 @@ def test_parser_strips_carriage_return_from_windows_edited_graph(parser: StackMa
     assert "\r" not in root.properties["status"]
 
 
+def test_line_locations_use_logical_one_based_lines_for_unicode_crlf(
+    parser: StackMachineParser,
+) -> None:
+    """Existing line locations remain safe across Unicode text and CRLF input."""
+    page = parser.parse(
+        "- Café 🙂\r\n"
+        "  status:: open\r\n"
+        "  continuation 東京\r\n"
+        "- Next\r\n",
+        page_title="source-location-crlf",
+    )
+    first, second = page.root_nodes
+
+    assert (first.line_start, first.line_end) == (1, 3)
+    assert (second.line_start, second.line_end) == (4, 4)
+    assert "\r" not in first.content
+
+
 def test_resolve_asset_path_nested_namespace_page(tmp_path: Path) -> None:
     """Nested namespace pages resolve ../assets links from graph root."""
     graph_root = tmp_path / "graph"


### PR DESCRIPTION
## Summary

Adds the M6 source-location decision tranche on top of M5 PR #168.

- add the source-location RFC covering offsets, line/column ranges, Unicode, CRLF, transformed text, provenance, stale ranges, serialization, and performance
- add the CRLF source-location regression contract
- keep the API experimental and deferred; no stable node-field or runtime behavior change
- update maintained documentation and the assurance plan

## Stack

This PR is intentionally based on `agent/parser-privacy-assurance-m5-next` and should be reviewed after or together with PR #168. M7 parser phase extraction remains separate.

## Validation

- `make all`
- 642 tests passed
- mypy passed on 68 files
- documentation and vendor-name checks passed
- exact stacked diff check passed