### PR TITLE
chore: prepare v1.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-20
+
 ### Tests
 
 - Define and regress the existing one-based source-line contract across Unicode
@@ -31,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pull-request dependency review and scheduled Scorecard** — added SHA-pinned,
   least-privilege workflows for newly introduced vulnerabilities and OpenSSF
   Scorecard SARIF monitoring.
-- **Privacy-safe local graph assurance (M5)** — add `matryca-parse assure`, an
+- **Privacy-safe local graph assurance (M5)** — added `matryca-parse assure`, an
   optional bounded local check that runs in a fresh worker, rejects symlinks,
   limits files/bytes/time, denies ordinary socket entry points, and returns a
   fixed aggregate-only JSON report. It does not upload, persist, or emit vault
@@ -85,6 +87,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fields; corpus bytes are forced to LF, and the snapshot generator is covered
   by the maintained mypy gate. This changes tests and tooling only, not package
   runtime behavior.
+- **Packaging metadata compatibility** — pin the Hatchling build backend to the
+  last release that emits Core Metadata 2.4 by default, keeping the published
+  wheel and source distribution accepted by the release Twine gate.
 
 ### Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ User-facing behavior is documented in:
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — LOGOS, SYNAPSE, `LogseqGraph`, agents, and data flow
 - [`docs/internal/LOCAL_CODE_STUDY.md`](docs/internal/LOCAL_CODE_STUDY.md) — maintainer local code audit runbook (not for public issues/CHANGELOG)
 - [`docs/logseq_ast_primer.md`](docs/logseq_ast_primer.md) — Logseq Spatial Markdown domain rules
