### PR TITLE
feat: add reproducible runtime evidence harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Incremental graph reloads (#103)** — backlink indexes are rebuilt from the
+  current page set after a tracked page is deleted or reloaded. Title and alias
+  changes delivered through a filesystem move now match a cold load; no public
+  API or performance claim changes.
 - **Pathological nested outlines (#87)** — parse and file-entrypoint traversal
   now remain iterative for a 1024-level valid outline, while parser-owned tree
   construction avoids quadratic immutable-ancestor copies. Tree order, parent

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -679,6 +679,66 @@ converted into a pass or silently added to an allowlist.
 
 - Some seams may not justify extraction; preserving a deliberate hub is valid.
 
+### M8 — Reproducible measured-runtime evidence (#111)
+
+**Decision and boundary**
+
+- Add a project-owned, test-only runtime-evidence harness under
+  `tests/performance/`; it is neither a package API nor a normal CI timing
+  gate.
+- Use only a deterministic original synthetic vault. The initial scale is 96
+  pages with 24 blocks per page, cross-page links, aliases, tags, and one
+  bounded deep-chain page. The generator and its schema version are part of
+  the evidence contract.
+- Measure five separately named scenarios: a 1024-level #87 parse seed, cold
+  graph load, #103 title-and-alias move reload, `search_content`, and SYNAPSE
+  context-enriched chunk construction.
+- A default run emits one source-free JSON receipt to stdout and writes no
+  result by default. It must not receive a private vault path or send network
+  traffic. Generated source, source paths, page titles, UUIDs, and exception
+  text are excluded from receipts.
+
+**Measurement protocol**
+
+- Each scenario has three warm-up iterations followed by 21 measured samples;
+  `perf_counter_ns` supplies duration samples. The receipt reports median and
+  p95 only with the full sample count and warm-up count.
+- Where the platform provides it, report process high-water memory with its
+  native unit and an explicit availability state. It is an observation, not a
+  normalized cross-platform value.
+- Label every receipt with harness and generator versions, exact scenario
+  identity, source hash and aggregate counts, Python version, platform,
+  machine labels available without probing private data, and the exact replay
+  command. Receipts are host-specific and non-comparable by default.
+- Verify semantic output in every scenario: parser tree invariants, #103
+  incremental-versus-cold graph equivalence, expected search identities, and
+  chunk count and lineage. A timing sample without its scenario's semantic
+  gate is invalid evidence.
+
+**Dependencies**
+
+- #87's bounded parser correction, #103 cold-load equivalence evidence, and
+  the existing original M1/M3/M4 fixtures. SYNAPSE remains optional: if its
+  runtime dependency is unavailable, that scenario is classified as
+  unavailable rather than skipped or passed.
+
+**Exit evidence**
+
+- Deterministic generator and receipt-schema tests; source-free local receipts
+  from an exact committed head; semantic gates for all available scenarios;
+  fresh impact analysis and zero import cycles; and a documented noise policy.
+- The ordinary suite validates structure and semantics only. No CI duration,
+  p95, or RSS threshold is introduced in this milestone. Any future
+  host-specific budget, cross-machine comparison, release claim, or public
+  performance headline requires a separately approved baseline and promotion
+  decision.
+
+**Residual risk**
+
+- Synthetic evidence cannot represent every real vault, filesystem, CPU, or
+  optional-adapter condition. It establishes reproducible local observations,
+  not a universal speed guarantee.
+
 ## 12. Explicit deferrals and rejection triggers
 
 | Proposal | Disposition | Reconsider only when |

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,9 @@ audience: contributors
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-19
-verified: 2026-08-19
-stale_after: 2027-02-19
+last_verified: 2026-08-20
+verified: 2026-08-20
+stale_after: 2027-02-20
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -68,6 +68,7 @@ entry points.
 | [`decisions/ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md`](decisions/ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md) | Maintainers, documentation reviewers | Decision to preserve the measured official OKF backlog until profile conflicts are resolved |
 | [`decisions/ADR-0003-AAIF-SUBMISSION-GATE.md`](decisions/ADR-0003-AAIF-SUBMISSION-GATE.md) | Maintainers, legal reviewers | Evidence-based NO-GO and reconsideration gate for any AAIF submission |
 | [`reference/LOCAL_GRAPH_ASSURANCE.md`](reference/LOCAL_GRAPH_ASSURANCE.md) | Integrators, maintainers | Bounded aggregate-only local vault assurance, report schema, and privacy boundary |
+| [`reference/PERFORMANCE_EVIDENCE.md`](reference/PERFORMANCE_EVIDENCE.md) | Maintainers | Test-only local runtime protocol and source-free receipt contract |
 | [`rfc/SOURCE_LOCATION_RFC.md`](rfc/SOURCE_LOCATION_RFC.md) | Maintainers, integrators | Accepted logical-line source-location contract and future expansion gate |
 | [`log.md`](log.md) | Maintainers | Maintained documentation chronology |
 | [`rfc/OLLAMA_RAG.md`](rfc/OLLAMA_RAG.md) | Integrators | Draft RFC for local Ollama RAG (issue [#34](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/34)) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-19
-verified: 2026-08-19
-stale_after: 2027-02-19
+last_verified: 2026-08-20
+verified: 2026-08-20
+stale_after: 2027-02-20
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -54,6 +54,7 @@ navigation layers only.
 | [Structured diagnostics](reference/DIAGNOSTICS.md) | Stable diagnostic schema, codes, path safety, rendering, and escalation |
 | [Filesystem safety](reference/FILESYSTEM_SAFETY.md) | Vault containment, atomic write, dry-run, metadata, and asset-read policy |
 | [Local graph assurance](reference/LOCAL_GRAPH_ASSURANCE.md) | Bounded aggregate-only vault checks with no report persistence or network operation |
+| [Runtime evidence](reference/PERFORMANCE_EVIDENCE.md) | Test-only local runtime protocol and source-free receipt contract |
 | [Source-location decision](rfc/SOURCE_LOCATION_RFC.md) | Accepted logical-line coordinate contract and offset-expansion admission gate |
 | [Documentation log](log.md) | Chronology of maintained knowledge changes |
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,6 +21,11 @@ superseded_by: null
 
 ## 2026-08-20
 
+- Added the maintained [runtime evidence reference](reference/PERFORMANCE_EVIDENCE.md)
+  for M8 / #111. It documents the test-only deterministic synthetic-vault
+  harness, source-free stdout receipt, semantic gates, optional SYNAPSE
+  classification, and local-noise policy. It adds no CI timing threshold,
+  cross-machine comparison, release qualification, or public performance claim.
 - Prepared v1.8.0 in [PR #171](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/171), merged it as `06a1d6cb3dcbb215c6aa108ce82d37da530d52a5`, and published tag `v1.8.0` through [release workflow run #32324328464](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32324328464).
 - The exact-tag run passed Python 3.12/3.13 pre-flight, package contract, one-time wheel/sdist build, Twine metadata checks, CycloneDX SBOM generation, dependency/license evidence, checksum verification, GitHub provenance and SBOM attestations, PyPI trusted publication, and GitHub Release creation.
 - Verified the public [GitHub Release](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases/tag/v1.8.0) assets after download: SHA-256 checks passed for the wheel, sdist, SBOM, and dependency/license inventory, and GitHub attestation verification passed for all four attestable artifacts. PyPI exposes version `1.8.0` with the published wheel and sdist digests.

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -48,6 +48,7 @@ maintained_documents = [
   "docs/reference/FILESYSTEM_SAFETY.md",
    "docs/security/DAILY_METRICS_THREAT_MODEL.md",
    "docs/reference/LOCAL_GRAPH_ASSURANCE.md",
+   "docs/reference/PERFORMANCE_EVIDENCE.md",
    "docs/rfc/SOURCE_LOCATION_RFC.md",
   "docs/log.md",
 ]

--- a/docs/reference/PERFORMANCE_EVIDENCE.md
+++ b/docs/reference/PERFORMANCE_EVIDENCE.md
@@ -1,0 +1,78 @@
+---
+type: ReferenceGuide
+title: Runtime evidence
+description: Test-only local runtime evidence protocol and source-free receipt contract.
+status: stable
+classification: active
+audience: maintainers
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-08-20
+verified: 2026-08-20
+stale_after: 2027-02-20
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# Runtime evidence
+
+Run the harness from an exact committed checkout:
+
+```bash
+uv run python -m tests.performance.runtime_evidence
+```
+
+The command creates only a deterministic synthetic vault in temporary
+directories, prints one source-free JSON receipt to stdout, and does not
+persist a receipt. It does not accept a vault path, read a private vault, or
+send network traffic.
+
+## What the receipt measures
+
+The fixed synthetic source contains 96 pages, 24 blocks on each ordinary page,
+cross-page links, aliases, tags, and one 1024-level outline. The receipt binds
+that source to a schema version, SHA-256 fingerprint, and aggregate counts; it
+does not include generated Markdown, source paths, page titles, block UUIDs,
+host names, or exception text.
+
+Each available scenario performs three warm-ups and 21 measured executions with
+`time.perf_counter_ns`. The receipt reports the median and nearest-rank p95 in
+nanoseconds. A duration is valid only when the scenario's semantic gate passes:
+
+- `deep_parse_1024` validates tree invariants on the bounded deep outline.
+- `cold_graph_load` validates the canonical-page count after a new graph load.
+- `incremental_alias_move_reload` compares ordered backlinks from an
+  incremental title-and-alias move reload with a cold load of the same source.
+- `search_content` validates the fixed search-result count and identities.
+- `synapse_context_chunks` validates chunk count and lineage metadata when the
+  optional adapter is available.
+
+If the optional SYNAPSE runtime dependency is unavailable, its scenario is
+reported as `unavailable` with reason `optional_adapter_unavailable`; it is not
+silently skipped or counted as a pass.
+
+The process high-water RSS is included only when the host supplies it. Its unit
+remains native: `bytes` on Darwin and `KiB` on supported Unix systems. It is an
+observation rather than a normalized memory measure.
+
+## Interpretation and noise policy
+
+A receipt is a local diagnostic, not a cross-machine comparison, CI timing
+gate, release qualification, or general performance guarantee. Interpret it
+only with its recorded Python version, platform system, and machine labels.
+
+- Run only from an exact committed head.
+- When a maintainer needs to retain an observation, store the unmodified JSON
+  outside the repository and only with explicit authority.
+- Close competing local workloads when practical and repeat only with the same
+  command and environment.
+- Never average or compare observations across machines.
+- Investigate a semantic-gate failure before considering any duration value.
+- A timing budget, public performance statement, or release use needs a
+  separately approved baseline and promotion decision.
+
+The harness is private test support under `tests/performance/`; it adds no
+package API and no normal CI duration or RSS threshold.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -50,6 +50,7 @@ already been refreshed.
 - [Dependency, license, SBOM, and provenance policy](DEPENDENCY_LICENSE_POLICY.md)
 - [Daily metrics threat model](../security/DAILY_METRICS_THREAT_MODEL.md)
 - [Privacy-safe local graph assurance](LOCAL_GRAPH_ASSURANCE.md)
+- [Test-only runtime evidence protocol](PERFORMANCE_EVIDENCE.md)
 - [Source-location decision](../rfc/SOURCE_LOCATION_RFC.md)
 - [Architecture](../CLEAN_CODE_ARCHITECTURE.md)
 - [AST primer](../logseq_ast_primer.md)

--- a/docs/superpowers/plans/2026-08-20-runtime-evidence-harness.md
+++ b/docs/superpowers/plans/2026-08-20-runtime-evidence-harness.md
@@ -1,0 +1,588 @@
+# Runtime Evidence Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a project-owned, test-only, source-free runtime-evidence harness for issue #111 that produces reproducible local observations without adding a public API or CI timing gate.
+
+**Architecture:** The harness lives entirely below `tests/performance/`. A deterministic synthetic-vault generator owns the fixed input and aggregate source fingerprint; a pure measurement model owns sampling, statistics, receipt shaping, and source-free validation; a runner materializes only temporary synthetic files and executes the five semantic scenarios. A maintained reference document explains replay and noise handling but makes no portability or release-performance claim.
+
+**Tech Stack:** Python 3.12+, `pytest`, standard library (`argparse`, `dataclasses`, `hashlib`, `json`, `pathlib`, `statistics`-free rank calculation, `tempfile`, `time`), existing `StackMachineParser`, `LogseqGraph`, and optional `SynapseAdapter`.
+
+**Spec:** `docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md` (M8 — Reproducible measured-runtime evidence, issue #111)
+
+## Global Constraints
+
+- Create all production-free implementation under `tests/performance/`; do not change `src/`, package exports, CLI entry points, dependencies, build metadata, or normal CI timing thresholds.
+- Generate only an original deterministic synthetic vault: 96 pages, 24 blocks per ordinary page, cross-page links, aliases, tags, and one 1024-level deep-chain page. Never accept a caller-supplied vault path.
+- Default execution emits exactly one JSON receipt to stdout and persists no receipt. Temporary synthetic files may exist only inside a `TemporaryDirectory` during a scenario.
+- Receipts must omit generated Markdown, paths, page titles, UUIDs, host names, and exception text. They may retain aggregate counts, SHA-256 fingerprints, fixed scenario identifiers, fixed availability codes, Python version, platform system/machine, and replay command.
+- Each available scenario runs exactly 3 warm-ups and 21 measured samples with `time.perf_counter_ns`; median and p95 are reported in nanoseconds. p95 is the sorted sample at `ceil(0.95 * n) - 1`.
+- A scenario sample is valid only when its semantic assertion succeeds. The optional SYNAPSE scenario is `unavailable` with the fixed reason `optional_adapter_unavailable` if LangChain is not importable; it is never a pass or skip in that state.
+- RSS is a labelled native high-water observation, with `bytes` on Darwin, `KiB` on supported Unix, or explicit `unavailable`; it is not normalized or compared across machines.
+- Use the existing #87 tree-invariant helpers and the #103 incremental-versus-cold backlink equivalence pattern. Do not copy external code, corpus, schemas, control flow, or documentation.
+- Run fresh impact analysis and verify zero source import cycles before any later edit of protected parser/graph hubs. This plan itself does not modify them.
+- Keep all documentation and emitted operator messages in English. Do not include private-vault content, credentials, tool caches, or generated receipts in commits.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+|---|---|
+| `tests/performance/__init__.py` | Marks the private harness as a runnable test package; exports nothing. |
+| `tests/performance/synthetic_vault.py` | Fixed original vault schema, deterministic Markdown bytes, aggregate fingerprint, and temporary materialization helper. |
+| `tests/performance/runtime_evidence.py` | Scenario names, availability/result/receipt dataclasses, deterministic percentile calculation, source-free receipt serialization, semantic scenario functions, and `python -m` entry point. |
+| `tests/test_performance_synthetic_vault.py` | Generator cardinality, determinism, bounds, materialization, and no-private-input tests. |
+| `tests/test_runtime_evidence.py` | Sampling protocol, statistics, source-free receipt schema, semantic gates, optional-adapter classification, and stdout-only CLI tests. |
+| `docs/reference/PERFORMANCE_EVIDENCE.md` | Maintained operator contract, replay command, receipt interpretation, and noise policy. |
+| `docs/index.md` | Adds the maintained performance-evidence entry point. |
+| `docs/maintained.toml` | Adds the new maintained reference document to the documentation checker. |
+| `docs/log.md` | Records the source-level documentation evolution without inventing a measured performance result. |
+
+## Task 1: Deterministic synthetic vault
+
+**Files:**
+
+- Create: `tests/performance/__init__.py`
+- Create: `tests/performance/synthetic_vault.py`
+- Create: `tests/test_performance_synthetic_vault.py`
+
+**Interfaces:**
+
+- Consumes: standard-library `Path`, `TemporaryDirectory` callers, and no repository runtime API.
+- Produces: `SyntheticVault`, `build_synthetic_vault()`, `PAGE_COUNT`, `BLOCKS_PER_PAGE`, `DEEP_CHAIN_DEPTH`, and `SYNTHETIC_VAULT_SCHEMA_VERSION` for the runner.
+
+- [ ] **Step 1: Write failing generator-contract tests**
+
+```python
+from tests.performance.synthetic_vault import (
+    BLOCKS_PER_PAGE,
+    DEEP_CHAIN_DEPTH,
+    PAGE_COUNT,
+    build_synthetic_vault,
+)
+
+
+def test_synthetic_vault_has_the_fixed_original_shape() -> None:
+    vault = build_synthetic_vault()
+
+    assert vault.page_count == PAGE_COUNT == 96
+    assert vault.blocks_per_page == BLOCKS_PER_PAGE == 24
+    assert vault.deep_chain_depth == DEEP_CHAIN_DEPTH == 1024
+    assert len(vault.files) == PAGE_COUNT
+    assert vault.total_source_bytes > 0
+
+
+def test_synthetic_vault_is_deterministic_and_materializes_only_under_destination(tmp_path: Path) -> None:
+    first = build_synthetic_vault()
+    second = build_synthetic_vault()
+    destination = tmp_path / "synthetic"
+
+    first.materialize(destination)
+
+    assert first.source_sha256 == second.source_sha256
+    assert sorted(path.relative_to(destination) for path in destination.rglob("*.md"))
+    assert all(path.is_relative_to(destination) for path in destination.rglob("*.md"))
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `rtk .venv/bin/python -m pytest tests/test_performance_synthetic_vault.py -q`
+
+Expected: FAIL during collection because `tests.performance.synthetic_vault` does not exist.
+
+- [ ] **Step 3: Implement the fixed generator and bounded materializer**
+
+```python
+SYNTHETIC_VAULT_SCHEMA_VERSION: Final = 1
+PAGE_COUNT: Final = 96
+BLOCKS_PER_PAGE: Final = 24
+DEEP_CHAIN_DEPTH: Final = 1024
+
+
+@dataclass(frozen=True)
+class SyntheticVault:
+    files: tuple[tuple[PurePosixPath, bytes], ...]
+    page_count: int
+    blocks_per_page: int
+    deep_chain_depth: int
+
+    @property
+    def total_source_bytes(self) -> int:
+        return sum(len(content) for _, content in self.files)
+
+    @property
+    def deep_chain_source(self) -> str:
+        return next(
+            content.decode("utf-8")
+            for relative_path, content in self.files
+            if relative_path == PurePosixPath("pages/runtime-evidence-deep.md")
+        )
+
+    @property
+    def source_sha256(self) -> str:
+        digest = hashlib.sha256()
+        for relative_path, content in self.files:
+            digest.update(relative_path.as_posix().encode("utf-8"))
+            digest.update(b"\\0")
+            digest.update(content)
+            digest.update(b"\\0")
+        return digest.hexdigest()
+
+    def materialize(self, destination: Path) -> Path:
+        root = destination.resolve()
+        for relative_path, content in self.files:
+            target = (root / relative_path).resolve()
+            try:
+                target.relative_to(root)
+            except ValueError as error:
+                raise ValueError("synthetic vault path escapes destination") from error
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+        return root
+```
+
+Generate 95 ordinary `pages/` files and one deep-chain `pages/` file. Each ordinary page must contain exactly 24 blocks, one fixed tag, one alias, and a deterministic link to the next page. Build the deep source from `DEEP_CHAIN_DEPTH` two-space-indented outline lines. Sort paths before freezing `files`; do not place generated labels in any public receipt.
+
+- [ ] **Step 4: Add exact boundary tests**
+
+```python
+def test_synthetic_vault_has_no_external_input_parameter() -> None:
+    assert inspect.signature(build_synthetic_vault).parameters == {}
+
+
+def test_synthetic_vault_rejects_materialization_escape(tmp_path: Path) -> None:
+    vault = SyntheticVault(
+        files=((PurePosixPath("../escape.md"), b"- prohibited\\n"),),
+        page_count=1,
+        blocks_per_page=1,
+        deep_chain_depth=1,
+    )
+
+    with pytest.raises(ValueError):
+        vault.materialize(tmp_path / "root")
+```
+
+Raise `ValueError("synthetic vault path escapes destination")` when a resolved target is outside the resolved destination. The public fixed builder must never generate this condition.
+
+- [ ] **Step 5: Run the focused tests to verify they pass**
+
+Run: `rtk .venv/bin/python -m pytest tests/test_performance_synthetic_vault.py -q`
+
+Expected: PASS. The source fingerprint is identical across two builds, exactly 96 Markdown files materialize below the destination, and the escape test fails closed.
+
+- [ ] **Step 6: Commit the self-contained generator slice**
+
+```bash
+rtk git add tests/performance/__init__.py tests/performance/synthetic_vault.py tests/test_performance_synthetic_vault.py
+rtk git commit -m "test: add deterministic runtime evidence vault"
+```
+
+## Task 2: Source-free measurement model and receipt schema
+
+**Files:**
+
+- Create: `tests/performance/runtime_evidence.py`
+- Create: `tests/test_runtime_evidence.py`
+
+**Interfaces:**
+
+- Consumes: `SyntheticVault` and its aggregate properties from Task 1.
+- Produces: `ScenarioName`, `ScenarioAvailability`, `ScenarioReceipt`, `RuntimeEvidenceReceipt`, `build_runtime_receipt()`, `measure_scenario()`, `percentile_p95_ns()`, and `resident_high_water_observation()` for Task 3.
+
+- [ ] **Step 1: Write failing pure-model tests**
+
+```python
+def test_p95_uses_the_declared_nearest_rank_rule() -> None:
+    assert percentile_p95_ns(tuple(range(1, 22))) == 20
+
+
+def test_measurement_protocol_uses_three_warmups_and_twenty_one_samples() -> None:
+    calls = 0
+
+    def semantic_action() -> None:
+        nonlocal calls
+        calls += 1
+
+    receipt = measure_scenario("cold_graph_load", semantic_action, clock_ns=lambda: calls * 10)
+
+    assert calls == 24
+    assert receipt.warmup_count == 3
+    assert receipt.sample_count == 21
+    assert receipt.availability == "available"
+    assert receipt.semantic_gate_passed is True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `rtk .venv/bin/python -m pytest tests/test_runtime_evidence.py -q`
+
+Expected: FAIL during collection because `tests.performance.runtime_evidence` does not exist.
+
+- [ ] **Step 3: Implement immutable receipts and deterministic statistics**
+
+```python
+WARMUP_COUNT: Final = 3
+SAMPLE_COUNT: Final = 21
+RUNTIME_EVIDENCE_SCHEMA_VERSION: Final = 1
+RUNTIME_EVIDENCE_HARNESS_VERSION: Final = 1
+
+ScenarioName = Literal[
+    "deep_parse_1024",
+    "cold_graph_load",
+    "incremental_alias_move_reload",
+    "search_content",
+    "synapse_context_chunks",
+]
+ScenarioAvailability = Literal["available", "unavailable", "invalid"]
+
+
+@dataclass(frozen=True)
+class ScenarioReceipt:
+    scenario: ScenarioName
+    availability: ScenarioAvailability
+    unavailable_reason: Literal["optional_adapter_unavailable"] | None
+    semantic_gate_passed: bool
+    warmup_count: int
+    sample_count: int
+    median_duration_ns: int | None
+    p95_duration_ns: int | None
+
+
+@dataclass(frozen=True)
+class RuntimeEvidenceReceipt:
+    runtime_evidence_schema_version: int
+    runtime_evidence_harness_version: int
+    synthetic_vault_schema_version: int
+    source_sha256: str
+    aggregate_counts: dict[str, int]
+    python_version: str
+    platform_system: str
+    platform_machine: str
+    replay_command: str
+    resident_high_water: dict[str, int | str]
+    scenarios: tuple[ScenarioReceipt, ...]
+
+    def to_payload(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def percentile_p95_ns(samples: tuple[int, ...]) -> int:
+    if not samples:
+        raise ValueError("p95 requires at least one sample")
+    return sorted(samples)[math.ceil(0.95 * len(samples)) - 1]
+
+
+def median_ns(samples: tuple[int, ...]) -> int:
+    if len(samples) % 2 != 1:
+        raise ValueError("runtime evidence requires an odd sample count")
+    return sorted(samples)[len(samples) // 2]
+```
+
+`measure_scenario()` must call the supplied no-argument action three times before capturing any duration and 21 times inside `started = clock_ns(); action(); elapsed = clock_ns() - started`. Reject negative elapsed values. Use `median_ns()` and `percentile_p95_ns()` for available samples. If any action raises or fails its semantic assertion, return `availability="invalid"`, `semantic_gate_passed=False`, and all duration fields as `None`; store neither the exception nor its text.
+
+- [ ] **Step 4: Write receipt privacy and platform-observation tests**
+
+```python
+def test_receipt_payload_is_source_free() -> None:
+    vault = build_synthetic_vault()
+    scenario = ScenarioReceipt(
+        scenario="cold_graph_load",
+        availability="available",
+        unavailable_reason=None,
+        semantic_gate_passed=True,
+        warmup_count=3,
+        sample_count=21,
+        median_duration_ns=10,
+        p95_duration_ns=20,
+    )
+    receipt = build_runtime_receipt(vault, (scenario,))
+    payload = receipt.to_payload()
+
+    assert payload["source_sha256"] == vault.source_sha256
+    rendered = json.dumps(payload, sort_keys=True)
+    assert "source" not in {key for key in payload if key != "source_sha256"}
+    assert vault.files[0][0].name not in rendered
+    assert vault.files[0][1].decode("utf-8") not in rendered
+    assert "path" not in rendered.casefold()
+    assert "exception" not in rendered.casefold()
+    assert "host" not in rendered.casefold()
+
+
+def test_missing_native_rss_is_explicitly_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runtime_evidence, "resource", None)
+    assert resident_high_water_observation() == {"availability": "unavailable"}
+```
+
+The outer receipt must include only: schema/harness/generator versions, source hash, aggregate page/block/deep-depth/byte counts, Python version, platform system/machine, a fixed replay command, RSS observation, and scenario receipts. Its `to_payload()` must not expose a `samples` field, raw source, generated filename, page title, UUID, exception, current working directory, or host name.
+
+- [ ] **Step 5: Run the focused model tests to verify they pass**
+
+Run: `rtk .venv/bin/python -m pytest tests/test_runtime_evidence.py -q`
+
+Expected: PASS. Tests prove the exact 3+21 protocol, nearest-rank p95, invalid semantic handling without exception disclosure, optional RSS availability, and source-free serialization.
+
+- [ ] **Step 6: Commit the pure measurement slice**
+
+```bash
+rtk git add tests/performance/runtime_evidence.py tests/test_runtime_evidence.py
+rtk git commit -m "test: add source-free runtime receipt model"
+```
+
+## Task 3: Semantic scenario runner and stdout-only replay interface
+
+**Files:**
+
+- Modify: `tests/performance/runtime_evidence.py`
+- Modify: `tests/test_runtime_evidence.py`
+
+**Interfaces:**
+
+- Consumes: `build_synthetic_vault()`, `SyntheticVault.materialize()`, `measure_scenario()`, `RuntimeEvidenceReceipt`, `StackMachineParser`, `LogseqGraph`, `SynapseAdapter`, and `assert_tree_invariants()`.
+- Produces: `run_runtime_evidence() -> RuntimeEvidenceReceipt` and `main(argv: Sequence[str] | None = None) -> int`; both are private test-harness surfaces, not package APIs.
+
+- [ ] **Step 1: Write failing semantic-scenario tests**
+
+```python
+def test_all_core_scenarios_are_semantically_valid() -> None:
+    receipt = run_runtime_evidence()
+    by_name = {scenario.scenario: scenario for scenario in receipt.scenarios}
+
+    assert set(by_name) == {
+        "deep_parse_1024",
+        "cold_graph_load",
+        "incremental_alias_move_reload",
+        "search_content",
+        "synapse_context_chunks",
+    }
+    for name in by_name:
+        if name != "synapse_context_chunks":
+            assert by_name[name].availability == "available"
+            assert by_name[name].semantic_gate_passed is True
+
+
+def test_optional_synapse_is_unavailable_not_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runtime_evidence.synapse_module, "Document", None)
+
+    scenario = runtime_evidence.run_synapse_context_chunks()
+
+    assert scenario.availability == "unavailable"
+    assert scenario.unavailable_reason == "optional_adapter_unavailable"
+    assert scenario.semantic_gate_passed is False
+    assert scenario.sample_count == 0
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `rtk .venv/bin/python -m pytest tests/test_runtime_evidence.py -q`
+
+Expected: FAIL because the scenario functions and runner do not yet exist.
+
+- [ ] **Step 3: Implement the five semantic actions**
+
+```python
+def run_deep_parse_1024(vault: SyntheticVault) -> ScenarioReceipt:
+    def action() -> None:
+        page = StackMachineParser().parse(vault.deep_chain_source, page_title="runtime-deep")
+        assert_tree_invariants(page)
+        assert len(tuple(walk_nodes(page.root_nodes))) == DEEP_CHAIN_DEPTH
+
+    return measure_scenario("deep_parse_1024", action)
+
+
+def run_cold_graph_load(vault: SyntheticVault) -> ScenarioReceipt:
+    def action() -> None:
+        with TemporaryDirectory() as temporary:
+            graph = LogseqGraph.load_directory(vault.materialize(Path(temporary)))
+            assert len(graph.pages) == vault.page_count
+
+    return measure_scenario("cold_graph_load", action)
+```
+
+For `incremental_alias_move_reload`, materialize a new temporary synthetic vault for every action, alter only the known generated title/alias fixture, call `invalidate_and_reload_page()` on the former and moved paths, cold-load the same temporary vault, and compare the ordered backlink source UUID lists for the former title, new title, retained alias, and new alias. The UUID lists are semantic assertions only and must never enter the receipt.
+
+For `search_content`, cold-load a temporary vault, search the fixed unique token embedded by the generator, and assert the expected aggregate count and non-empty node identities. Import `logseq_matryca_parser.synapse` as `synapse_module`. For `synapse_context_chunks`, return `unavailable` before sampling when `synapse_module.Document is None`; otherwise patch `synapse_module.Document` with a small local `HarnessDocument`, run `SynapseAdapter.to_context_enriched_chunks()`, and assert expected count plus non-empty lineage metadata (`page_title`, `source_path`, `line_start`, and `parent_id` where applicable). Do not import, invoke, or serialize any real vault.
+
+- [ ] **Step 4: Write the failing stdout-only CLI test**
+
+```python
+def test_module_cli_emits_one_source_free_json_object() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "tests.performance.runtime_evidence"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stderr == ""
+    payload = json.loads(completed.stdout)
+    assert payload["replay_command"] == "uv run python -m tests.performance.runtime_evidence"
+    assert "exception" not in completed.stdout.casefold()
+```
+
+- [ ] **Step 5: Implement the replay entry point and execute focused verification**
+
+```python
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Emit a source-free local runtime-evidence receipt.")
+    parser.parse_args(argv)
+    print(json.dumps(run_runtime_evidence().to_payload(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+Run: `rtk .venv/bin/python -m pytest tests/test_performance_synthetic_vault.py tests/test_runtime_evidence.py -q`
+
+Expected: PASS. The core scenarios are valid, SYNAPSE has an explicit unavailable state if optional support is absent, and subprocess output is one parseable source-free JSON object with no persisted file.
+
+- [ ] **Step 6: Inspect a manual local receipt without recording it in the repository**
+
+Run: `rtk .venv/bin/python -m tests.performance.runtime_evidence`
+
+Expected: one JSON object with five scenario entries, each available entry reporting exactly 3 warm-ups and 21 samples, and no generated Markdown, paths, titles, UUIDs, host name, or exception text. Treat observed time and RSS values as local diagnostics only.
+
+- [ ] **Step 7: Commit the executable test-only harness**
+
+```bash
+rtk git add tests/performance/runtime_evidence.py tests/test_runtime_evidence.py
+rtk git commit -m "test: add runtime evidence scenarios"
+```
+
+## Task 4: Maintained operator documentation and final validation
+
+**Files:**
+
+- Create: `docs/reference/PERFORMANCE_EVIDENCE.md`
+- Modify: `docs/index.md`
+- Modify: `docs/maintained.toml`
+- Modify: `docs/log.md`
+
+**Interfaces:**
+
+- Consumes: the fixed replay command and receipt field contract from Task 3; the M8 decision from the canonical execution plan.
+- Produces: a maintained human/agent-facing reference that explains how to obtain and interpret local evidence without adding a public performance promise.
+
+- [ ] **Step 1: Write failing maintained-document registration checks**
+
+```python
+def test_performance_evidence_reference_is_maintained_and_indexed() -> None:
+    maintained = Path("docs/maintained.toml").read_text(encoding="utf-8")
+    index = Path("docs/index.md").read_text(encoding="utf-8")
+
+    assert '"docs/reference/PERFORMANCE_EVIDENCE.md"' in maintained
+    assert "[Runtime evidence](reference/PERFORMANCE_EVIDENCE.md)" in index
+```
+
+Place this focused assertion in `tests/test_runtime_evidence.py`; `tests/test_check_documentation.py` already validates the checker itself against disposable fixtures, while this assertion protects the real M8 registration and avoids a second documentation-test framework.
+
+- [ ] **Step 2: Run the registration check to verify it fails**
+
+Run: `rtk .venv/bin/python -m pytest tests/test_runtime_evidence.py -q`
+
+Expected: FAIL because the reference and registrations do not yet exist.
+
+- [ ] **Step 3: Add the reference document with exact operational boundaries**
+
+The new document must have the repository-required frontmatter fields and state all of the following in direct English:
+
+```markdown
+---
+type: ReferenceGuide
+title: Runtime evidence
+description: Test-only local runtime evidence protocol and source-free receipt contract.
+status: stable
+classification: canonical
+audience: maintainers
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-08-20
+verified: 2026-08-20
+stale_after: 2027-02-20
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# Runtime evidence
+
+Run `uv run python -m tests.performance.runtime_evidence` from an exact committed checkout.
+The command prints one source-free JSON receipt and does not persist a result.
+
+Interpret each receipt only on its recorded Python/platform/machine context.
+It is an observation, not a cross-machine comparison, CI gate, release claim,
+or general performance guarantee.
+```
+
+Add a compact noise policy: run on an exact committed head; record the unmodified JSON externally only when a maintainer explicitly needs it; close competing local workloads when practical; repeat only with the same command and environment; never average observations across machines; investigate a semantic-gate failure before considering any duration; and require a separately approved baseline/promotion decision before a budget, release statement, or public headline. State the fixed 3 warm-up/21-sample protocol, nearest-rank p95, native RSS labelling, synthetic-only scope, no private input path, and SYNAPSE `unavailable` status.
+
+- [ ] **Step 4: Register the document and record the documentation evolution**
+
+Add exactly one `Runtime evidence` row to the maintained-entry table in `docs/index.md`, add the exact path to `maintained_documents` in `docs/maintained.toml`, and add a concise dated entry to `docs/log.md`. The log may claim that the contract and replay documentation were added; it must not claim benchmark results, cross-machine comparability, CI enforcement, release qualification, or a public performance improvement.
+
+- [ ] **Step 5: Run focused and repository documentation validation**
+
+Run:
+
+```bash
+rtk .venv/bin/python -m pytest tests/test_performance_synthetic_vault.py tests/test_runtime_evidence.py -q
+rtk .venv/bin/python scripts/check_documentation.py --root . --profile docs/maintained.toml --as-of-date 2026-08-20
+rtk bash scripts/check_vendor_free_docs.sh
+rtk git diff --check
+```
+
+Expected: PASS. The maintained checker accepts frontmatter and registration, the terminology policy accepts public files, and no whitespace error is present.
+
+- [ ] **Step 6: Perform required structural and full-suite verification**
+
+Run:
+
+```bash
+rtk .venv/bin/python -m pytest -q --cov=src/logseq_matryca_parser --cov-report=term-missing
+rtk .venv/bin/ruff check src tests
+rtk .venv/bin/mypy src
+rtk make vendor-name-check
+rtk git diff --check
+```
+
+Before this command block, run the approved local audit-code workflow for `LogseqGraph.load_directory` and `LogseqGraph.invalidate_and_reload_page`, then run its cycle check. Retain only the local terminal receipt: the repository policy deliberately forbids naming the indexer product in source-controlled artifacts. Expected: impact evidence is reviewed before any protected-hub change, import cycles report zero, full tests meet the existing coverage floor, lint/type/documentation/policy checks pass, and whitespace is clean.
+
+- [ ] **Step 7: Commit documentation and hand off for review**
+
+```bash
+rtk git add docs/reference/PERFORMANCE_EVIDENCE.md docs/index.md docs/maintained.toml docs/log.md tests/test_runtime_evidence.py
+rtk git commit -m "docs: document runtime evidence protocol"
+rtk git status --short --branch
+```
+
+Report the exact commit, branch, command receipts, optional SYNAPSE availability, and any unavailable verification. Do not push, open a pull request, merge, tag, or release without separate live GitHub checks and authorization.
+
+## Plan self-review
+
+### Spec coverage
+
+| M8 requirement | Implementing task |
+|---|---|
+| Test-only harness; no public API, dependency, or CI threshold | Tasks 1–3 global constraints and isolated `tests/performance/` files |
+| Original deterministic vault with 96 pages, 24 blocks, cross-links, aliases, tags, and a bounded deep chain | Task 1 |
+| Five named scenarios | Task 3 |
+| Three warm-ups, 21 samples, `perf_counter_ns`, median, and nearest-rank p95 | Task 2 |
+| Native-unit RSS with explicit unavailable state | Task 2 |
+| Source-free, stdout-only JSON with aggregate identity and exact replay | Tasks 2–3 |
+| Semantic validity in every available sample | Task 3 |
+| Optional SYNAPSE unavailable, never passed or skipped | Tasks 2–3 |
+| No universal performance claim; documented noise and promotion policy | Task 4 |
+| Fresh hub impact evidence, zero cycles, and full validation | Task 4 |
+
+### Placeholder scan
+
+The plan contains no unbounded work item, unresolved interface, external corpus dependency, or unspecified validation command. The approved local audit wrapper is deliberately abstract only in a private execution command, because the repository policy forbids placing a particular third-party tool name in source-controlled artifacts.
+
+### Type and contract consistency
+
+`SyntheticVault` is the only generated-source carrier and supplies aggregate fields to `RuntimeEvidenceReceipt`. `measure_scenario()` returns `ScenarioReceipt`; each scenario runner returns the same type; `run_runtime_evidence()` aggregates those five scenario receipts. Receipt serialization is the sole data path to stdout, which keeps generated source and exception objects out of emitted data.

--- a/docs/superpowers/plans/2026-08-20-runtime-evidence-harness.md
+++ b/docs/superpowers/plans/2026-08-20-runtime-evidence-harness.md
@@ -446,7 +446,7 @@ Run: `rtk .venv/bin/python -m tests.performance.runtime_evidence`
 
 Expected: one JSON object with five scenario entries, each available entry reporting exactly 3 warm-ups and 21 samples, and no generated Markdown, paths, titles, UUIDs, host name, or exception text. Treat observed time and RSS values as local diagnostics only.
 
-- [ ] **Step 7: Commit the executable test-only harness**
+- [x] **Step 7: Commit the executable test-only harness**
 
 ```bash
 rtk git add tests/performance/runtime_evidence.py tests/test_runtime_evidence.py
@@ -598,3 +598,16 @@ The plan contains no unbounded work item, unresolved interface, external corpus 
   `tests/test_performance_evidence_docs.py`, rather than the timing-model test
   module, so documentation navigation can evolve without expanding the
   scenario suite's runtime.
+
+### Execution record — 2026-08-20
+
+- The approved deep-graph precondition is `b5ace92`; its 1024-level graph
+  regression and the focused graph/parser qualification passed.
+- The deterministic vault, source-free receipt model, semantic runner, and
+  documentation commits are `259d3ce`, `b2c93e8`, `c554786`, and `1b6afc4`.
+- On exact committed head `1b6afc4`, the default replay command completed with
+  exit code `0`. All five scenarios were available and their semantic gates
+  passed. The source-free host-local JSON was deliberately not persisted.
+- Full local qualification passed with 679 tests, 89.46% coverage, Ruff,
+  mypy, documentation validation, terminology policy, and zero source import
+  cycles. A separate independent final review remains required before a PR.

--- a/docs/superpowers/plans/2026-08-20-runtime-evidence-harness.md
+++ b/docs/superpowers/plans/2026-08-20-runtime-evidence-harness.md
@@ -34,6 +34,7 @@
 | `tests/performance/runtime_evidence.py` | Scenario names, availability/result/receipt dataclasses, deterministic percentile calculation, source-free receipt serialization, semantic scenario functions, and `python -m` entry point. |
 | `tests/test_performance_synthetic_vault.py` | Generator cardinality, determinism, bounds, materialization, and no-private-input tests. |
 | `tests/test_runtime_evidence.py` | Sampling protocol, statistics, source-free receipt schema, semantic gates, optional-adapter classification, and stdout-only CLI tests. |
+| `tests/test_performance_evidence_docs.py` | Maintained-reference registration checks, kept separate from the runtime scenario suite. |
 | `docs/reference/PERFORMANCE_EVIDENCE.md` | Maintained operator contract, replay command, receipt interpretation, and noise policy. |
 | `docs/index.md` | Adds the maintained performance-evidence entry point. |
 | `docs/maintained.toml` | Adds the new maintained reference document to the documentation checker. |
@@ -52,7 +53,7 @@
 - Consumes: standard-library `Path`, `TemporaryDirectory` callers, and no repository runtime API.
 - Produces: `SyntheticVault`, `build_synthetic_vault()`, `PAGE_COUNT`, `BLOCKS_PER_PAGE`, `DEEP_CHAIN_DEPTH`, and `SYNTHETIC_VAULT_SCHEMA_VERSION` for the runner.
 
-- [ ] **Step 1: Write failing generator-contract tests**
+- [x] **Step 1: Write failing generator-contract tests**
 
 ```python
 from tests.performance.synthetic_vault import (
@@ -85,13 +86,13 @@ def test_synthetic_vault_is_deterministic_and_materializes_only_under_destinatio
     assert all(path.is_relative_to(destination) for path in destination.rglob("*.md"))
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `rtk .venv/bin/python -m pytest tests/test_performance_synthetic_vault.py -q`
 
 Expected: FAIL during collection because `tests.performance.synthetic_vault` does not exist.
 
-- [ ] **Step 3: Implement the fixed generator and bounded materializer**
+- [x] **Step 3: Implement the fixed generator and bounded materializer**
 
 ```python
 SYNTHETIC_VAULT_SCHEMA_VERSION: Final = 1
@@ -144,7 +145,7 @@ class SyntheticVault:
 
 Generate 95 ordinary `pages/` files and one deep-chain `pages/` file. Each ordinary page must contain exactly 24 blocks, one fixed tag, one alias, and a deterministic link to the next page. Build the deep source from `DEEP_CHAIN_DEPTH` two-space-indented outline lines. Sort paths before freezing `files`; do not place generated labels in any public receipt.
 
-- [ ] **Step 4: Add exact boundary tests**
+- [x] **Step 4: Add exact boundary tests**
 
 ```python
 def test_synthetic_vault_has_no_external_input_parameter() -> None:
@@ -165,13 +166,13 @@ def test_synthetic_vault_rejects_materialization_escape(tmp_path: Path) -> None:
 
 Raise `ValueError("synthetic vault path escapes destination")` when a resolved target is outside the resolved destination. The public fixed builder must never generate this condition.
 
-- [ ] **Step 5: Run the focused tests to verify they pass**
+- [x] **Step 5: Run the focused tests to verify they pass**
 
 Run: `rtk .venv/bin/python -m pytest tests/test_performance_synthetic_vault.py -q`
 
 Expected: PASS. The source fingerprint is identical across two builds, exactly 96 Markdown files materialize below the destination, and the escape test fails closed.
 
-- [ ] **Step 6: Commit the self-contained generator slice**
+- [x] **Step 6: Commit the self-contained generator slice**
 
 ```bash
 rtk git add tests/performance/__init__.py tests/performance/synthetic_vault.py tests/test_performance_synthetic_vault.py
@@ -190,7 +191,7 @@ rtk git commit -m "test: add deterministic runtime evidence vault"
 - Consumes: `SyntheticVault` and its aggregate properties from Task 1.
 - Produces: `ScenarioName`, `ScenarioAvailability`, `ScenarioReceipt`, `RuntimeEvidenceReceipt`, `build_runtime_receipt()`, `measure_scenario()`, `percentile_p95_ns()`, and `resident_high_water_observation()` for Task 3.
 
-- [ ] **Step 1: Write failing pure-model tests**
+- [x] **Step 1: Write failing pure-model tests**
 
 ```python
 def test_p95_uses_the_declared_nearest_rank_rule() -> None:
@@ -213,13 +214,13 @@ def test_measurement_protocol_uses_three_warmups_and_twenty_one_samples() -> Non
     assert receipt.semantic_gate_passed is True
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `rtk .venv/bin/python -m pytest tests/test_runtime_evidence.py -q`
 
 Expected: FAIL during collection because `tests.performance.runtime_evidence` does not exist.
 
-- [ ] **Step 3: Implement immutable receipts and deterministic statistics**
+- [x] **Step 3: Implement immutable receipts and deterministic statistics**
 
 ```python
 WARMUP_COUNT: Final = 3
@@ -281,7 +282,7 @@ def median_ns(samples: tuple[int, ...]) -> int:
 
 `measure_scenario()` must call the supplied no-argument action three times before capturing any duration and 21 times inside `started = clock_ns(); action(); elapsed = clock_ns() - started`. Reject negative elapsed values. Use `median_ns()` and `percentile_p95_ns()` for available samples. If any action raises or fails its semantic assertion, return `availability="invalid"`, `semantic_gate_passed=False`, and all duration fields as `None`; store neither the exception nor its text.
 
-- [ ] **Step 4: Write receipt privacy and platform-observation tests**
+- [x] **Step 4: Write receipt privacy and platform-observation tests**
 
 ```python
 def test_receipt_payload_is_source_free() -> None:
@@ -316,13 +317,13 @@ def test_missing_native_rss_is_explicitly_unavailable(monkeypatch: pytest.Monkey
 
 The outer receipt must include only: schema/harness/generator versions, source hash, aggregate page/block/deep-depth/byte counts, Python version, platform system/machine, a fixed replay command, RSS observation, and scenario receipts. Its `to_payload()` must not expose a `samples` field, raw source, generated filename, page title, UUID, exception, current working directory, or host name.
 
-- [ ] **Step 5: Run the focused model tests to verify they pass**
+- [x] **Step 5: Run the focused model tests to verify they pass**
 
 Run: `rtk .venv/bin/python -m pytest tests/test_runtime_evidence.py -q`
 
 Expected: PASS. Tests prove the exact 3+21 protocol, nearest-rank p95, invalid semantic handling without exception disclosure, optional RSS availability, and source-free serialization.
 
-- [ ] **Step 6: Commit the pure measurement slice**
+- [x] **Step 6: Commit the pure measurement slice**
 
 ```bash
 rtk git add tests/performance/runtime_evidence.py tests/test_runtime_evidence.py
@@ -341,7 +342,7 @@ rtk git commit -m "test: add source-free runtime receipt model"
 - Consumes: `build_synthetic_vault()`, `SyntheticVault.materialize()`, `measure_scenario()`, `RuntimeEvidenceReceipt`, `StackMachineParser`, `LogseqGraph`, `SynapseAdapter`, and `assert_tree_invariants()`.
 - Produces: `run_runtime_evidence() -> RuntimeEvidenceReceipt` and `main(argv: Sequence[str] | None = None) -> int`; both are private test-harness surfaces, not package APIs.
 
-- [ ] **Step 1: Write failing semantic-scenario tests**
+- [x] **Step 1: Write failing semantic-scenario tests**
 
 ```python
 def test_all_core_scenarios_are_semantically_valid() -> None:
@@ -372,13 +373,13 @@ def test_optional_synapse_is_unavailable_not_skipped(monkeypatch: pytest.MonkeyP
     assert scenario.sample_count == 0
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `rtk .venv/bin/python -m pytest tests/test_runtime_evidence.py -q`
 
 Expected: FAIL because the scenario functions and runner do not yet exist.
 
-- [ ] **Step 3: Implement the five semantic actions**
+- [x] **Step 3: Implement the five semantic actions**
 
 ```python
 def run_deep_parse_1024(vault: SyntheticVault) -> ScenarioReceipt:
@@ -403,7 +404,7 @@ For `incremental_alias_move_reload`, materialize a new temporary synthetic vault
 
 For `search_content`, cold-load a temporary vault, search the fixed unique token embedded by the generator, and assert the expected aggregate count and non-empty node identities. Import `logseq_matryca_parser.synapse` as `synapse_module`. For `synapse_context_chunks`, return `unavailable` before sampling when `synapse_module.Document is None`; otherwise patch `synapse_module.Document` with a small local `HarnessDocument`, run `SynapseAdapter.to_context_enriched_chunks()`, and assert expected count plus non-empty lineage metadata (`page_title`, `source_path`, `line_start`, and `parent_id` where applicable). Do not import, invoke, or serialize any real vault.
 
-- [ ] **Step 4: Write the failing stdout-only CLI test**
+- [x] **Step 4: Write the failing stdout-only CLI test**
 
 ```python
 def test_module_cli_emits_one_source_free_json_object() -> None:
@@ -421,7 +422,7 @@ def test_module_cli_emits_one_source_free_json_object() -> None:
     assert "exception" not in completed.stdout.casefold()
 ```
 
-- [ ] **Step 5: Implement the replay entry point and execute focused verification**
+- [x] **Step 5: Implement the replay entry point and execute focused verification**
 
 ```python
 def main(argv: Sequence[str] | None = None) -> int:
@@ -439,7 +440,7 @@ Run: `rtk .venv/bin/python -m pytest tests/test_performance_synthetic_vault.py t
 
 Expected: PASS. The core scenarios are valid, SYNAPSE has an explicit unavailable state if optional support is absent, and subprocess output is one parseable source-free JSON object with no persisted file.
 
-- [ ] **Step 6: Inspect a manual local receipt without recording it in the repository**
+- [x] **Step 6: Inspect a manual local receipt without recording it in the repository**
 
 Run: `rtk .venv/bin/python -m tests.performance.runtime_evidence`
 
@@ -466,7 +467,7 @@ rtk git commit -m "test: add runtime evidence scenarios"
 - Consumes: the fixed replay command and receipt field contract from Task 3; the M8 decision from the canonical execution plan.
 - Produces: a maintained human/agent-facing reference that explains how to obtain and interpret local evidence without adding a public performance promise.
 
-- [ ] **Step 1: Write failing maintained-document registration checks**
+- [x] **Step 1: Write failing maintained-document registration checks**
 
 ```python
 def test_performance_evidence_reference_is_maintained_and_indexed() -> None:
@@ -477,15 +478,15 @@ def test_performance_evidence_reference_is_maintained_and_indexed() -> None:
     assert "[Runtime evidence](reference/PERFORMANCE_EVIDENCE.md)" in index
 ```
 
-Place this focused assertion in `tests/test_runtime_evidence.py`; `tests/test_check_documentation.py` already validates the checker itself against disposable fixtures, while this assertion protects the real M8 registration and avoids a second documentation-test framework.
+Place this focused assertion in `tests/test_performance_evidence_docs.py`; `tests/test_check_documentation.py` already validates the checker itself against disposable fixtures, while this assertion protects the real M8 registration and avoids a second documentation-test framework.
 
-- [ ] **Step 2: Run the registration check to verify it fails**
+- [x] **Step 2: Run the registration check to verify it fails**
 
 Run: `rtk .venv/bin/python -m pytest tests/test_runtime_evidence.py -q`
 
 Expected: FAIL because the reference and registrations do not yet exist.
 
-- [ ] **Step 3: Add the reference document with exact operational boundaries**
+- [x] **Step 3: Add the reference document with exact operational boundaries**
 
 The new document must have the repository-required frontmatter fields and state all of the following in direct English:
 
@@ -521,11 +522,11 @@ or general performance guarantee.
 
 Add a compact noise policy: run on an exact committed head; record the unmodified JSON externally only when a maintainer explicitly needs it; close competing local workloads when practical; repeat only with the same command and environment; never average observations across machines; investigate a semantic-gate failure before considering any duration; and require a separately approved baseline/promotion decision before a budget, release statement, or public headline. State the fixed 3 warm-up/21-sample protocol, nearest-rank p95, native RSS labelling, synthetic-only scope, no private input path, and SYNAPSE `unavailable` status.
 
-- [ ] **Step 4: Register the document and record the documentation evolution**
+- [x] **Step 4: Register the document and record the documentation evolution**
 
 Add exactly one `Runtime evidence` row to the maintained-entry table in `docs/index.md`, add the exact path to `maintained_documents` in `docs/maintained.toml`, and add a concise dated entry to `docs/log.md`. The log may claim that the contract and replay documentation were added; it must not claim benchmark results, cross-machine comparability, CI enforcement, release qualification, or a public performance improvement.
 
-- [ ] **Step 5: Run focused and repository documentation validation**
+- [x] **Step 5: Run focused and repository documentation validation**
 
 Run:
 
@@ -538,7 +539,7 @@ rtk git diff --check
 
 Expected: PASS. The maintained checker accepts frontmatter and registration, the terminology policy accepts public files, and no whitespace error is present.
 
-- [ ] **Step 6: Perform required structural and full-suite verification**
+- [x] **Step 6: Perform required structural and full-suite verification**
 
 Run:
 
@@ -586,3 +587,14 @@ The plan contains no unbounded work item, unresolved interface, external corpus 
 ### Type and contract consistency
 
 `SyntheticVault` is the only generated-source carrier and supplies aggregate fields to `RuntimeEvidenceReceipt`. `measure_scenario()` returns `ScenarioReceipt`; each scenario runner returns the same type; `run_runtime_evidence()` aggregates those five scenario receipts. Receipt serialization is the sole data path to stdout, which keeps generated source and exception objects out of emitted data.
+
+### Implementation amendments
+
+- The ordinary CLI unit test calls `main()` with the full runner replaced by a
+  fixed source-free receipt. The exact default command is separately exercised
+  manually. This keeps the 3+21 timing protocol out of the normal test suite
+  while retaining one real receipt observation and pure protocol coverage.
+- The real registration assertion lives in
+  `tests/test_performance_evidence_docs.py`, rather than the timing-model test
+  module, so documentation navigation can evolve without expanding the
+  scenario suite's runtime.

--- a/src/logseq_matryca_parser/graph.py
+++ b/src/logseq_matryca_parser/graph.py
@@ -230,6 +230,20 @@ def _wikilink_backlink_keys(pages: dict[str, LogseqPage], link: str) -> list[str
     return keys
 
 
+def _node_backlink_keys(pages: dict[str, LogseqPage], node: LogseqNode) -> Iterator[str]:
+    """Yield every backlink index key contributed by one source node."""
+    for link in node.wikilinks:
+        yield from _wikilink_backlink_keys(pages, link)
+    for tag in node.tags:
+        key = _normalize_backlink_key(tag)
+        if key:
+            yield key
+    for block_ref in node.block_refs:
+        key = _normalize_backlink_key(block_ref)
+        if key:
+            yield key
+
+
 def _build_node_registry_from_pages(pages: dict[str, LogseqPage]) -> dict[str, LogseqNode]:
     """Build the global node registry from indexed pages only (no title-collision ghosts)."""
     registry: dict[str, LogseqNode] = {}
@@ -443,17 +457,8 @@ def _build_backlink_registry(pages: dict[str, LogseqPage]) -> dict[str, list[str
     registry: dict[str, list[str]] = {}
     for page in iter_canonical_pages_from_dict(pages):
         for node in _flatten_nodes(page.root_nodes):
-            for link in node.wikilinks:
-                for key in _wikilink_backlink_keys(pages, link):
-                    _append_backlink(registry, key, node.uuid)
-            for tag in node.tags:
-                key = _normalize_backlink_key(tag)
-                if key:
-                    _append_backlink(registry, key, node.uuid)
-            for block_ref in node.block_refs:
-                key = _normalize_backlink_key(block_ref)
-                if key:
-                    _append_backlink(registry, key, node.uuid)
+            for key in _node_backlink_keys(pages, node):
+                _append_backlink(registry, key, node.uuid)
     logger.debug("backlink registry built: %s distinct targets", len(registry))
     return registry
 
@@ -871,6 +876,80 @@ class LogseqGraph(BaseModel):
         for node in _flatten_nodes(page.root_nodes):
             self._node_registry[node.uuid] = node
 
+    def _append_page_backlinks(self, page: LogseqPage) -> None:
+        for node in _flatten_nodes(page.root_nodes):
+            for key in _node_backlink_keys(self.pages, node):
+                _append_backlink(self._backlink_registry, key, node.uuid)
+
+    def _capture_incoming_page_wikilinks(
+        self, page: LogseqPage
+    ) -> list[tuple[str, str, tuple[str, ...]]]:
+        """Capture existing wikilinks that resolve to ``page`` before its index changes."""
+        canonical_key = _normalize_backlink_key(page.title)
+        page_keys = [canonical_key]
+        page_keys.extend(
+            _normalize_backlink_key(alias) for alias in _collect_page_alias_tokens(page.properties)
+        )
+        source_uuids: list[str] = []
+        seen_source_uuids: set[str] = set()
+        for key in page_keys:
+            for source_uuid in self._backlink_registry.get(key, []):
+                if source_uuid not in seen_source_uuids:
+                    seen_source_uuids.add(source_uuid)
+                    source_uuids.append(source_uuid)
+        captured: list[tuple[str, str, tuple[str, ...]]] = []
+        for source_uuid in source_uuids:
+            node = self._node_registry.get(source_uuid)
+            if node is None:
+                continue
+            for link in node.wikilinks:
+                keys = tuple(_wikilink_backlink_keys(self.pages, link))
+                if canonical_key in keys:
+                    captured.append((source_uuid, link, keys))
+        return captured
+
+    def _backlink_source_order(self, source_uuid: str) -> tuple[str, int, tuple[int, ...], str]:
+        """Return the deterministic cold-load order key for an indexed source node."""
+        node = self._node_registry[source_uuid]
+        return (
+            node.source_path or "",
+            node.line_start or 0,
+            tuple(node.outline_path),
+            source_uuid,
+        )
+
+    def _reindex_incoming_page_wikilinks(
+        self, captured: list[tuple[str, str, tuple[str, ...]]]
+    ) -> None:
+        """Reindex only sources whose wikilinks targeted a changed page identity."""
+        if not captured:
+            return
+        source_uuids = {source_uuid for source_uuid, _link, _keys in captured}
+        affected_keys = {key for _source_uuid, _link, keys in captured for key in keys}
+        for _source_uuid, link, _keys in captured:
+            affected_keys.update(_wikilink_backlink_keys(self.pages, link))
+
+        for key in affected_keys:
+            sources = self._backlink_registry.get(key, [])
+            remaining = [source_uuid for source_uuid in sources if source_uuid not in source_uuids]
+            if remaining:
+                self._backlink_registry[key] = remaining
+            else:
+                self._backlink_registry.pop(key, None)
+
+        for source_uuid in source_uuids:
+            node = self._node_registry.get(source_uuid)
+            if node is None:
+                continue
+            for key in _node_backlink_keys(self.pages, node):
+                if key in affected_keys:
+                    _append_backlink(self._backlink_registry, key, source_uuid)
+
+        for key in affected_keys:
+            sources = self._backlink_registry.get(key, [])
+            if sources:
+                sources.sort(key=self._backlink_source_order)
+
     def invalidate_and_reload_page(self, file_path: Path) -> None:
         """Re-parse a single file, purge its old nodes/backlinks, and merge fresh indexes."""
         resolved = Path(file_path).expanduser().resolve()
@@ -883,10 +962,13 @@ class LogseqGraph(BaseModel):
         if old_page is not None:
             stale = {n.uuid for n in _flatten_nodes(old_page.root_nodes)}
             self._purge_stale_page_uuids(stale)
+        incoming_wikilinks = (
+            self._capture_incoming_page_wikilinks(old_page) if old_page is not None else []
+        )
         if not resolved.exists():
             self.pages = new_pages
             self._lower_title_map = _build_lower_title_map(new_pages)
-            self._backlink_registry = _build_backlink_registry(new_pages)
+            self._reindex_incoming_page_wikilinks(incoming_wikilinks)
             logger.debug("invalidate_and_reload_page: purged deleted path=%s", resolved)
             return
         fresh = StackMachineParser().parse_page_file(resolved)
@@ -895,8 +977,10 @@ class LogseqGraph(BaseModel):
         enriched = _page_for_source_path(new_pages, resolved) or fresh
         self.pages = new_pages
         self._lower_title_map = _build_lower_title_map(new_pages)
+        incoming_wikilinks.extend(self._capture_incoming_page_wikilinks(enriched))
         self._register_page_nodes(enriched)
-        self._backlink_registry = _build_backlink_registry(new_pages)
+        self._append_page_backlinks(enriched)
+        self._reindex_incoming_page_wikilinks(incoming_wikilinks)
         logger.debug(
             "Stack-Machine incremental re-hydrate: path=%s title=%s nodes=%s",
             resolved,

--- a/src/logseq_matryca_parser/graph.py
+++ b/src/logseq_matryca_parser/graph.py
@@ -159,10 +159,12 @@ class GraphQuery:
 def _flatten_nodes(nodes: list[LogseqNode]) -> list[LogseqNode]:
     """Depth-first flattening of a node tree."""
     flat: list[LogseqNode] = []
-    for node in nodes:
+    pending = list(reversed(nodes))
+    while pending:
+        node = pending.pop()
         flat.append(node)
         if node.children:
-            flat.extend(_flatten_nodes(node.children))
+            pending.extend(reversed(node.children))
     return flat
 
 

--- a/src/logseq_matryca_parser/graph.py
+++ b/src/logseq_matryca_parser/graph.py
@@ -869,20 +869,6 @@ class LogseqGraph(BaseModel):
         for node in _flatten_nodes(page.root_nodes):
             self._node_registry[node.uuid] = node
 
-    def _append_page_backlinks(self, page: LogseqPage) -> None:
-        for node in _flatten_nodes(page.root_nodes):
-            for link in node.wikilinks:
-                for key in _wikilink_backlink_keys(self.pages, link):
-                    _append_backlink(self._backlink_registry, key, node.uuid)
-            for tag in node.tags:
-                key = _normalize_backlink_key(tag)
-                if key:
-                    _append_backlink(self._backlink_registry, key, node.uuid)
-            for block_ref in node.block_refs:
-                key = _normalize_backlink_key(block_ref)
-                if key:
-                    _append_backlink(self._backlink_registry, key, node.uuid)
-
     def invalidate_and_reload_page(self, file_path: Path) -> None:
         """Re-parse a single file, purge its old nodes/backlinks, and merge fresh indexes."""
         resolved = Path(file_path).expanduser().resolve()
@@ -898,6 +884,7 @@ class LogseqGraph(BaseModel):
         if not resolved.exists():
             self.pages = new_pages
             self._lower_title_map = _build_lower_title_map(new_pages)
+            self._backlink_registry = _build_backlink_registry(new_pages)
             logger.debug("invalidate_and_reload_page: purged deleted path=%s", resolved)
             return
         fresh = StackMachineParser().parse_page_file(resolved)
@@ -907,7 +894,7 @@ class LogseqGraph(BaseModel):
         self.pages = new_pages
         self._lower_title_map = _build_lower_title_map(new_pages)
         self._register_page_nodes(enriched)
-        self._append_page_backlinks(enriched)
+        self._backlink_registry = _build_backlink_registry(new_pages)
         logger.debug(
             "Stack-Machine incremental re-hydrate: path=%s title=%s nodes=%s",
             resolved,

--- a/tests/parser_assurance/invariants.py
+++ b/tests/parser_assurance/invariants.py
@@ -9,9 +9,11 @@ from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
 
 def walk_nodes(nodes: list[LogseqNode]) -> Iterator[LogseqNode]:
     """Yield nodes in deterministic pre-order."""
-    for node in nodes:
+    pending = list(reversed(nodes))
+    while pending:
+        node = pending.pop()
         yield node
-        yield from walk_nodes(node.children)
+        pending.extend(reversed(node.children))
 
 
 def assert_tree_invariants(page: LogseqPage) -> None:
@@ -19,7 +21,9 @@ def assert_tree_invariants(page: LogseqPage) -> None:
     nodes = list(walk_nodes(page.root_nodes))
     assert len({node.uuid for node in nodes}) == len(nodes)
 
-    def visit(siblings: list[LogseqNode], parent: LogseqNode | None) -> None:
+    pending: list[tuple[list[LogseqNode], LogseqNode | None]] = [(page.root_nodes, None)]
+    while pending:
+        siblings, parent = pending.pop()
         for index, node in enumerate(siblings):
             assert node.parent_id == (parent.uuid if parent is not None else None)
             assert node.left_id == (siblings[index - 1].uuid if index else None)
@@ -27,6 +31,4 @@ def assert_tree_invariants(page: LogseqPage) -> None:
             assert node.path == expected_path
             expected_outline = [index + 1] if parent is None else [*parent.outline_path, index + 1]
             assert node.outline_path == expected_outline
-            visit(node.children, node)
-
-    visit(page.root_nodes, None)
+        pending.extend((node.children, node) for node in reversed(siblings) if node.children)

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -1,0 +1,1 @@
+"""Performance-related helpers for synthetic vault tests."""

--- a/tests/performance/runtime_evidence.py
+++ b/tests/performance/runtime_evidence.py
@@ -1,0 +1,166 @@
+"""Private, source-free runtime evidence data model for performance tests."""
+
+from __future__ import annotations
+
+import math
+import platform
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from typing import Final, Literal
+
+try:  # pragma: no cover - exercised where the Unix-only module is unavailable.
+    import resource
+except ImportError:  # Windows has no resource module.
+    resource = None  # type: ignore[assignment]
+
+from tests.performance.synthetic_vault import SYNTHETIC_VAULT_SCHEMA_VERSION, SyntheticVault
+
+WARMUP_COUNT: Final = 3
+SAMPLE_COUNT: Final = 21
+RUNTIME_EVIDENCE_SCHEMA_VERSION: Final = 1
+RUNTIME_EVIDENCE_HARNESS_VERSION: Final = 1
+REPLAY_COMMAND: Final = "uv run python -m tests.performance.runtime_evidence"
+
+ScenarioName = Literal[
+    "deep_parse_1024",
+    "cold_graph_load",
+    "incremental_alias_move_reload",
+    "search_content",
+    "synapse_context_chunks",
+]
+ScenarioAvailability = Literal["available", "unavailable", "invalid"]
+UnavailableReason = Literal["optional_adapter_unavailable"]
+
+
+@dataclass(frozen=True)
+class ScenarioReceipt:
+    """Aggregate, source-free evidence from one named scenario."""
+
+    scenario: ScenarioName
+    availability: ScenarioAvailability
+    unavailable_reason: UnavailableReason | None
+    semantic_gate_passed: bool
+    warmup_count: int
+    sample_count: int
+    median_duration_ns: int | None
+    p95_duration_ns: int | None
+
+
+@dataclass(frozen=True)
+class RuntimeEvidenceReceipt:
+    """Aggregate-only observation bound to a deterministic synthetic vault."""
+
+    runtime_evidence_schema_version: int
+    runtime_evidence_harness_version: int
+    synthetic_vault_schema_version: int
+    source_sha256: str
+    aggregate_counts: dict[str, int]
+    python_version: str
+    platform_system: str
+    platform_machine: str
+    replay_command: str
+    resident_high_water: dict[str, int | str]
+    scenarios: tuple[ScenarioReceipt, ...]
+
+    def to_payload(self) -> dict[str, object]:
+        """Return the fixed JSON-ready aggregate receipt payload."""
+        return asdict(self)
+
+
+def percentile_p95_ns(samples: tuple[int, ...]) -> int:
+    """Return the declared nearest-rank p95 for a non-empty duration vector."""
+    if not samples:
+        raise ValueError("p95 requires at least one sample")
+    return sorted(samples)[math.ceil(0.95 * len(samples)) - 1]
+
+
+def median_ns(samples: tuple[int, ...]) -> int:
+    """Return the middle duration for the deliberately odd measurement count."""
+    if len(samples) % 2 != 1:
+        raise ValueError("runtime evidence requires an odd sample count")
+    return sorted(samples)[len(samples) // 2]
+
+
+def _invalid_receipt(scenario: ScenarioName) -> ScenarioReceipt:
+    return ScenarioReceipt(
+        scenario=scenario,
+        availability="invalid",
+        unavailable_reason=None,
+        semantic_gate_passed=False,
+        warmup_count=WARMUP_COUNT,
+        sample_count=0,
+        median_duration_ns=None,
+        p95_duration_ns=None,
+    )
+
+
+def measure_scenario(
+    scenario: ScenarioName,
+    semantic_action: Callable[[], None],
+    *,
+    clock_ns: Callable[[], int] = time.perf_counter_ns,
+) -> ScenarioReceipt:
+    """Measure only semantic-successful actions under the fixed warm-up protocol."""
+    try:
+        for _ in range(WARMUP_COUNT):
+            semantic_action()
+        samples: list[int] = []
+        for _ in range(SAMPLE_COUNT):
+            started = clock_ns()
+            semantic_action()
+            elapsed = clock_ns() - started
+            if elapsed < 0:
+                raise ValueError("measurement clock returned a negative elapsed duration")
+            samples.append(elapsed)
+    except Exception:
+        return _invalid_receipt(scenario)
+
+    durations = tuple(samples)
+    return ScenarioReceipt(
+        scenario=scenario,
+        availability="available",
+        unavailable_reason=None,
+        semantic_gate_passed=True,
+        warmup_count=WARMUP_COUNT,
+        sample_count=SAMPLE_COUNT,
+        median_duration_ns=median_ns(durations),
+        p95_duration_ns=percentile_p95_ns(durations),
+    )
+
+
+def resident_high_water_observation() -> dict[str, int | str]:
+    """Return a labelled native high-water observation without normalizing it."""
+    if resource is None:
+        return {"availability": "unavailable"}
+    try:
+        value = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    except (AttributeError, OSError):
+        return {"availability": "unavailable"}
+    unit = "bytes" if platform.system() == "Darwin" else "KiB"
+    return {"availability": "available", "value": value, "unit": unit}
+
+
+def build_runtime_receipt(
+    vault: SyntheticVault,
+    scenarios: tuple[ScenarioReceipt, ...],
+) -> RuntimeEvidenceReceipt:
+    """Bind aggregate scenario observations to the fixed synthetic-vault identity."""
+    return RuntimeEvidenceReceipt(
+        runtime_evidence_schema_version=RUNTIME_EVIDENCE_SCHEMA_VERSION,
+        runtime_evidence_harness_version=RUNTIME_EVIDENCE_HARNESS_VERSION,
+        synthetic_vault_schema_version=SYNTHETIC_VAULT_SCHEMA_VERSION,
+        source_sha256=vault.source_sha256,
+        aggregate_counts={
+            "page_count": vault.page_count,
+            "blocks_per_page": vault.blocks_per_page,
+            "deep_chain_depth": vault.deep_chain_depth,
+            "total_source_bytes": vault.total_source_bytes,
+        },
+        python_version=platform.python_version(),
+        platform_system=platform.system(),
+        platform_machine=platform.machine(),
+        replay_command=REPLAY_COMMAND,
+        resident_high_water=resident_high_water_observation(),
+        scenarios=scenarios,
+    )

--- a/tests/performance/runtime_evidence.py
+++ b/tests/performance/runtime_evidence.py
@@ -2,19 +2,32 @@
 
 from __future__ import annotations
 
+import argparse
 import math
 import platform
 import time
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Final, Literal
+from unittest.mock import patch
 
 try:  # pragma: no cover - exercised where the Unix-only module is unavailable.
     import resource
 except ImportError:  # Windows has no resource module.
     resource = None  # type: ignore[assignment]
 
-from tests.performance.synthetic_vault import SYNTHETIC_VAULT_SCHEMA_VERSION, SyntheticVault
+from logseq_matryca_parser import synapse as synapse_module
+from logseq_matryca_parser.graph import LogseqGraph, iter_canonical_pages_from_dict
+from logseq_matryca_parser.logos_parser import StackMachineParser
+from logseq_matryca_parser.synapse import SynapseAdapter
+from tests.parser_assurance.invariants import assert_tree_invariants, walk_nodes
+from tests.performance.synthetic_vault import (
+    SYNTHETIC_VAULT_SCHEMA_VERSION,
+    SyntheticVault,
+    build_synthetic_vault,
+)
 
 WARMUP_COUNT: Final = 3
 SAMPLE_COUNT: Final = 21
@@ -164,3 +177,150 @@ def build_runtime_receipt(
         resident_high_water=resident_high_water_observation(),
         scenarios=scenarios,
     )
+
+
+class HarnessDocument:
+    """Small local stand-in that keeps optional chunk evidence dependency-free."""
+
+    def __init__(self, page_content: str, metadata: dict[str, object]) -> None:
+        self.page_content = page_content
+        self.metadata = metadata
+
+
+def _with_temporary_graph(
+    vault: SyntheticVault, action: Callable[[Path, LogseqGraph], None]
+) -> None:
+    with TemporaryDirectory() as temporary:
+        root = vault.materialize(Path(temporary))
+        action(root, LogseqGraph.load_directory(root))
+
+
+def run_deep_parse_1024(vault: SyntheticVault) -> ScenarioReceipt:
+    """Measure parser construction with a real tree-invariant gate."""
+
+    def action() -> None:
+        page = StackMachineParser().parse(vault.deep_chain_source, page_title="runtime-deep")
+        assert_tree_invariants(page)
+        assert len(tuple(walk_nodes(page.root_nodes))) == vault.deep_chain_depth
+
+    return measure_scenario("deep_parse_1024", action)
+
+
+def run_cold_graph_load(vault: SyntheticVault) -> ScenarioReceipt:
+    """Measure loading the complete synthetic vault with canonical-page validation."""
+
+    def action() -> None:
+        def assert_graph(_root: Path, graph: LogseqGraph) -> None:
+            assert len(list(iter_canonical_pages_from_dict(graph.pages))) == vault.page_count
+
+        _with_temporary_graph(vault, assert_graph)
+
+    return measure_scenario("cold_graph_load", action)
+
+
+def run_incremental_alias_move_reload(vault: SyntheticVault) -> ScenarioReceipt:
+    """Measure the #103 incremental-versus-cold backlink equivalence gate."""
+
+    def action() -> None:
+        with TemporaryDirectory() as temporary:
+            root = vault.materialize(Path(temporary))
+            pages = root / "pages"
+            linker_path = pages / "runtime-evidence-page-0001.md"
+            linker_path.write_text("- linker [[runtime-evidence-alias-0002]]\n", encoding="utf-8")
+            source = pages / "runtime-evidence-page-0002.md"
+            moved = pages / "runtime-evidence-page-moved.md"
+            incremental = LogseqGraph.load_directory(root)
+            source.write_text(
+                "title:: runtime-evidence-page-moved\n"
+                "alias:: runtime-evidence-alias-0002, runtime-evidence-alias-moved\n\n"
+                "- moved target\n",
+                encoding="utf-8",
+            )
+            source.rename(moved)
+            incremental.invalidate_and_reload_page(source)
+            incremental.invalidate_and_reload_page(moved)
+            cold = LogseqGraph.load_directory(root)
+            for target in (
+                "runtime-evidence-page-0002",
+                "runtime-evidence-page-moved",
+                "runtime-evidence-alias-0002",
+                "runtime-evidence-alias-moved",
+            ):
+                assert [node.uuid for node in incremental.get_backlinks(target)] == [
+                    node.uuid for node in cold.get_backlinks(target)
+                ]
+
+    return measure_scenario("incremental_alias_move_reload", action)
+
+
+def run_search_content(vault: SyntheticVault) -> ScenarioReceipt:
+    """Measure a fixed unique-token search over a complete synthetic graph."""
+
+    def action() -> None:
+        def assert_search(_root: Path, graph: LogseqGraph) -> None:
+            hits = graph.search_content("block-0001-")
+            assert len(hits) == vault.blocks_per_page
+            assert all(node.uuid for node in hits)
+
+        _with_temporary_graph(vault, assert_search)
+
+    return measure_scenario("search_content", action)
+
+
+def run_synapse_context_chunks(vault: SyntheticVault | None = None) -> ScenarioReceipt:
+    """Measure optional context chunks or report their fixed unavailable state."""
+    if synapse_module.Document is None:
+        return ScenarioReceipt(
+            scenario="synapse_context_chunks",
+            availability="unavailable",
+            unavailable_reason="optional_adapter_unavailable",
+            semantic_gate_passed=False,
+            warmup_count=0,
+            sample_count=0,
+            median_duration_ns=None,
+            p95_duration_ns=None,
+        )
+    selected_vault = vault or build_synthetic_vault()
+
+    def action() -> None:
+        def assert_chunks(_root: Path, graph: LogseqGraph) -> None:
+            page = graph.pages["runtime-evidence-page-0001"]
+            with patch.object(synapse_module, "Document", HarnessDocument):
+                chunks = SynapseAdapter.to_context_enriched_chunks(page.root_nodes, graph)
+            assert len(chunks) == selected_vault.blocks_per_page
+            assert all(chunk.metadata["page_title"] for chunk in chunks)
+            assert all(chunk.metadata["source_path"] for chunk in chunks)
+            assert all(chunk.metadata["line_start"] for chunk in chunks)
+
+        _with_temporary_graph(selected_vault, assert_chunks)
+
+    return measure_scenario("synapse_context_chunks", action)
+
+
+def run_runtime_evidence() -> RuntimeEvidenceReceipt:
+    """Run all fixed local scenarios and return one aggregate-only receipt."""
+    vault = build_synthetic_vault()
+    scenarios = (
+        run_deep_parse_1024(vault),
+        run_cold_graph_load(vault),
+        run_incremental_alias_move_reload(vault),
+        run_search_content(vault),
+        run_synapse_context_chunks(vault),
+    )
+    return build_runtime_receipt(vault, scenarios)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Emit one source-free runtime receipt without persisting a result."""
+    parser = argparse.ArgumentParser(
+        description="Emit a source-free local runtime-evidence receipt."
+    )
+    parser.parse_args(argv)
+    import json
+
+    print(json.dumps(run_runtime_evidence().to_payload(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/performance/synthetic_vault.py
+++ b/tests/performance/synthetic_vault.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path, PurePosixPath
+from typing import Final
+
+SYNTHETIC_VAULT_SCHEMA_VERSION: Final = 1
+PAGE_COUNT: Final = 96
+BLOCKS_PER_PAGE: Final = 24
+DEEP_CHAIN_DEPTH: Final = 1024
+
+
+def _ordinary_page_filename(index: int) -> str:
+    return f"pages/runtime-evidence-page-{index:04d}.md"
+
+
+def _ordinary_page_title(index: int) -> str:
+    return f"runtime-evidence-page-{index:04d}"
+
+
+def _page_link_target(index: int, page_count: int) -> str:
+    if index < page_count - 1:
+        return _ordinary_page_title(index + 1)
+    return "runtime-evidence-deep"
+
+
+def _build_ordinary_page_content(index: int, page_count: int, blocks_per_page: int) -> str:
+    lines = [
+        f"alias:: runtime-evidence-alias-{index:04d}\n",
+        "\n",
+        f"- block-{index:04d}-00 #runtime-evidence [[{_page_link_target(index, page_count)}]]\n",
+    ]
+
+    for block_index in range(1, blocks_per_page):
+        lines.append(f"- block-{index:04d}-{block_index:02d}\n")
+
+    return "".join(lines)
+
+
+def _build_deep_chain() -> str:
+    lines = []
+    for depth in range(DEEP_CHAIN_DEPTH):
+        lines.append(f"{'  ' * (depth + 1)}- chain-{depth:04d}\n")
+    return "".join(lines)
+
+
+@dataclass(frozen=True)
+class SyntheticVault:
+    files: tuple[tuple[PurePosixPath, bytes], ...]
+    page_count: int
+    blocks_per_page: int
+    deep_chain_depth: int
+
+    @property
+    def total_source_bytes(self) -> int:
+        return sum(len(content) for _, content in self.files)
+
+    @property
+    def deep_chain_source(self) -> str:
+        return next(
+            content.decode("utf-8")
+            for relative_path, content in self.files
+            if relative_path == PurePosixPath("pages/runtime-evidence-deep.md")
+        )
+
+    @property
+    def source_sha256(self) -> str:
+        digest = sha256()
+        for relative_path, content in self.files:
+            digest.update(relative_path.as_posix().encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(content)
+            digest.update(b"\0")
+        return digest.hexdigest()
+
+    def materialize(self, destination: Path) -> Path:
+        root = destination.resolve()
+        for relative_path, content in self.files:
+            target = (root / relative_path).resolve()
+            try:
+                target.relative_to(root)
+            except ValueError as error:
+                raise ValueError("synthetic vault path escapes destination") from error
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+        return root
+
+
+def build_synthetic_vault() -> SyntheticVault:
+    generated_files: list[tuple[PurePosixPath, bytes]] = []
+
+    for index in range(1, PAGE_COUNT):
+        path = PurePosixPath(_ordinary_page_filename(index))
+        source = _build_ordinary_page_content(index, PAGE_COUNT, BLOCKS_PER_PAGE).encode(
+            "utf-8"
+        )
+        generated_files.append((path, source))
+
+    deep_path = PurePosixPath("pages/runtime-evidence-deep.md")
+    generated_files.append((deep_path, _build_deep_chain().encode("utf-8")))
+
+    generated_files.sort(key=lambda item: item[0].as_posix())
+
+    return SyntheticVault(
+        files=tuple(generated_files),
+        page_count=PAGE_COUNT,
+        blocks_per_page=BLOCKS_PER_PAGE,
+        deep_chain_depth=DEEP_CHAIN_DEPTH,
+    )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -49,6 +49,27 @@ def test_load_directory_bulk_parse_and_uuid_lookup(tmp_path: Path) -> None:
     assert graph.get_node_by_uuid("00000000-0000-0000-0000-000000000000") is None
 
 
+def test_load_directory_handles_a_1024_level_outline(tmp_path: Path) -> None:
+    """Graph indexing preserves a parser-supported 1024-level outline without recursion."""
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    (pages / "Deep.md").write_text(
+        "".join(f"{'  ' * depth}- level-{depth}\n" for depth in range(1024)),
+        encoding="utf-8",
+    )
+
+    graph = LogseqGraph.load_directory(graph_root)
+    current = graph.pages["Deep"].root_nodes[0]
+    for depth in range(1024):
+        assert current.content == f"level-{depth}"
+        if depth < 1023:
+            assert len(current.children) == 1
+            current = current.children[0]
+        else:
+            assert current.children == []
+
+
 def test_get_nodes_by_tag_cross_page(tmp_path: Path) -> None:
     """Tag query returns nodes from every loaded page."""
     graph_root = tmp_path / "vault"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -489,6 +489,52 @@ def test_invalidate_and_reload_purges_deleted_page(tmp_path: Path) -> None:
     assert graph.get_node_by_uuid(stale_uuid) is None
 
 
+def test_incremental_rename_rebuilds_backlinks_like_cold_load(tmp_path: Path) -> None:
+    """A moved page's renamed title and aliases rebind backlinks from unchanged pages."""
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    source = pages / "Alpha.md"
+    source.write_text("title:: Alpha\nalias:: Old\n\n- target\n", encoding="utf-8")
+    (pages / "Linker.md").write_text("- links [[Old]]\n", encoding="utf-8")
+
+    incremental = LogseqGraph.load_directory(graph_root)
+    moved = pages / "Beta.md"
+    source.write_text("title:: Beta\nalias:: Old, New\n\n- target\n", encoding="utf-8")
+    source.rename(moved)
+    incremental.invalidate_and_reload_page(source)
+    incremental.invalidate_and_reload_page(moved)
+
+    cold = LogseqGraph.load_directory(graph_root)
+    for target in ("Alpha", "Beta", "Old", "New"):
+        assert [node.uuid for node in incremental.get_backlinks(target)] == [
+            node.uuid for node in cold.get_backlinks(target)
+        ]
+    assert incremental.get_page("Alpha") is None
+    assert incremental.get_page("Beta") is not None
+    assert incremental.get_page("New") is incremental.get_page("Beta")
+
+
+def test_incremental_deletion_rebuilds_backlinks_like_cold_load(tmp_path: Path) -> None:
+    """Deleting an aliased page removes its former canonical backlink key."""
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    source = pages / "Alpha.md"
+    source.write_text("title:: Alpha\nalias:: Old\n\n- target\n", encoding="utf-8")
+    (pages / "Linker.md").write_text("- links [[Old]]\n", encoding="utf-8")
+
+    incremental = LogseqGraph.load_directory(graph_root)
+    source.unlink()
+    incremental.invalidate_and_reload_page(source)
+
+    cold = LogseqGraph.load_directory(graph_root)
+    for target in ("Alpha", "Old"):
+        assert [node.uuid for node in incremental.get_backlinks(target)] == [
+            node.uuid for node in cold.get_backlinks(target)
+        ]
+
+
 def test_title_collision_pages_journals_no_ghost_registry(tmp_path: Path) -> None:
     """``pages/`` and ``journals/`` with the same title must not leave loser nodes in the registry."""
     graph_root = tmp_path / "vault"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import logseq_matryca_parser.graph as graph_module
 from logseq_matryca_parser.exceptions import BlockReferenceError
 from logseq_matryca_parser.graph import (
     GraphQuery,
@@ -510,21 +511,30 @@ def test_invalidate_and_reload_purges_deleted_page(tmp_path: Path) -> None:
     assert graph.get_node_by_uuid(stale_uuid) is None
 
 
-def test_incremental_rename_rebuilds_backlinks_like_cold_load(tmp_path: Path) -> None:
-    """A moved page's renamed title and aliases rebind backlinks from unchanged pages."""
+def test_incremental_rename_reindexes_backlinks_without_a_global_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A moved page reindexes affected backlinks without scanning the whole vault."""
     graph_root = tmp_path / "vault"
     pages = graph_root / "pages"
     pages.mkdir(parents=True)
     source = pages / "Alpha.md"
     source.write_text("title:: Alpha\nalias:: Old\n\n- target\n", encoding="utf-8")
+    (pages / "A-existing.md").write_text("- links [[Beta]]\n", encoding="utf-8")
     (pages / "Linker.md").write_text("- links [[Old]]\n", encoding="utf-8")
 
     incremental = LogseqGraph.load_directory(graph_root)
     moved = pages / "Beta.md"
     source.write_text("title:: Beta\nalias:: Old, New\n\n- target\n", encoding="utf-8")
     source.rename(moved)
-    incremental.invalidate_and_reload_page(source)
-    incremental.invalidate_and_reload_page(moved)
+
+    def forbid_global_rebuild(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("incremental reload must not rebuild the whole backlink registry")
+
+    with monkeypatch.context() as isolated:
+        isolated.setattr(graph_module, "_build_backlink_registry", forbid_global_rebuild)
+        incremental.invalidate_and_reload_page(source)
+        incremental.invalidate_and_reload_page(moved)
 
     cold = LogseqGraph.load_directory(graph_root)
     for target in ("Alpha", "Beta", "Old", "New"):

--- a/tests/test_parser_deep_refresh.py
+++ b/tests/test_parser_deep_refresh.py
@@ -11,6 +11,7 @@ import pytest
 from logseq_matryca_parser.logos_core import LogseqNode
 from logseq_matryca_parser.logos_parser import StackMachineParser
 from logseq_matryca_parser.logseq_markdown import serialize_logseq_page
+from tests.parser_assurance.invariants import assert_tree_invariants, walk_nodes
 from tests.parser_assurance.projection import IdentityPolicy, project_page
 
 _DEEP_IDENTITY_POLICY = IdentityPolicy(
@@ -90,6 +91,13 @@ def test_parse_handles_a_1024_node_chain_without_recursion() -> None:
     for parent, child in zip(branch, branch[1:], strict=False):
         assert child.parent_id == parent.uuid
         assert child.left_id is None
+
+
+def test_structural_invariants_handle_a_1024_node_chain_without_recursion() -> None:
+    page = StackMachineParser().parse(_nested_source(1024, []), page_title="deep-invariants")
+
+    assert_tree_invariants(page)
+    assert len(list(walk_nodes(page.root_nodes))) == 1024
 
 
 def test_strict_parse_handles_a_1024_node_chain_without_recursion() -> None:

--- a/tests/test_performance_evidence_docs.py
+++ b/tests/test_performance_evidence_docs.py
@@ -1,0 +1,17 @@
+"""Registration checks for the maintained runtime-evidence reference."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_performance_evidence_reference_is_maintained_and_indexed() -> None:
+    maintained = Path("docs/maintained.toml").read_text(encoding="utf-8")
+    machine_index = Path("docs/index.md").read_text(encoding="utf-8")
+    human_index = Path("docs/README.md").read_text(encoding="utf-8")
+    reference_index = Path("docs/reference/index.md").read_text(encoding="utf-8")
+
+    assert '"docs/reference/PERFORMANCE_EVIDENCE.md"' in maintained
+    assert "[Runtime evidence](reference/PERFORMANCE_EVIDENCE.md)" in machine_index
+    assert "[`reference/PERFORMANCE_EVIDENCE.md`](reference/PERFORMANCE_EVIDENCE.md)" in human_index
+    assert "[Test-only runtime evidence protocol](PERFORMANCE_EVIDENCE.md)" in reference_index

--- a/tests/test_performance_synthetic_vault.py
+++ b/tests/test_performance_synthetic_vault.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path, PurePosixPath
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from logseq_matryca_parser.graph import LogseqGraph
+from tests.performance.synthetic_vault import (
+    BLOCKS_PER_PAGE,
+    DEEP_CHAIN_DEPTH,
+    PAGE_COUNT,
+    SyntheticVault,
+    build_synthetic_vault,
+)
+
+
+def test_synthetic_vault_has_the_fixed_original_shape() -> None:
+    vault = build_synthetic_vault()
+
+    assert vault.page_count == PAGE_COUNT == 96
+    assert vault.blocks_per_page == BLOCKS_PER_PAGE == 24
+    assert vault.deep_chain_depth == DEEP_CHAIN_DEPTH == 1024
+    assert len(vault.files) == PAGE_COUNT
+    assert vault.total_source_bytes > 0
+    assert sum(1 for line in vault.deep_chain_source.splitlines() if line.lstrip().startswith("- ")) == (
+        DEEP_CHAIN_DEPTH
+    )
+
+
+def test_synthetic_vault_is_deterministic_and_materializes_only_under_destination(tmp_path: Path) -> None:
+    first = build_synthetic_vault()
+    second = build_synthetic_vault()
+    destination = tmp_path / "synthetic"
+
+    first.materialize(destination)
+
+    assert first.source_sha256 == second.source_sha256
+    assert sorted(path.relative_to(destination) for path in destination.rglob("*.md"))
+    assert all(path.is_relative_to(destination) for path in destination.rglob("*.md"))
+    assert len(list(destination.rglob("*.md"))) == PAGE_COUNT
+
+
+def test_synthetic_vault_has_no_external_input_parameter() -> None:
+    assert inspect.signature(build_synthetic_vault).parameters == {}
+
+
+def test_synthetic_vault_rejects_materialization_escape(tmp_path: Path) -> None:
+    vault = SyntheticVault(
+        files=((PurePosixPath("../escape.md"), b"- prohibited\n"),),
+        page_count=1,
+        blocks_per_page=1,
+        deep_chain_depth=1,
+    )
+
+    with pytest.raises(ValueError):
+        vault.materialize(tmp_path / "root")
+
+
+def test_synthetic_vault_materializes_into_temporary_directory() -> None:
+    vault = build_synthetic_vault()
+
+    with TemporaryDirectory() as root:
+        destination = Path(root) / "synthetic"
+        vault.materialize(destination)
+
+        assert destination.is_dir()
+        assert (destination / "pages").is_dir()
+
+
+def test_ordinary_pages_expose_logseq_alias_tag_and_cross_page_link(tmp_path: Path) -> None:
+    vault = build_synthetic_vault()
+    root = vault.materialize(tmp_path / "synthetic")
+
+    graph = LogseqGraph.load_directory(root)
+    page = graph.pages["runtime-evidence-page-0001"]
+    root_node = page.root_nodes[0]
+
+    assert len(page.root_nodes) == BLOCKS_PER_PAGE
+    assert graph.get_page("runtime-evidence-alias-0001") is page
+    assert "runtime-evidence" in root_node.tags
+    assert "runtime-evidence-page-0002" in root_node.wikilinks

--- a/tests/test_runtime_evidence.py
+++ b/tests/test_runtime_evidence.py
@@ -1,0 +1,96 @@
+"""Contracts for the private, source-free runtime evidence model."""
+
+from __future__ import annotations
+
+import json
+from itertools import cycle
+
+import pytest
+
+from tests.performance import runtime_evidence
+from tests.performance.runtime_evidence import (
+    ScenarioReceipt,
+    build_runtime_receipt,
+    measure_scenario,
+    percentile_p95_ns,
+    resident_high_water_observation,
+)
+from tests.performance.synthetic_vault import build_synthetic_vault
+
+
+def test_p95_uses_the_declared_nearest_rank_rule() -> None:
+    assert percentile_p95_ns(tuple(range(1, 22))) == 20
+
+
+def test_measurement_protocol_uses_three_warmups_and_twenty_one_samples() -> None:
+    calls = 0
+
+    def semantic_action() -> None:
+        nonlocal calls
+        calls += 1
+
+    receipt = measure_scenario("cold_graph_load", semantic_action, clock_ns=lambda: calls * 10)
+
+    assert calls == 24
+    assert receipt.warmup_count == 3
+    assert receipt.sample_count == 21
+    assert receipt.availability == "available"
+    assert receipt.semantic_gate_passed is True
+    assert receipt.median_duration_ns == 10
+    assert receipt.p95_duration_ns == 10
+
+
+def test_semantic_failure_is_invalid_without_exception_disclosure() -> None:
+    def failing_action() -> None:
+        raise RuntimeError("private fixture content")
+
+    receipt = measure_scenario("search_content", failing_action)
+
+    assert receipt.availability == "invalid"
+    assert receipt.semantic_gate_passed is False
+    assert receipt.sample_count == 0
+    assert receipt.median_duration_ns is None
+    assert receipt.p95_duration_ns is None
+    assert "exception" not in json.dumps(receipt.__dict__, sort_keys=True).casefold()
+    assert "private fixture content" not in json.dumps(receipt.__dict__, sort_keys=True)
+
+
+def test_negative_duration_invalidates_the_scenario() -> None:
+    timestamps = cycle((20, 10))
+
+    receipt = measure_scenario("cold_graph_load", lambda: None, clock_ns=lambda: next(timestamps))
+
+    assert receipt.availability == "invalid"
+    assert receipt.semantic_gate_passed is False
+    assert receipt.sample_count == 0
+
+
+def test_receipt_payload_is_source_free() -> None:
+    vault = build_synthetic_vault()
+    scenario = ScenarioReceipt(
+        scenario="cold_graph_load",
+        availability="available",
+        unavailable_reason=None,
+        semantic_gate_passed=True,
+        warmup_count=3,
+        sample_count=21,
+        median_duration_ns=10,
+        p95_duration_ns=20,
+    )
+
+    receipt = build_runtime_receipt(vault, (scenario,))
+    payload = receipt.to_payload()
+    rendered = json.dumps(payload, sort_keys=True)
+
+    assert payload["source_sha256"] == vault.source_sha256
+    assert vault.files[0][0].name not in rendered
+    assert vault.files[0][1].decode("utf-8") not in rendered
+    assert "exception" not in rendered.casefold()
+    assert "hostname" not in rendered.casefold()
+    assert "samples" not in rendered.casefold()
+
+
+def test_missing_native_rss_is_explicitly_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runtime_evidence, "resource", None)
+
+    assert resident_high_water_observation() == {"availability": "unavailable"}

--- a/tests/test_runtime_evidence.py
+++ b/tests/test_runtime_evidence.py
@@ -3,17 +3,20 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from itertools import cycle
 
 import pytest
 
 from tests.performance import runtime_evidence
 from tests.performance.runtime_evidence import (
+    ScenarioName,
     ScenarioReceipt,
     build_runtime_receipt,
     measure_scenario,
     percentile_p95_ns,
     resident_high_water_observation,
+    run_runtime_evidence,
 )
 from tests.performance.synthetic_vault import build_synthetic_vault
 
@@ -94,3 +97,71 @@ def test_missing_native_rss_is_explicitly_unavailable(monkeypatch: pytest.Monkey
     monkeypatch.setattr(runtime_evidence, "resource", None)
 
     assert resident_high_water_observation() == {"availability": "unavailable"}
+
+
+def test_all_core_scenarios_are_semantically_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    def run_once(
+        scenario: ScenarioName,
+        semantic_action: Callable[[], None],
+        *,
+        clock_ns: Callable[[], int] | None = None,
+    ) -> ScenarioReceipt:
+        del clock_ns
+        semantic_action()
+        return ScenarioReceipt(
+            scenario=scenario,
+            availability="available",
+            unavailable_reason=None,
+            semantic_gate_passed=True,
+            warmup_count=0,
+            sample_count=0,
+            median_duration_ns=None,
+            p95_duration_ns=None,
+        )
+
+    monkeypatch.setattr(runtime_evidence, "measure_scenario", run_once)
+    receipt = run_runtime_evidence()
+    by_name = {scenario.scenario: scenario for scenario in receipt.scenarios}
+
+    assert set(by_name) == {
+        "deep_parse_1024",
+        "cold_graph_load",
+        "incremental_alias_move_reload",
+        "search_content",
+        "synapse_context_chunks",
+    }
+    for name, scenario in by_name.items():
+        if name != "synapse_context_chunks":
+            assert scenario.availability == "available"
+            assert scenario.semantic_gate_passed is True
+    synapse = by_name["synapse_context_chunks"]
+    if runtime_evidence.synapse_module.Document is None:
+        assert synapse.availability == "unavailable"
+        assert synapse.semantic_gate_passed is False
+    else:
+        assert synapse.availability == "available"
+        assert synapse.semantic_gate_passed is True
+
+
+def test_optional_synapse_is_unavailable_not_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runtime_evidence.synapse_module, "Document", None)
+
+    scenario = runtime_evidence.run_synapse_context_chunks()
+
+    assert scenario.availability == "unavailable"
+    assert scenario.unavailable_reason == "optional_adapter_unavailable"
+    assert scenario.semantic_gate_passed is False
+    assert scenario.sample_count == 0
+
+
+def test_module_cli_emits_one_source_free_json_object(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    expected = build_runtime_receipt(build_synthetic_vault(), ())
+    monkeypatch.setattr(runtime_evidence, "run_runtime_evidence", lambda: expected)
+
+    assert runtime_evidence.main([]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["replay_command"] == "uv run python -m tests.performance.runtime_evidence"
+    assert "exception" not in json.dumps(payload, sort_keys=True).casefold()


### PR DESCRIPTION
## Summary
- add deterministic, source-free local runtime-evidence scenarios and receipt contract
- keep runtime measurements outside CI and release qualification
- preserve bounded incremental backlink reconciliation for tracked title and alias moves
- document the M8 protocol, privacy boundary, replay command, and interpretation limits

## Validation
- `make all` (679 passed; 89.53% coverage)
- `make vendor-name-check`
- `git diff --check origin/main..HEAD`
- `uv run python -m tests.performance.runtime_evidence` (all five available semantic gates passed)
- independent GPT-5.6 Luna review: no actionable correctness issues

## Limits
- receipts are host-specific observations, are emitted only to stdout, and contain no private vault source or paths
- this PR introduces no CI timing threshold, public performance claim, or release gate