### PR TITLE
refactor(parser): extract internal line classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   graph checks, and a source-location RFC. No AGPL source, tests, corpora,
   schemas, or documentation were copied or adapted.
 
+### Changed
+
+- **Internal line classification (#165 M7)** — route the existing parser loop
+  through a private, immutable syntax event while retaining the stack reducer,
+  AST construction, semantic enrichment, identities, public API, and
+  dependencies. The change is covered by focused parser, corpus, adversarial,
+  and deterministic work-growth tests; it makes no benchmark or release claim.
+
 ### Fixed
 
 - **Diagnostic dependency boundary** — replaced the graph module's type-only

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -645,6 +645,17 @@ converted into a pass or silently added to an allowlist.
 
 ### M7 — Parser phase extraction under frozen evidence
 
+**Current tranche**
+
+- [Issue #165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165)
+  records the first intentionally narrow implementation slice: a private,
+  pure line-classification event. Local code commit `f8c3f65` reuses the event
+  within `StackMachineParser.parse()` while leaving state reduction, node
+  creation, identity registration, semantic enrichment, package exports, and
+  dependencies unchanged. It passed focused parser, compatibility-corpus,
+  adversarial, and deterministic work-growth gates locally. This is not a
+  publication, performance, release, or #108-closure claim.
+
 **Outcome**
 
 - Resume [#108](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/108)
@@ -832,3 +843,5 @@ Completion is unproven until every applicable item has authoritative evidence.
 | 2026-08-18 | M2–M4 controlled publication | merged | M3, M4, and M2 merged through [PR #162](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/162), [PR #163](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/163), and [PR #164](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/164), yielding `main` commits `172be70`, `5d38e01`, and `98bc5aa`. This updates the delivery state only; it does not close #104, #103, #87, #111, or #108. |
 | 2026-08-18 | M5 local graph assurance `41486b3` | local implementation checkpoint | An isolated branch based on `main@27d0061` adds a fresh-worker `assure` CLI command, file/byte/timeout bounds, symlink rejection, ordinary-socket denial, project-owned structure and reference checks, a fixed aggregate-only report schema, and a synthetic self-test. The current head validates nested report fields, rejects unknown finding codes and invalid direct limit values, and rechecks the total byte bound while reading. It remains local only; exact-head qualification, independent review, hosted checks, PR, merge, and release remain separate gates. |
 | 2026-08-18 | M5 direct final review and correction `e2d0e5a` | locally qualified; publication pending | Direct full-patch review reproduced four fail-closed defects: arbitrary runtime strings passed report validation, symlink-loop inputs produced path-bearing parent tracebacks, dangling `pages/` links could pass, and global graph input was ignored by `--self-test`. Non-amending corrections bind reports to exact runtime labels and parent limits, preserve invalid-root handling inside the worker, reject dangling root links, and enforce self-test isolation. The corrected code head passed 622 tests plus Ruff, mypy, documentation, vendor, coverage, and diff gates. No P0/P1/P2 finding remains in the reviewed local patch; live-base refresh, push authorization, hosted checks, PR, merge, and release remain separate gates. |
+ | 2026-08-18 | M6 source-location decision `7bf5c6d` | local documentation and regression checkpoint | The accepted source-location RFC retains the existing one-based logical line contract for diagnostics, writer splicing, and SYNAPSE lineage. A CRLF/Unicode regression covers line positions. Byte, code-point, column, range, and source-map expansion is rejected until a named consumer meets the RFC admission gate. No parser or public API change is claimed. |
+ | 2026-08-18 | M7 line classifier / #165 `f8c3f65` | local implementation checkpoint | A fresh impact review classified `_refresh_node` as HIGH risk and created [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165). The first slice adds a private pure syntax event and routes the existing parser through it without extracting state reduction or semantic enrichment. Focused parser, corpus, adversarial, and work-growth checks pass locally; independent review, exact-head full qualification, hosted checks, PR, merge, and release remain separate gates. |

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -42,6 +42,14 @@ content, paths, titles, UUIDs, exception text, or host names; it must not claim
 #103 incremental/cold-load equivalence, #87 or #111 performance evidence,
 external-oracle parity, release qualification, or closure of #104/#108.
 
+M6 has an accepted local source-location RFC at `7bf5c6d`: existing one-based
+logical line fields remain the only supported coordinates, while offset and
+source-map expansion stays behind its admission gate. M7 begins at local code
+checkpoint `f8c3f65` for [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165),
+the private line-classification extraction. It preserves parser state reduction,
+node creation, identities, graph behavior, public imports, and dependencies;
+publication and review gates remain independent of M5.
+
 M2 is complete through the accepted negative
 [ADR-001](../decisions/ADR-001-external-oracle-boundary.md): no external
 `mldoc` executable may be installed, invoked, pinned, packaged, or integrated

--- a/docs/log.md
+++ b/docs/log.md
@@ -53,6 +53,13 @@ superseded_by: null
   workflow, settings, and release receipts remain separate gates.
 ## 2026-08-18
 
+- Created [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165)
+  after an impact review of the parser hub and locally implemented its first M7
+  slice: a private pure line-classification event. The reducer, AST creation,
+  semantic enrichment, deterministic identities, public imports, and
+  dependencies remain unchanged. Parser, corpus, adversarial, and work-growth
+  gates passed locally; no publication, benchmark, release, or #108-closure
+  claim is made.
 - Recorded the accepted [source-location contract decision](rfc/SOURCE_LOCATION_RFC.md).
   Existing one-based `line_start`/`line_end` fields remain the supported
   parse-snapshot coordinates for diagnostics, bounded writer splicing, and

--- a/src/logseq_matryca_parser/logos_parser.py
+++ b/src/logseq_matryca_parser/logos_parser.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -90,6 +91,50 @@ logger = logging.getLogger(__name__)
 def _sanitize_line(raw_line: str) -> str:
     """Strip stray CR bytes from Windows-edited graph lines before tokenization."""
     return raw_line.rstrip("\r")
+
+
+@dataclass(frozen=True)
+class _LineClassification:
+    """Private syntax signals for one sanitized logical parser input line."""
+
+    raw_line: str
+    stripped_line: str
+    bullet_match: re.Match[str] | None
+    heading_match: re.Match[str] | None
+    property_match: re.Match[str] | None
+    yaml_property_match: re.Match[str] | None
+    collapsed_match: re.Match[str] | None
+    is_blank: bool
+    is_system_block: bool
+    is_yaml_delimiter: bool
+    is_code_fence: bool
+    is_query_begin: bool
+    is_query_end: bool
+    is_logbook_begin: bool
+    is_drawer_end: bool
+
+
+def _classify_line(raw_line: str) -> _LineClassification:
+    """Classify syntax without reading or mutating parser state."""
+    sanitized = _sanitize_line(raw_line)
+    stripped = sanitized.strip()
+    return _LineClassification(
+        raw_line=sanitized,
+        stripped_line=stripped,
+        bullet_match=BULLET_PATTERN.match(sanitized),
+        heading_match=HEADING_BLOCK_PATTERN.match(sanitized),
+        property_match=LOGSEQ_PATTERNS["property"].match(stripped),
+        yaml_property_match=YAML_FRONTMATTER_PROPERTY_PATTERN.match(stripped),
+        collapsed_match=re.match(r"^\s*collapsed::\s*(\S+)\s*$", sanitized, re.IGNORECASE),
+        is_blank=not stripped,
+        is_system_block=is_system_block(sanitized),
+        is_yaml_delimiter=stripped == "---",
+        is_code_fence=_is_code_fence_line(stripped),
+        is_query_begin=_is_query_begin_line(stripped),
+        is_query_end=_is_query_end_line(stripped),
+        is_logbook_begin=stripped.upper() == ":LOGBOOK:",
+        is_drawer_end=stripped.upper() == ":END:",
+    )
 
 
 def _normalize_property_key(key: str) -> str:
@@ -668,19 +713,20 @@ class StackMachineParser:
         in_yaml_frontmatter = False
         line_number = 0
 
-        for line_number, raw_line in enumerate(text.splitlines(), start=1):
-            raw_line = _sanitize_line(raw_line)
-            stripped_line = raw_line.strip()
+        for line_number, input_line in enumerate(text.splitlines(), start=1):
+            line = _classify_line(input_line)
+            raw_line = line.raw_line
+            stripped_line = line.stripped_line
 
             if in_yaml_frontmatter:
-                if stripped_line == "---":
+                if line.is_yaml_delimiter:
                     in_yaml_frontmatter = False
                     frontmatter_active = False
                     yaml_title = page_properties.get("title")
                     if isinstance(yaml_title, str) and yaml_title.strip():
                         page_title = yaml_title.strip()
                     continue
-                yaml_match = YAML_FRONTMATTER_PROPERTY_PATTERN.match(stripped_line)
+                yaml_match = line.yaml_property_match
                 if yaml_match:
                     key = _normalize_property_key(yaml_match.group(1))
                     value = yaml_match.group(2).strip()
@@ -689,7 +735,7 @@ class StackMachineParser:
                         page_properties_order.append(key)
                 continue
 
-            if line_number == 1 and stripped_line == "---":
+            if line_number == 1 and line.is_yaml_delimiter:
                 in_yaml_frontmatter = True
                 continue
 
@@ -698,7 +744,7 @@ class StackMachineParser:
                 updated = self._refresh_node(current_node, merged_content, line_end=line_number)
                 self._replace_stack_tail_node(stack, root_nodes, updated)
                 current_node = updated
-                if _is_query_end_line(stripped_line):
+                if line.is_query_end:
                     in_query_block = False
                 frontmatter_active = False
                 pending_list_key = None
@@ -711,7 +757,7 @@ class StackMachineParser:
                 updated = self._refresh_node(current_node, merged_content, line_end=line_number)
                 self._replace_stack_tail_node(stack, root_nodes, updated)
                 current_node = updated
-                if _is_code_fence_line(stripped_line):
+                if line.is_code_fence:
                     in_code_block = False
                     properties_allowed = True
                 frontmatter_active = False
@@ -721,10 +767,10 @@ class StackMachineParser:
                 continue
 
             if in_drawer:
-                if stripped_line.upper() == ":END:":
+                if line.is_drawer_end:
                     in_drawer = False
                     continue
-                if BULLET_PATTERN.match(raw_line):
+                if line.bullet_match:
                     in_drawer = False
                 else:
                     if current_node is not None:
@@ -759,7 +805,7 @@ class StackMachineParser:
                         current_node = updated
                     continue
 
-            if stripped_line.upper() == ":LOGBOOK:" and current_node is not None:
+            if line.is_logbook_begin and current_node is not None:
                 in_drawer = True
                 properties = dict(current_node.properties)
                 properties.setdefault("logbook", [])
@@ -773,7 +819,7 @@ class StackMachineParser:
                 current_node = updated
                 continue
 
-            collapsed_match = re.match(r"^\s*collapsed::\s*(\S+)\s*$", raw_line, re.IGNORECASE)
+            collapsed_match = line.collapsed_match
             if collapsed_match and current_node is not None:
                 collapsed_value = collapsed_match.group(1).lower() == "true"
                 properties = dict(current_node.properties)
@@ -788,11 +834,11 @@ class StackMachineParser:
                 current_node = updated
                 continue
 
-            if not stripped_line or is_system_block(raw_line):
+            if line.is_blank or line.is_system_block:
                 continue
 
             if pending_list_key is not None and current_node is not None:
-                pending_bullet = BULLET_PATTERN.match(raw_line)
+                pending_bullet = line.bullet_match
                 if pending_bullet is not None:
                     pending_indent = self._compute_indent_level(pending_bullet.group(1))
                     if (
@@ -828,7 +874,7 @@ class StackMachineParser:
                 pending_list_items = []
                 pending_list_indent = None
 
-            bullet_match = BULLET_PATTERN.match(raw_line)
+            bullet_match = line.bullet_match
             if bullet_match:
                 indent_level = self._compute_indent_level(bullet_match.group(1))
 
@@ -871,7 +917,7 @@ class StackMachineParser:
                 properties_allowed = True
                 continue
 
-            heading_match = HEADING_BLOCK_PATTERN.match(raw_line)
+            heading_match = line.heading_match
             if heading_match:
                 indent_level = self._compute_indent_level(heading_match.group(1))
 
@@ -906,7 +952,7 @@ class StackMachineParser:
                 properties_allowed = True
                 continue
 
-            property_match = LOGSEQ_PATTERNS["property"].match(raw_line.strip())
+            property_match = line.property_match
             if property_match:
                 key, value = property_match.groups()
                 key = _normalize_property_key(key)
@@ -1005,9 +1051,9 @@ class StackMachineParser:
             )
             frontmatter_active = False
             properties_allowed = False
-            if _is_code_fence_line(stripped_line):
+            if line.is_code_fence:
                 in_code_block = True
-            if _is_query_begin_line(stripped_line):
+            if line.is_query_begin:
                 in_query_block = True
 
         if pending_list_key is not None and current_node is not None:

--- a/tests/test_logos_parser.py
+++ b/tests/test_logos_parser.py
@@ -12,6 +12,7 @@ from logseq_matryca_parser.exceptions import BlockReferenceError
 from logseq_matryca_parser.logos_parser import (
     LogosParser,
     StackMachineParser,
+    _classify_line,
     clean_node_content,
     is_system_block,
     normalize_logseq_timestamp,
@@ -1339,6 +1340,45 @@ def test_line_locations_use_logical_one_based_lines_for_unicode_crlf(
     assert (first.line_start, first.line_end) == (1, 3)
     assert (second.line_start, second.line_end) == (4, 4)
     assert "\r" not in first.content
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("\r", {"is_blank": True}),
+        ("  - Child", {"bullet": "  ", "is_system_block": False}),
+        ("\t## Heading", {"heading": "\t"}),
+        (" status:: open ", {"property": ("status", "open")}),
+        ("---", {"is_yaml_delimiter": True}),
+        ("#+BEGIN_QUERY", {"is_query_begin": True}),
+        ("#+END_QUERY", {"is_query_end": True}),
+        ("  ```python", {"is_code_fence": True}),
+        (":LOGBOOK:", {"is_logbook_begin": True, "is_system_block": True}),
+        (":END:", {"is_drawer_end": True, "is_system_block": False}),
+        ("collapsed:: true", {"collapsed": "true", "is_system_block": True}),
+    ],
+)
+def test_line_classifier_reports_private_pure_syntax_signals(
+    source: str, expected: dict[str, object]
+) -> None:
+    event = _classify_line(source)
+
+    assert "\r" not in event.raw_line
+    for key, value in expected.items():
+        if key == "bullet":
+            assert event.bullet_match is not None
+            assert event.bullet_match.group(1) == value
+        elif key == "heading":
+            assert event.heading_match is not None
+            assert event.heading_match.group(1) == value
+        elif key == "property":
+            assert event.property_match is not None
+            assert event.property_match.groups() == value
+        elif key == "collapsed":
+            assert event.collapsed_match is not None
+            assert event.collapsed_match.group(1) == value
+        else:
+            assert getattr(event, key) == value
 
 
 def test_resolve_asset_path_nested_namespace_page(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds the first M7 implementation slice for issue #165 on top of M5 and M6.

- introduce a private typed line-classification representation
- route the existing parser through the pure classification phase
- keep stack reduction, parser state, node creation, identity registration, and semantic enrichment in their existing owners
- add focused classification and parser-equivalence tests
- preserve public imports, UUIDs, ordering, links, line ranges, properties, and `strict_refs`

## Stack

This PR is intentionally based on `agent/parser-source-location-m6-next` and is reviewable after PRs #168 and #169. It does not include a big-bang parser rewrite, public API change, dependency, package metadata, external oracle, or source-location expansion.

## Validation

- `make all`
- 653 tests passed
- mypy passed on 68 files
- documentation and vendor-name checks passed
- exact stacked diff check passed