-- [`CHANGELOG.md`](CHANGELOG.md) — shipped releases (current: **1.7.1**) and **Unreleased** changes (Keep a Changelog)
+- [`CHANGELOG.md`](CHANGELOG.md) — shipped releases (current: **1.8.0**) and **Unreleased** changes (Keep a Changelog)
 - [`docs/RELEASE_PROCESS.md`](docs/RELEASE_PROCESS.md) — version bump, tag, and PyPI publish checklist
 - [`docs/CODEQL.md`](docs/CODEQL.md) — CodeQL default setup (no custom `codeql.yml`)
 - [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) — curated starter tasks for new contributors

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Read the complete [release highlights](RELEASE_HIGHLIGHTS.md), the exhaustive
 [changelog](CHANGELOG.md), or the signed artifacts on
 [GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
 
+- **v1.8.0** — Added bounded privacy-safe local graph assurance, source-location contracts, and the first internal parser line-classification phase.
 - **v1.7.1** — Added the runnable offline SYNAPSE RAG example and tightened release-note and optional-dependency security checks.
 - **v1.7.0** — Hardened parser correctness, graph diagnostics, writer safety, API stability, documentation governance, and release provenance.
 - **v1.6.0** — Clean Architecture v1 structural slices, new public graph APIs, layer-boundary CI, and documentation SSOT.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Security fixes are provided **only for the latest released version** on [PyPI](h
 
 | Version | Supported |
 | ------- | --------- |
-| **1.7.1** (latest) | Yes |
-| 1.7.0 and older | No |
+| **1.8.0** (latest) | Yes |
+| 1.7.1 and older | No |
 
 We recommend always running the current release and upgrading promptly when a security advisory is published.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -611,7 +611,7 @@ Recursive and character-budget chunkers assume **approximately flat prose**. Log
 | [`index.md`](index.md) | Canonical maintained knowledge-bundle entry point |
 | [`design-docs/README.md`](design-docs/README.md) | Warning before using historical DDD blueprints |
 
-### Quality gate (v1.7.1)
+### Quality gate (v1.8.0)
 
 Local and CI parity: `uv sync --all-extras` → `make lint` → `make check` →
 `make test` → `make vendor-name-check` → `make docs-check`. These targets are

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -8,8 +8,8 @@ audience: contributors
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-08
-verified: 2026-08-08
+last_verified: 2026-08-20
+verified: 2026-08-20
 stale_after: 2027-02-02
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -19,7 +19,7 @@ superseded_by: null
 
 # Clean Code & Clean Architecture — Logseq Matryca Parser
 
-**Version:** documents **v1.7.1** maintainer contracts (v1 structural backlog complete)
+**Version:** documents **v1.8.0** maintainer contracts (v1 structural backlog complete; M5–M7 assurance slices merged)
 **Audience:** contributors and Cursor agents patching `src/logseq_matryca_parser/`  
 **Companion:** [`ARCHITECTURE.md`](ARCHITECTURE.md) (LOGOS domain contract) · [`BUG_HUNT_REPORT.md`](BUG_HUNT_REPORT.md) (audit evidence) · [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -8,15 +8,15 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-18
-verified: 2026-08-18
+last_verified: 2026-08-20
+verified: 2026-08-20
 stale_after: 2026-11-14
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
 superseded_by: null
 parent_plan: docs/REPOSITORY_STELLAR_ROADMAP_2026-08-06.md
-source_commit: 27d006153e45f2c4ae37ca03136114fb8246ac88
+source_commit: e427234be4ffb30e770e75344e914b85a6c78ef2
 reference_commit: c79cb059da5b4360ebde2e5fd953fa1f43ddabc3
 ---
 
@@ -52,18 +52,21 @@ Markdown source-of-truth model.
 
 | Item | Verified state | Evidence |
 |---|---|---|
-| Source repository | `MarcoPorcellato/logseq-matryca-parser` | `origin/main` fetched 2026-08-18 |
-| Source base | `27d006153e45f2c4ae37ca03136114fb8246ac88` | live `origin/main` verified on 2026-08-18 after M2–M4 PRs merged |
+| Source repository | `MarcoPorcellato/logseq-matryca-parser` | `origin/main` fetched 2026-08-20 |
+| Source base | `e427234be4ffb30e770e75344e914b85a6c78ef2` | live `origin/main` verified on 2026-08-20 after M5–M7 PRs merged |
 | Source license | Apache License 2.0 | [`LICENSE`](../LICENSE) |
 | Reference repository | `martinkoutecky/lsdoc` release `v0.5.5` | [reference commit `c79cb059`](https://github.com/martinkoutecky/lsdoc/commit/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3) |
 | Reference license | `AGPL-3.0-only` | [`Cargo.toml`](https://github.com/martinkoutecky/lsdoc/blob/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3/Cargo.toml) and [`LICENSE`](https://github.com/martinkoutecky/lsdoc/blob/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3/LICENSE) |
 | Parent roadmap | current repository-wide quality SSOT | [stellar roadmap](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) |
 | M0 publication | merged as [PR #159](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/159) | source head `a6056413`, squash merge `30946446`, terminal validation recorded in the PR |
-| Existing delivery anchors | #87, #103, #104, #108, #111 are open; #106 and #113 are closed | live GitHub issue reads on 2026-08-16 |
+| Existing delivery anchors | #87, #103, #104, #108, and #111 remain open; #106, #113, and #165 are closed | live GitHub issue reads on 2026-08-20 |
 | Local implementation checkpoint | `8806205c35b104ed65d00a273acc9eeca572ae38` | clean local commit on `agent/parser-assurance-m1`; exact-head tests passed, but independent oracle review rejected publication |
 | M1 delivery | merged | [PR #161](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/161) merged the project-owned compatibility-corpus foundation; it remains only the first #104 tranche |
 | M2–M4 delivery | merged | M3 [PR #162](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/162), M4 [PR #163](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/163), and M2 [PR #164](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/164) are in `main` as `172be70`, `5d38e01`, and `98bc5aa` respectively |
-| Current milestone | M5 locally qualified; publication pending | Corrected code head `e2d0e5a` on `agent/parser-privacy-assurance-m5` passed direct final review and local gates; it is not a publication, hosted-check, merge, or release claim |
+| M5 delivery | merged | Privacy-safe local graph assurance merged through [PR #168](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/168) |
+| M6 delivery | merged | Source-location contract and RFC merged through [PR #169](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/169) |
+| M7 delivery | merged | Internal line-classification slice merged through [PR #170](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/170); issue [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165) is closed |
+| Current milestone | v1.8.0 release preparation | M5–M7 are in `origin/main@e427234`; release contract, package evidence, protected-branch publication, tag workflow, and public artifact verification remain the open gates |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
 publication, or qualification.
@@ -803,14 +806,12 @@ It must not replace the requirements in this plan.
   separate explicit gate.
 - [ ] #87 and #111 have complementary deterministic-work and measured-runtime
   evidence without semantic drift.
-- [ ] The privacy-safe local graph tool is delivered or explicitly rejected with
-  recorded reasons. Corrected code head `e2d0e5a` passed exact-code
-  qualification and direct final review; live-base refresh, hosted checks, and
-  publication remain open.
-- [ ] The source-location RFC is accepted or rejected with consumer and cost
-  evidence.
-- [ ] Every #108 extraction slice is covered by the semantic and performance
-  gates, or the epic records why no extraction is justified.
+- [x] The privacy-safe local graph tool is delivered through PR #168 with its
+  aggregate-only privacy boundary and bounded local execution contract.
+- [x] The source-location RFC is accepted through PR #169 with consumer and
+  cost evidence recorded in the decision document.
+- [x] The first #108 extraction slice is covered by semantic and work-growth
+  gates through PR #170; the broader extraction epic remains open.
 - [ ] No AGPL-covered expression entered Apache-only source, tests, fixtures,
   schemas, or documentation.
 - [ ] Documentation, issue state, and public claims match the delivered behavior.
@@ -844,4 +845,6 @@ Completion is unproven until every applicable item has authoritative evidence.
 | 2026-08-18 | M5 local graph assurance `41486b3` | local implementation checkpoint | An isolated branch based on `main@27d0061` adds a fresh-worker `assure` CLI command, file/byte/timeout bounds, symlink rejection, ordinary-socket denial, project-owned structure and reference checks, a fixed aggregate-only report schema, and a synthetic self-test. The current head validates nested report fields, rejects unknown finding codes and invalid direct limit values, and rechecks the total byte bound while reading. It remains local only; exact-head qualification, independent review, hosted checks, PR, merge, and release remain separate gates. |
 | 2026-08-18 | M5 direct final review and correction `e2d0e5a` | locally qualified; publication pending | Direct full-patch review reproduced four fail-closed defects: arbitrary runtime strings passed report validation, symlink-loop inputs produced path-bearing parent tracebacks, dangling `pages/` links could pass, and global graph input was ignored by `--self-test`. Non-amending corrections bind reports to exact runtime labels and parent limits, preserve invalid-root handling inside the worker, reject dangling root links, and enforce self-test isolation. The corrected code head passed 622 tests plus Ruff, mypy, documentation, vendor, coverage, and diff gates. No P0/P1/P2 finding remains in the reviewed local patch; live-base refresh, push authorization, hosted checks, PR, merge, and release remain separate gates. |
  | 2026-08-18 | M6 source-location decision `7bf5c6d` | local documentation and regression checkpoint | The accepted source-location RFC retains the existing one-based logical line contract for diagnostics, writer splicing, and SYNAPSE lineage. A CRLF/Unicode regression covers line positions. Byte, code-point, column, range, and source-map expansion is rejected until a named consumer meets the RFC admission gate. No parser or public API change is claimed. |
- | 2026-08-18 | M7 line classifier / #165 `f8c3f65` | local implementation checkpoint | A fresh impact review classified `_refresh_node` as HIGH risk and created [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165). The first slice adds a private pure syntax event and routes the existing parser through it without extracting state reduction or semantic enrichment. Focused parser, corpus, adversarial, and work-growth checks pass locally; independent review, exact-head full qualification, hosted checks, PR, merge, and release remain separate gates. |
+| 2026-08-18 | M7 line classifier / #165 `f8c3f65` | local implementation checkpoint | A fresh impact review classified `_refresh_node` as HIGH risk and created [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165). The first slice adds a private pure syntax event and routes the existing parser through it without extracting state reduction or semantic enrichment. Focused parser, corpus, adversarial, and work-growth checks passed locally. |
+| 2026-08-20 | M5–M7 controlled publication | merged | PRs [#168](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/168), [#169](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/169), and [#170](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/170) were squash-merged in order. `origin/main` is `e427234`; issue #165 was closed with the delivered evidence. |
+| 2026-08-20 | v1.8.0 release preparation | in progress | The release branch updates the source version, changelog, README release index, security support window, contributor guidance, and assurance goal. Exact package, supply-chain, tag, workflow, and public-artifact receipts remain required before declaring the release complete. |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -43,13 +43,13 @@ version; use `vX.Y.Z` for the git tag).
 
 - [ ] Move everything from `[Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` in `CHANGELOG.md`
 - [ ] Leave an empty `## [Unreleased]` section at the top
-- [ ] Set `__version__ = "X.Y.Z"` in `src/logseq_matryca_parser/_version.py`; Hatchling derives package metadata from this single source
+- [ ] Set `__version__ = "X.Y.Z"` in `src/logseq_matryca_parser/_version.py`; the pinned Hatchling backend derives package metadata from this single source
 - [ ] Update `README.md`, `SECURITY.md`, and contributor-facing current-version references
 - [ ] Verify every file, command, issue disposition, and shipped capability
       named in the versioned changelog against the exact release commit
 - [ ] Run `make all` (Ruff, Mypy, documentation checks, and Pytest)
 - [ ] Run `python -m scripts.check_release_contract --tag vX.Y.Z`
-- [ ] Build wheel and sdist once locally, run `python scripts/check_wheel_contract.py path/to/wheel.whl`, `twine check`, and record SHA-256 digests
+- [ ] Build wheel and sdist once locally, run `python scripts/check_wheel_contract.py path/to/wheel.whl`, `twine check`, and record SHA-256 digests; keep the build backend pin when metadata compatibility matters
 - [ ] Review [the dependency/license policy](reference/DEPENDENCY_LICENSE_POLICY.md),
       including every direct dependency, VCS source, and version-exact override
 

--- a/docs/decisions/ADR-002-local-graph-assurance-boundary.md
+++ b/docs/decisions/ADR-002-local-graph-assurance-boundary.md
@@ -9,8 +9,8 @@ owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
 decision_date: 2026-08-18
-last_verified: 2026-08-18
-verified: 2026-08-18
+last_verified: 2026-08-20
+verified: 2026-08-20
 stale_after: 2027-02-18
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -22,7 +22,7 @@ superseded_by: null
 
 ## Status
 
-Accepted on 2026-08-18 for the M5 assurance tranche. The initial implementation
+Accepted on 2026-08-18 for the M5 assurance tranche and shipped in v1.8.0. The initial implementation
 is the optional `matryca-parse assure` command and its project-owned synthetic
 self-test.
 

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -8,8 +8,8 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-18
-verified: 2026-08-18
+last_verified: 2026-08-20
+verified: 2026-08-20
 stale_after: 2026-11-14
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -33,22 +33,22 @@ bounded adversarial laboratory; M4 remains a Python-native, test-only,
 deterministic work model. Neither expands #103, #87, or #111 ownership or
 constitutes a release claim.
 
-M5 is in delivery from local corrected code head `e2d0e5a` on
-`agent/parser-privacy-assurance-m5`, based on `main@27d0061`. It adds an
-optional aggregate-only local assurance CLI with a fresh worker, file/byte/time
-bounds, symlink rejection, ordinary-socket denial, safe report validation, and
-a project-owned synthetic self-test. It must not emit or retain vault-derived
-content, paths, titles, UUIDs, exception text, or host names; it must not claim
-#103 incremental/cold-load equivalence, #87 or #111 performance evidence,
-external-oracle parity, release qualification, or closure of #104/#108.
+M5 was delivered through [PR #168](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/168)
+and adds an optional aggregate-only local assurance CLI with a fresh worker,
+file/byte/time bounds, symlink rejection, ordinary-socket denial, safe report
+validation, and a project-owned synthetic self-test. It does not emit or retain
+vault-derived content, paths, titles, UUIDs, exception text, or host names.
 
-M6 has an accepted local source-location RFC at `7bf5c6d`: existing one-based
-logical line fields remain the only supported coordinates, while offset and
-source-map expansion stays behind its admission gate. M7 begins at local code
-checkpoint `f8c3f65` for [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165),
-the private line-classification extraction. It preserves parser state reduction,
-node creation, identities, graph behavior, public imports, and dependencies;
-publication and review gates remain independent of M5.
+M6 was delivered through [PR #169](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/169).
+Its accepted source-location RFC retains one-based logical line fields as the
+only supported coordinates; offset and source-map expansion stays behind its
+admission gate.
+
+M7 was delivered through [PR #170](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/170)
+and closes child issue [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165).
+The private line-classification extraction preserves parser state reduction,
+node creation, identities, graph behavior, public imports, and dependencies.
+The broader #108 epic remains open for later gated phase slices.
 
 M2 is complete through the accepted negative
 [ADR-001](../decisions/ADR-001-external-oracle-boundary.md): no external
@@ -61,9 +61,9 @@ including a maintainer-approved process boundary.
 
 The direct GPT-5.6 Sol review found and corrected unsafe runtime-string
 admission, parent-side symlink-loop disclosure, dangling root-link acceptance,
-and ignored global graph input in self-test mode. Before any M5 push or pull
-request, re-verify the live base, freeze the raw full diff, qualify its exact
-head, and stop before publication unless separately authorized.
+and ignored global graph input in self-test mode. These corrections are now
+published through PR #168; the M5 privacy and non-retention boundary remains
+part of the supported contract.
 
 The initial checkpoint `8806205c35b104ed65d00a273acc9eeca572ae38` is rejected
 pre-correction evidence. Corrective implementation

--- a/docs/reference/LOCAL_GRAPH_ASSURANCE.md
+++ b/docs/reference/LOCAL_GRAPH_ASSURANCE.md
@@ -8,8 +8,8 @@ audience: integrators
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-18
-verified: 2026-08-18
+last_verified: 2026-08-20
+verified: 2026-08-20
 stale_after: 2027-02-18
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null

--- a/docs/rfc/SOURCE_LOCATION_RFC.md
+++ b/docs/rfc/SOURCE_LOCATION_RFC.md
@@ -8,8 +8,8 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-18
-verified: 2026-08-18
+last_verified: 2026-08-20
+verified: 2026-08-20
 stale_after: 2027-02-18
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -22,7 +22,7 @@ decision_date: 2026-08-18
 
 ## Status
 
-Accepted on 2026-08-18. M6 records a deliberately small source-location
+Accepted on 2026-08-18 and shipped in v1.8.0. M6 records a deliberately small source-location
 contract and rejects a new byte-, code-point-, or column-offset prototype for
 the current release line.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.30.1"]
 build-backend = "hatchling.build"
 
 [project]

--- a/src/logseq_matryca_parser/_version.py
+++ b/src/logseq_matryca_parser/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the distribution version."""
 
-__version__ = "1.7.1"
+__version__ = "1.8.0"

--- a/tests/test_check_wheel_contract.py
+++ b/tests/test_check_wheel_contract.py
@@ -32,7 +32,7 @@ def _wheel(
 
 
 def test_source_version_reads_lightweight_version_module() -> None:
-    assert source_version() == "1.7.1"
+    assert source_version() == "1.8.0"
 
 
 def test_valid_wheel_contract(tmp_path: Path) -> None:

--- a/tests/test_quality_gate_contract.py
+++ b/tests/test_quality_gate_contract.py
@@ -86,6 +86,12 @@ def test_release_builds_once_and_orders_publication() -> None:
     assert "release-bundle/dist/*" in workflow
 
 
+def test_build_backend_pin_keeps_release_metadata_twine_compatible() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'requires = ["hatchling==1.30.1"]' in pyproject
+
+
 def test_release_publishes_and_verifies_supply_chain_evidence() -> None:
     workflow = (ROOT / ".github" / "workflows" / "pypi_publish.yml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
Summary: prepare v1.8.0 for the merged M5, M6, and M7 assurance work. Align version, changelog, README release index, support window, contributor guidance, and canonical documentation. Pin Hatchling 1.30.1 so distributions emit Twine-compatible Core Metadata 2.4. Add a regression guard for the build-backend pin and close the stale issue 165 release reference. Local validation: make all passed with 654 tests and 89.32% coverage; Ruff, mypy, documentation, and vendor-name checks passed. The release contract for tag v1.8.0 passed. Wheel contract and Twine checks passed for wheel and sdist. CycloneDX 1.5 SBOM and dependency/license inventory generated successfully. The tag and public release remain separate until this PR is reviewed and merged.