### PR TITLE
fix(parser): bound pathological nested outline work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pathological nested outlines (#87)** — parse and file-entrypoint traversal
+  now remain iterative for a 1024-level valid outline, while parser-owned tree
+  construction avoids quadratic immutable-ancestor copies. Tree order, parent
+  and left relationships, source paths, and stable public API are preserved.
+  Local timing observations are diagnostic only; this does not add a vault-scale
+  performance claim.
+
 ## [1.8.0] - 2026-08-20
 
 ### Tests

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -536,8 +536,8 @@ converted into a pass or silently added to an allowlist.
 
 - Define a Python-native, test-only parser work model based on this parser's own
   phases and operations; do not reproduce lsdoc's counter placement or schema.
-- Run input families at increasing sizes and reject superlinear growth outside
-  explicitly documented exceptions.
+- Run input families at increasing sizes and reject superlinear growth in every
+  parser-owned operation.
 - Preserve #87 as the focused pathological seed and #111 as the wall-time,
   p95, RSS, and vault-scale owner.
 - Keep the work model under `tests/` only. It may count input lines,
@@ -545,12 +545,10 @@ converted into a pass or silently added to an allowlist.
   refresh, replacement, normalization, and reference-collection operations,
   but it must not expose a parser runtime hook or public API.
 - Use the fixed project-authored matrix `8`, `16`, `32`, and `64` for flat
-  blocks, deep chains, fenced continuations, and properties. Every
-  non-exception operation in the vector must remain within a `2.5x` ratio as a
-  size doubles. The deep-chain
-  family is the sole named structural exception: immutable ancestor rebuilding
-  is asserted against its exact `n * (n - 1) / 2` model while its remaining
-  vector stays within the linear envelope.
+  blocks, deep chains, fenced continuations, and properties. Every operation in
+  the vector must remain within a `2.5x` ratio as a size doubles. Immutable
+  ancestor rebuilding is forbidden: an independent model-copy budget guards the
+  deep-chain family against reintroducing quadratic Pydantic copies.
 - Emit source-free receipts with schema and generator versions, case identity,
   exact replay command with bounded mode and timeout when applicable, size,
   source hash and byte count, operation vector,

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -76,6 +76,17 @@ and [PyPI package](https://pypi.org/project/logseq-matryca-parser/1.8.0/)
 were checked after publication. The broader #104, #103, #87, #111, and #108
 acceptance work remains open where the plan still marks it incomplete.
 
+Post-release #87 work is in delivery on a local branch and is not yet a release
+or hosted-validation claim. On source code identical to v1.8.0, a valid
+1024-level nested outline raised `RecursionError`; profiling also identified
+quadratic Pydantic ancestor copies during incremental tree construction. The
+bounded correction replaces parser-owned recursive traversals with iterative
+ones and forbids immutable ancestor rebuilding in the test-only work model. The
+new checks preserve tree order, parent and left relationships, source paths,
+and a linear model-copy budget. Local elapsed observations remain diagnostic
+only; #111 still owns vault-scale wall-time, p95, RSS, reload, search, and
+RAG-chunk benchmark evidence.
+
 The initial checkpoint `8806205c35b104ed65d00a273acc9eeca572ae38` is rejected
 pre-correction evidence. Corrective implementation
 `996c5a52b08f2670ecd80fb3f1515b65ae567465` passed local exact-head checks, but

--- a/src/logseq_matryca_parser/logos_parser.py
+++ b/src/logseq_matryca_parser/logos_parser.py
@@ -1155,15 +1155,23 @@ class StackMachineParser:
         return derive_graph_root_from_source_path(path)
 
     def _apply_source_path(self, nodes: list[LogseqNode], source_path: str) -> list[LogseqNode]:
-        return [
-            node.model_copy(
+        copied: dict[int, LogseqNode] = {}
+        pending = [(node, False) for node in reversed(nodes)]
+
+        while pending:
+            node, children_copied = pending.pop()
+            if not children_copied:
+                pending.append((node, True))
+                pending.extend((child, False) for child in reversed(node.children))
+                continue
+            copied[id(node)] = node.model_copy(
                 update={
                     "source_path": source_path,
-                    "children": self._apply_source_path(node.children, source_path),
+                    "children": [copied[id(child)] for child in node.children],
                 }
             )
-            for node in nodes
-        ]
+
+        return [copied[id(node)] for node in nodes]
 
     def _compute_indent_level(self, indentation: str) -> int:
         spaces = indentation.count(" ") + (indentation.count("\t") * self.tab_size)
@@ -1288,19 +1296,16 @@ class StackMachineParser:
         root_nodes: list[LogseqNode],
         updated_node: LogseqNode,
     ) -> None:
-        """Replace the active leaf and rebuild every immutable ancestor to the root."""
+        """Replace the active leaf while the parser still exclusively owns the tree."""
         if not stack:
             return
 
         stack[-1] = updated_node
         updated_ancestor = updated_node
 
-        for idx in range(len(stack) - 2, -1, -1):
-            ancestor = stack[idx]
-            ancestor_children = list(ancestor.children)
-            ancestor_children[-1] = updated_ancestor
-            updated_ancestor = ancestor.model_copy(update={"children": ancestor_children})
-            stack[idx] = updated_ancestor
+        for ancestor in reversed(stack[:-1]):
+            ancestor.children[-1] = updated_ancestor
+            updated_ancestor = ancestor
 
         root_nodes[-1] = updated_ancestor
 
@@ -1312,19 +1317,9 @@ class StackMachineParser:
     ) -> LogseqNode:
         parent = stack[-1]
         attached_node = node.model_copy(update={"parent_id": parent.uuid})
-        updated_ancestor = attached_node
-
-        for idx in range(len(stack) - 1, -1, -1):
-            ancestor = stack[idx]
-            ancestor_children = list(ancestor.children)
-            if idx == len(stack) - 1:
-                ancestor_children.append(updated_ancestor)
-            else:
-                ancestor_children[-1] = updated_ancestor
-            updated_ancestor = ancestor.model_copy(update={"children": ancestor_children})
-            stack[idx] = updated_ancestor
-
-        root_nodes[-1] = stack[0]
+        # ``children`` is parser-owned until ``parse`` returns the page.  Mutating
+        # it here avoids copying every ancestor for each new child.
+        parent.children.append(attached_node)
         return attached_node
 
     def _initialize_node_graph_fields(
@@ -1356,16 +1351,15 @@ class StackMachineParser:
     def _collect_page_refs(self, roots: list[LogseqNode]) -> list[str]:
         collected: list[str] = []
         seen: set[str] = set()
+        pending = list(reversed(roots))
 
-        def visit(nodes: list[LogseqNode]) -> None:
-            for node in nodes:
-                for token in node.refs:
-                    if token not in seen:
-                        seen.add(token)
-                        collected.append(token)
-                visit(node.children)
-
-        visit(roots)
+        while pending:
+            node = pending.pop()
+            for token in node.refs:
+                if token not in seen:
+                    seen.add(token)
+                    collected.append(token)
+            pending.extend(reversed(node.children))
         return collected
 
     def _resolve_block_ref_on_page(self, block_ref: str) -> LogseqNode | None:
@@ -1386,17 +1380,16 @@ class StackMachineParser:
     def _validate_references(self, roots: list[LogseqNode]) -> None:
         if not self.strict_refs:
             return
+        pending = list(reversed(roots))
 
-        def visit(nodes: list[LogseqNode]) -> None:
-            for node in nodes:
-                for ref in node.block_refs:
-                    if self._resolve_block_ref_on_page(ref) is None:
-                        raise BlockReferenceError(
-                            f"Unresolved block reference (({ref})) on node {node.uuid}"
-                        )
-                visit(node.children)
-
-        visit(roots)
+        while pending:
+            node = pending.pop()
+            for ref in node.block_refs:
+                if self._resolve_block_ref_on_page(ref) is None:
+                    raise BlockReferenceError(
+                        f"Unresolved block reference (({ref})) on node {node.uuid}"
+                    )
+            pending.extend(reversed(node.children))
 
     def _refresh_node(
         self,
@@ -1465,13 +1458,25 @@ class StackMachineParser:
     def _normalize_indent_levels(
         self, nodes: list[LogseqNode], depth: int = 0
     ) -> list[LogseqNode]:
-        normalized_nodes: list[LogseqNode] = []
-        for node in nodes:
-            normalized_children = self._normalize_indent_levels(node.children, depth + 1)
-            normalized_nodes.append(
-                node.model_copy(update={"indent_level": depth, "children": normalized_children})
+        normalized: dict[int, LogseqNode] = {}
+        pending = [(node, depth, False) for node in reversed(nodes)]
+
+        while pending:
+            node, node_depth, children_normalized = pending.pop()
+            if not children_normalized:
+                pending.append((node, node_depth, True))
+                pending.extend(
+                    (child, node_depth + 1, False) for child in reversed(node.children)
+                )
+                continue
+            normalized[id(node)] = node.model_copy(
+                update={
+                    "indent_level": node_depth,
+                    "children": [normalized[id(child)] for child in node.children],
+                }
             )
-        return normalized_nodes
+
+        return [normalized[id(node)] for node in nodes]
 
 
 # Backward-compatible alias.

--- a/tests/parser_assurance/work_growth.py
+++ b/tests/parser_assurance/work_growth.py
@@ -263,7 +263,7 @@ class InstrumentedStackMachineParser(StackMachineParser):
         root_nodes: list[LogseqNode],
         node: LogseqNode,
     ) -> LogseqNode:
-        self._add(node_attachments=1, immutable_ancestor_rebuild_steps=len(stack))
+        self._add(node_attachments=1)
         return super()._attach_node_to_parent(stack, root_nodes, node)
 
     def _refresh_node(
@@ -289,10 +289,7 @@ class InstrumentedStackMachineParser(StackMachineParser):
         root_nodes: list[LogseqNode],
         updated_node: LogseqNode,
     ) -> None:
-        self._add(
-            replacement_events=1,
-            immutable_ancestor_rebuild_steps=max(len(stack) - 1, 0),
-        )
+        self._add(replacement_events=1)
         super()._replace_stack_tail_node(stack, root_nodes, updated_node)
 
     def _normalize_indent_levels(
@@ -567,10 +564,6 @@ def run_profile(
     return tuple(evaluate_case(case) for case in cases)
 
 
-def _expected_deep_ancestor_steps(size: int) -> int:
-    return size * (size - 1) // 2
-
-
 def assert_growth_contract(receipts: Sequence[WorkReceipt]) -> None:
     """Reject unexplained superlinear deterministic work in the declared matrix."""
     by_family: dict[WorkFamily, list[WorkReceipt]] = {}
@@ -598,17 +591,8 @@ def assert_growth_contract(receipts: Sequence[WorkReceipt]) -> None:
                     raise AssertionError(
                         f"{family}: {operation} work exceeded the documented 2.5x envelope"
                     )
-        if family == "deep-chain":
-            for receipt in ordered:
-                assert receipt.work is not None
-                if receipt.work.immutable_ancestor_rebuild_steps != _expected_deep_ancestor_steps(
-                    receipt.size
-                ):
-                    raise AssertionError(
-                        "deep-chain: immutable ancestor rebuild exception no longer matches its model"
-                    )
-        elif any(receipt.work and receipt.work.immutable_ancestor_rebuild_steps for receipt in ordered):
-            raise AssertionError(f"{family}: undeclared immutable ancestor rebuild work")
+        if any(receipt.work and receipt.work.immutable_ancestor_rebuild_steps for receipt in ordered):
+            raise AssertionError(f"{family}: immutable ancestor rebuild work is forbidden")
 
 
 def _worker_main() -> int:

--- a/tests/test_parser_deep_refresh.py
+++ b/tests/test_parser_deep_refresh.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -77,6 +79,55 @@ def test_deep_refresh_preserves_sibling_order_and_left_pointer() -> None:
     assert second.left_id == first.uuid
     assert second.parent_id == parent.uuid
     assert second.line_end == 10
+
+
+def test_parse_handles_a_1024_node_chain_without_recursion() -> None:
+    page = StackMachineParser().parse(_nested_source(1024, []), page_title="deep-chain")
+    branch = _branch(page.root_nodes[0])
+
+    assert len(branch) == 1024
+    assert [node.indent_level for node in branch] == list(range(1024))
+    for parent, child in zip(branch, branch[1:], strict=False):
+        assert child.parent_id == parent.uuid
+        assert child.left_id is None
+
+
+def test_strict_parse_handles_a_1024_node_chain_without_recursion() -> None:
+    page = StackMachineParser(strict_refs=True).parse(
+        _nested_source(1024, []), page_title="deep-strict-chain"
+    )
+
+    assert len(_branch(page.root_nodes[0])) == 1024
+
+
+def test_deep_chain_uses_a_linear_model_copy_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    copies = 0
+    original_model_copy = LogseqNode.model_copy
+
+    def counted_model_copy(
+        node: LogseqNode, *, update: Mapping[str, Any] | None = None, deep: bool = False
+    ) -> LogseqNode:
+        nonlocal copies
+        copies += 1
+        return original_model_copy(node, update=update, deep=deep)
+
+    monkeypatch.setattr(LogseqNode, "model_copy", counted_model_copy)
+
+    StackMachineParser().parse(_nested_source(128, []), page_title="deep-copy-budget")
+
+    assert copies <= 5 * 128
+
+
+def test_parse_page_file_handles_a_1024_node_chain_without_recursion(tmp_path: Path) -> None:
+    path = tmp_path / "pages" / "deep-chain.md"
+    path.parent.mkdir()
+    path.write_text(_nested_source(1024, []), encoding="utf-8")
+
+    page = StackMachineParser().parse_page_file(path)
+    branch = _branch(page.root_nodes[0])
+
+    assert len(branch) == 1024
+    assert all(node.source_path == str(path.resolve()) for node in branch)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parser_work_growth.py
+++ b/tests/test_parser_work_growth.py
@@ -36,7 +36,7 @@ def test_fixed_profile_proves_declared_growth_and_semantic_contracts() -> None:
     assert all(receipt.python_version for receipt in receipts)
 
 
-def test_deep_chain_declares_and_proves_the_immutable_ancestor_exception() -> None:
+def test_deep_chain_forbids_immutable_ancestor_rebuild_work() -> None:
     receipts = [
         receipt
         for receipt in work_growth.run_profile("fixed")
@@ -47,7 +47,7 @@ def test_deep_chain_declares_and_proves_the_immutable_ancestor_exception() -> No
         assert receipt.growth_policy == "immutable-ancestor-rebuild-v1"
         assert receipt.work is not None
         assert receipt.work.node_builds == receipt.size
-        assert receipt.work.immutable_ancestor_rebuild_steps == receipt.size * (receipt.size - 1) // 2
+        assert receipt.work.immutable_ancestor_rebuild_steps == 0
 
 
 def test_growth_contract_rejects_superlinear_operation_growth_hidden_by_other_counters() -> None:
@@ -65,6 +65,24 @@ def test_growth_contract_rejects_superlinear_operation_growth_hidden_by_other_co
     )
 
     with pytest.raises(AssertionError, match="node_builds work exceeded"):
+        work_growth.assert_growth_contract(receipts)
+
+
+def test_growth_contract_rejects_immutable_ancestor_rebuild_work() -> None:
+    receipts = list(work_growth.run_profile("fixed"))
+    target_index = next(
+        index
+        for index, receipt in enumerate(receipts)
+        if receipt.family == "deep-chain" and receipt.size == 16
+    )
+    target = receipts[target_index]
+    assert target.work is not None
+    receipts[target_index] = replace(
+        target,
+        work=replace(target.work, immutable_ancestor_rebuild_steps=1),
+    )
+
+    with pytest.raises(AssertionError, match="immutable ancestor rebuild work is forbidden"):
         work_growth.assert_growth_contract(receipts)
 
 


### PR DESCRIPTION
## Summary\n\n- replace parser-owned recursive traversals with iterative traversal for deep outlines\n- avoid quadratic immutable ancestor copies during tree construction\n- add 1024-level, strict-validation, file-entrypoint, copy-budget, and work-growth regressions\n- align assurance and changelog documentation with the new bounded contract\n\n## Validation\n\n- 659 tests passed\n- 89.32% coverage\n- Ruff, mypy, documentation, vendor-name, and diff checks passed\n- GitNexus impact review completed; 0 import cycles\n\nFixes #87