### PR TITLE
docs: align indexes with official OKF v0.2

### DIFF
--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,21 +1,3 @@
----
-type: DecisionIndex
-title: Architecture decision index
-description: Canonical registry of architectural decisions and required ADRs.
-status: draft
-classification: canonical
-audience: maintainers
-owner: logseq-matryca-parser
-authority: source_repository
-execution_mode: reviewed
-last_verified: 2026-08-19
-verified: 2026-08-19
-stale_after: 2027-02-19
-okf_profile: matryca_okf_inspired_quality
-okf_spec_version: null
-supersedes: null
-superseded_by: null
----
 # Architecture decision index
 
 The existing architecture guides remain authoritative while formal ADRs are

--- a/docs/internal/M5_LOCAL_GRAPH_ASSURANCE_REVIEW_HANDOFF_2026-08-18.md
+++ b/docs/internal/M5_LOCAL_GRAPH_ASSURANCE_REVIEW_HANDOFF_2026-08-18.md
@@ -1,3 +1,7 @@
+---
+type: Document
+---
+
 # M5 local graph assurance pre-publication handoff — 2026-08-18
 
 ## Safe resume point

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,21 +1,3 @@
----
-type: ReferenceIndex
-title: Reference and provenance index
-description: Canonical external relations and immutable provenance for maintained documentation.
-status: stable
-classification: canonical
-audience: maintainers
-owner: logseq-matryca-parser
-authority: source_repository
-execution_mode: reviewed
-last_verified: 2026-08-19
-verified: 2026-08-19
-stale_after: 2027-02-19
-okf_profile: matryca_okf_inspired_quality
-okf_spec_version: null
-supersedes: null
-superseded_by: null
----
 # Reference and provenance index
 
 ## Matryca relations


### PR DESCRIPTION
Removes frontmatter from the two nested index.md files as required by official OKF v0.2 and adds the missing type metadata to the internal handoff document. Local official OKF v0.2 audit: 69 documents, 0 findings. git diff --check passed; parser documentation hooks passed.