### PR TITLE
refactor(parser): isolate lexical state transitions

### DIFF
--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -10,7 +10,7 @@ authority: source_repository
 execution_mode: reviewed
 last_verified: 2026-08-20
 verified: 2026-08-20
-stale_after: 2026-11-14
+stale_after: 2026-11-18
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -66,6 +66,7 @@ Markdown source-of-truth model.
 | M5 delivery | merged | Privacy-safe local graph assurance merged through [PR #168](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/168) |
 | M6 delivery | merged | Source-location contract and RFC merged through [PR #169](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/169) |
 | M7 delivery | merged | Internal line-classification slice merged through [PR #170](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/170); issue [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165) is closed |
+| M9 local checkpoint | locally qualified, unpublished | Private lexical-state slice `d3dd316d4536ea428747dc3a4895ad633ffa6993` from `b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e`; publication and hosted validation remain separate gates |
 | Current milestone | v1.8.0 released; broader assurance work remains | M5–M7 are in `origin/main@06a1d6c`; tag `v1.8.0`, exact workflow run `32324328464`, PyPI publication, GitHub Release, checksums, and attestations were verified on 2026-08-20 |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
@@ -739,6 +740,44 @@ converted into a pass or silently added to an allowlist.
   optional-adapter condition. It establishes reproducible local observations,
   not a universal speed guarantee.
 
+### M9 — Private lexical-state extraction under frozen evidence (#108)
+
+**Local checkpoint and boundary**
+
+- Exact implementation head `d3dd316d4536ea428747dc3a4895ad633ffa6993`
+  is based on `b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e`.
+- A private standard-library-only `_LexicalState` owns YAML, code, query,
+  drawer, frontmatter, and block-property eligibility transitions.
+  `StackMachineParser.parse()` still owns line classification, branch order,
+  page properties, AST construction, identity, LOGBOOK/CLOCK handling,
+  pending property lists, node refresh, and content mutation.
+- This is the second private #108 slice. It adds no public API or dependency and
+  does not close #108, #87, #103, #104, or #111.
+
+**Terminal local evidence**
+
+- Native-worktree `make all` passed at the exact implementation head with 685
+  tests, 89.73% coverage, Ruff, mypy, documentation validation, and the
+  vendor-name gate. The focused parser/corpus/round-trip/adversarial/deep-refresh/
+  work-growth selection passed 288 tests; diff validation and the repeated
+  vendor-name gate also passed.
+- Fresh protected-hub impact analysis classified `StackMachineParser.parse()`
+  as CRITICAL with 101 direct and 117 total dependents. The maintainer approved
+  that exact risk before integration. Final change analysis identified 16
+  affected execution processes, all expected parser consumers, and the source
+  import-cycle check returned zero cycles.
+- An independent complete-range Luna review of
+  `b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e..d3dd316d4536ea428747dc3a4895ad633ffa6993`
+  returned `APPROVED` with no actionable correctness, test, dependency, or scope
+  finding. The primary controller retained the architecture and qualification
+  decision.
+
+**Residual boundary**
+
+- This is a local implementation checkpoint only. Push, hosted checks, pull
+  request, merge, issue-state changes, release, and performance claims remain
+  separate explicit gates.
+
 ## 12. Explicit deferrals and rejection triggers
 
 | Proposal | Disposition | Reconsider only when |
@@ -870,6 +909,9 @@ It must not replace the requirements in this plan.
   cost evidence recorded in the decision document.
 - [x] The first #108 extraction slice is covered by semantic and work-growth
   gates through PR #170; the broader extraction epic remains open.
+- [x] The second private #108 lexical-state slice is locally exact-head
+  qualified at `d3dd316`; hosted validation, publication, and epic closure
+  remain separate gates.
 - [ ] No AGPL-covered expression entered Apache-only source, tests, fixtures,
   schemas, or documentation.
 - [ ] Documentation, issue state, and public claims match the delivered behavior.
@@ -882,6 +924,7 @@ Completion is unproven until every applicable item has authoritative evidence.
 
 | Date | Anchor | Result | Evidence and residual boundary |
 |---|---|---|---|
+| 2026-08-20 | M9 lexical-state implementation `d3dd316` | local implementation checkpoint / docs checkpointing | Native make all ran from exact base `b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e` to `d3dd316d4536ea428747dc3a4895ad633ffa6993`; it passed 685 tests (89.73%), Ruff, mypy, documentation checks, vendor-name check, git diff check, and zero-cycle audit. Focused suite passed with 288 tests. Complete-range review on `Luna` found no actionable correctness or scope defects. This second private #108 slice does not close #108, #87, #103, #104, or #111; no publication or GitHub-release claim is made. |
 | 2026-08-16 | M0 / PR #159 | merged | Source head `a6056413`, squash merge `30946446`; PR records 535 passing tests, 91.95% coverage, documentation/package/vendor gates, and zero cycles. No parser behavior changed. |
 | 2026-08-16 | M1 activation | verified | Clean `agent/parser-assurance-m1` at `e2a3f9a`, matching `origin/main`; no tracked M1 changes at activation. |
 | 2026-08-16 | Independent M1 review | reconciled | Accepted the larger review surface, two-profile/single-projector model, explicit identity policy, and manifest expansion after source and live-issue verification. M1 is #104-A; #104 remains open. |

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -10,7 +10,7 @@ authority: source_repository
 execution_mode: reviewed
 last_verified: 2026-08-20
 verified: 2026-08-20
-stale_after: 2026-11-14
+stale_after: 2026-11-18
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -49,6 +49,17 @@ and closes child issue [#165](https://github.com/MarcoPorcellato/logseq-matryca-
 The private line-classification extraction preserves parser state reduction,
 node creation, identities, graph behavior, public imports, and dependencies.
 The broader #108 epic remains open for later gated phase slices.
+
+M9 is a locally qualified, unpublished second private #108 slice at exact
+implementation head `d3dd316d4536ea428747dc3a4895ad633ffa6993`, based on
+`b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e`. It moves only lexical mode and
+eligibility transitions into a private standard-library-only state object while
+leaving parser semantics and ownership in `StackMachineParser.parse()`. Native
+`make all` passed with 685 tests and 89.73% coverage; the focused suite passed
+288 tests; static, documentation, vendor, diff, impact, zero-cycle, and
+independent-review gates are recorded in the canonical plan. This checkpoint
+does not close #108, #87, #103, #104, or #111, and it is not a hosted,
+publication, merge, release, or performance claim.
 
 M2 is complete through the accepted negative
 [ADR-001](../decisions/ADR-001-external-oracle-boundary.md): no external

--- a/docs/superpowers/plans/2026-08-20-parser-lexical-state.md
+++ b/docs/superpowers/plans/2026-08-20-parser-lexical-state.md
@@ -1,0 +1,524 @@
+# Private Parser Lexical State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract private YAML, fence, query, drawer, and eligibility state from `StackMachineParser.parse()` without changing parser semantics or public API.
+
+**Architecture:** Add one dependency-free private lexical-state module with a mutable `_LexicalState` data object and named transition methods. `logos_parser.py` continues to classify lines, build and refresh AST nodes, own pending property lists, and perform every semantic operation; it delegates only the six existing lexical flags and their transitions. Focused state tests establish the transition contract, while existing parser/corpus/round-trip/adversarial/work-growth tests prove no externally observable drift.
+
+**Tech Stack:** Python 3.12+, standard-library `dataclasses` and `typing`, `pytest`, existing `StackMachineParser`, compatibility corpus, parser-assurance laboratories, Ruff, mypy, and Make targets.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-parser-lexical-state-design.md`
+
+## Global Constraints
+
+- Work only from a clean isolated branch based on the live `origin/main` anchor recorded in the specification; retry the all-extras bootstrap if its Git dependency fetch is unavailable.
+- Keep the feature private: no package-root export, CLI command, dependency, public type, runtime hook, filesystem authority, or network operation.
+- Preserve page title/properties/order, AST node identity, parent/left relations, source lines, references, strict-reference behavior, serialization, recovery, and deterministic tree order.
+- `_LineClassification` remains the syntax recognizer. The new module accepts only primitive flags and must not import graph, writer, CLI, adapters, `LogseqNode`, or `LogseqPage`.
+- Do not copy or adapt external parser code, test material, schemas, control flow, or documentation. Do not commit vault data, generated caches, or runtime receipts.
+- Before modifying `StackMachineParser.parse`, run fresh impact analysis, review direct callers, and stop on an unresolved HIGH or CRITICAL finding unless the maintainer explicitly approves continuation.
+- Treat `make all` as unavailable—not passing—if the isolated dependency bootstrap fails. Do not push, create a PR, close an issue, merge, or release without separate explicit authority.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+| --- | --- |
+| `src/logseq_matryca_parser/_lexical_state.py` | Private mode and eligibility state plus deterministic transition methods. |
+| `src/logseq_matryca_parser/logos_parser.py` | Replaces local lexical booleans with `_LexicalState` calls while retaining parser control flow and AST work. |
+| `tests/test_parser_lexical_state.py` | Direct unit contract for every lexical state transition, with no AST dependency. |
+| `tests/test_logos_parser.py` | Parser-level boundary regressions for transitions that change what a line means. |
+| `docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md` | Records the M9 implementation checkpoint and remaining #108 boundary only after exact-head qualification. |
+| `docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md` | Advances the persistent assurance anchor only after qualification; it must not claim epic or issue closure. |
+
+## Task 0: Re-establish the isolated baseline
+
+**Files:**
+
+- Modify: none.
+
+**Interfaces:**
+
+- Consumes: the clean worktree and locked project dependencies.
+- Produces: a known baseline result or an explicit unavailable dependency receipt before any source edit.
+
+- [ ] **Step 1: Confirm the exact starting point and worktree cleanliness**
+
+Run:
+
+```bash
+rtk git status --short --branch
+rtk git rev-parse HEAD
+rtk git rev-parse origin/main
+```
+
+Expected: the working tree is clean and the branch is based on the recorded `origin/main` anchor. If `origin/main` has moved, fetch it, review the intervening commits, and rebase before changing source.
+
+- [ ] **Step 2: Retry the complete baseline once with a writable temporary cache**
+
+Run:
+
+```bash
+UV_CACHE_DIR=/private/tmp/logseq-matryca-parser-m9-uv-cache rtk uv sync --all-extras
+rtk make all
+rtk make vendor-name-check
+```
+
+Expected: dependency resolution completes, the complete suite passes, and the vendor-name gate is `OK`. If the pinned `nltk` Git fetch fails again, record the exact transport failure as unavailable, do not edit parser code, and request an environment retry before resuming implementation.
+
+- [ ] **Step 3: Record the parser-hub impact before editing**
+
+Run the repository's configured audit-code impact command against the exact `StackMachineParser.parse` symbol, inspect direct callers and affected processes, then run the zero-cycle check.
+
+Expected: every direct caller is enumerated, the risk is recorded in the implementation notes, and `src/` has zero import cycles. A HIGH or CRITICAL unresolved finding stops this plan pending maintainer approval.
+
+## Task 1: Specify lexical transitions with failing private tests
+
+**Files:**
+
+- Create: `tests/test_parser_lexical_state.py`
+- Create later in this task: `src/logseq_matryca_parser/_lexical_state.py`
+
+**Interfaces:**
+
+- Consumes: no parser model or syntax-recognition object; only booleans that `logos_parser.py` already derives from `_LineClassification`.
+- Produces: private `_LexicalState` with `mode`, `frontmatter_active`, `properties_allowed`, and named transitions used by `StackMachineParser.parse`.
+
+- [ ] **Step 1: Write the failing transition-contract tests**
+
+Create `tests/test_parser_lexical_state.py` with these assertions:
+
+```python
+from logseq_matryca_parser._lexical_state import _LexicalState
+
+
+def test_yaml_frontmatter_close_disables_page_frontmatter() -> None:
+    state = _LexicalState()
+    assert state.frontmatter_active is True
+    assert state.properties_allowed is True
+
+    state.begin_yaml_frontmatter()
+    assert state.mode == "yaml"
+
+    state.finish_yaml_frontmatter()
+    assert state.mode == "normal"
+    assert state.frontmatter_active is False
+
+
+def test_code_and_query_closures_restore_existing_eligibility() -> None:
+    state = _LexicalState()
+    state.begin_code_block()
+    state.consume_code_line(is_code_fence=True)
+    assert state.mode == "normal"
+    assert state.properties_allowed is True
+
+    state.begin_query_block()
+    state.consume_query_line(is_query_end=True)
+    assert state.mode == "normal"
+    assert state.frontmatter_active is False
+
+
+def test_drawer_bullet_returns_to_normal_processing() -> None:
+    state = _LexicalState()
+    state.begin_drawer()
+    assert state.mode == "drawer"
+
+    assert state.consume_drawer_line(is_drawer_end=False, is_bullet=True) is False
+    assert state.mode == "normal"
+
+
+def test_structural_property_and_continuation_events_match_current_flags() -> None:
+    state = _LexicalState()
+    state.observe_structural_node()
+    assert state.frontmatter_active is False
+    assert state.properties_allowed is True
+
+    state.observe_continuation(is_code_fence=True, is_query_begin=False)
+    assert state.mode == "code"
+    assert state.properties_allowed is False
+```
+
+- [ ] **Step 2: Run the new tests and confirm the expected collection failure**
+
+Run:
+
+```bash
+rtk uv run pytest -q tests/test_parser_lexical_state.py
+```
+
+Expected: collection fails because `logseq_matryca_parser._lexical_state` does not exist. Do not weaken the tests to pass without the private module.
+
+- [ ] **Step 3: Implement the smallest dependency-free state unit**
+
+Create `src/logseq_matryca_parser/_lexical_state.py` using a private mutable data class and these exact members:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+_LexicalMode = Literal["normal", "yaml", "code", "query", "drawer"]
+
+
+@dataclass
+class _LexicalState:
+    mode: _LexicalMode = "normal"
+    frontmatter_active: bool = True
+    properties_allowed: bool = True
+
+    def begin_yaml_frontmatter(self) -> None:
+        self.mode = "yaml"
+
+    def finish_yaml_frontmatter(self) -> None:
+        self.mode = "normal"
+        self.frontmatter_active = False
+
+    def begin_code_block(self) -> None:
+        self.mode = "code"
+        self.frontmatter_active = False
+        self.properties_allowed = False
+
+    def consume_code_line(self, *, is_code_fence: bool) -> None:
+        if is_code_fence:
+            self.mode = "normal"
+            self.properties_allowed = True
+        self.frontmatter_active = False
+
+    def begin_query_block(self) -> None:
+        self.mode = "query"
+        self.frontmatter_active = False
+        self.properties_allowed = False
+
+    def consume_query_line(self, *, is_query_end: bool) -> None:
+        if is_query_end:
+            self.mode = "normal"
+        self.frontmatter_active = False
+
+    def begin_drawer(self) -> None:
+        self.mode = "drawer"
+
+    def consume_drawer_line(self, *, is_drawer_end: bool, is_bullet: bool) -> bool:
+        if is_drawer_end or is_bullet:
+            self.mode = "normal"
+            return False
+        return True
+
+    def observe_structural_node(self) -> None:
+        self.frontmatter_active = False
+        self.properties_allowed = True
+
+    def observe_property(self) -> None:
+        self.frontmatter_active = False
+
+    def observe_continuation(self, *, is_code_fence: bool, is_query_begin: bool) -> None:
+        self.frontmatter_active = False
+        self.properties_allowed = False
+        if is_code_fence:
+            self.begin_code_block()
+        if is_query_begin:
+            self.begin_query_block()
+
+    def observe_nonstructural_line_without_node(self) -> None:
+        self.frontmatter_active = False
+```
+
+`consume_drawer_line()` returns `True` only when the caller must keep treating the line as drawer payload. It must return `False` and restore `normal` mode for `:END:` and a bullet, so `parse()` retains its current bullet-processing path. The module must import only the standard library.
+
+- [ ] **Step 4: Run the state contract and static checks**
+
+Run:
+
+```bash
+rtk uv run pytest -q tests/test_parser_lexical_state.py
+rtk uv run ruff check src/logseq_matryca_parser/_lexical_state.py tests/test_parser_lexical_state.py
+rtk uv run mypy src/logseq_matryca_parser/_lexical_state.py
+```
+
+Expected: all state tests, lint, and typing pass without importing parser models or public package symbols.
+
+- [ ] **Step 5: Commit the private-state unit**
+
+```bash
+rtk git add -- src/logseq_matryca_parser/_lexical_state.py tests/test_parser_lexical_state.py
+rtk git commit -m "refactor(parser): isolate lexical state transitions"
+```
+
+## Task 2: Add parser-level boundary regressions before routing the loop
+
+**Files:**
+
+- Modify: `tests/test_logos_parser.py`
+- Modify: `tests/test_pre_release_roundtrip.py`
+
+**Interfaces:**
+
+- Consumes: the existing `StackMachineParser` public behavior and the private state contract from Task 1.
+- Produces: parser-level guardrails that make a lexical extraction fail on semantic drift.
+
+- [ ] **Step 1: Add one mixed-boundary regression**
+
+Add this test to `tests/test_logos_parser.py`:
+
+```python
+def test_lexical_boundaries_keep_properties_out_of_query_and_drawer(
+    parser: StackMachineParser,
+) -> None:
+    source = (
+        "- Root\n"
+        "  ```\n"
+        "  literal:: fence\n"
+        "  ```\n"
+        "  tags:: [[Visible]]\n"
+        "  #+BEGIN_QUERY\n"
+        "  query:: [[HiddenQuery]]\n"
+        "  #+END_QUERY\n"
+        "  :LOGBOOK:\n"
+        "  collapsed:: true\n"
+        "  :END:\n"
+        "  - Child"
+    )
+
+    page = parser.parse(source, page_title="lexical-boundaries")
+    root = page.root_nodes[0]
+
+    assert root.properties["tags"] == "[[Visible]]"
+    assert "query" not in root.properties
+    assert "collapsed" not in root.properties
+    assert "literal:: fence" in root.content
+    assert "query:: [[HiddenQuery]]" in root.content
+    assert "collapsed:: true" in root.properties["logbook"]
+    assert root.children[0].content == "Child"
+```
+
+- [ ] **Step 2: Add a frontmatter-eligibility regression**
+
+Add this test to `tests/test_logos_parser.py`:
+
+```python
+def test_nonstructural_preamble_closes_page_frontmatter_eligibility(
+    parser: StackMachineParser,
+) -> None:
+    page = parser.parse(
+        "title:: Page title\nplain preamble\nalias:: MustNotBecomePageProperty\n- Root",
+        page_title="fallback",
+    )
+
+    assert page.title == "Page title"
+    assert page.properties == {"title": "Page title"}
+    assert page.root_nodes[0].content == "Root"
+```
+
+- [ ] **Step 3: Run the new parser tests and verify they pass before production routing**
+
+Run:
+
+```bash
+rtk uv run pytest -q \
+  tests/test_logos_parser.py::test_lexical_boundaries_keep_properties_out_of_query_and_drawer \
+  tests/test_logos_parser.py::test_nonstructural_preamble_closes_page_frontmatter_eligibility
+```
+
+Expected: both tests pass on the un-routed parser, proving they freeze existing behavior rather than specifying a new feature.
+
+- [ ] **Step 4: Run the reusable lexical regressions**
+
+Run:
+
+```bash
+rtk uv run pytest -q \
+  tests/test_logos_parser.py::test_yaml_frontmatter_is_parsed_as_page_properties \
+  tests/test_logos_parser.py::test_fenced_code_shields_graph_tokens \
+  tests/test_logos_parser.py::test_tilde_fence_shields_graph_tokens \
+  tests/test_logos_parser.py::test_query_block_shields_graph_tokens \
+  tests/test_logos_parser.py::test_properties_allowed_after_code_fence \
+  tests/test_logos_parser.py::test_official_logbook_drawer_preserves_clock_metadata \
+  tests/test_pre_release_roundtrip.py::test_logbook_drawer_roundtrip \
+  tests/test_pre_release_roundtrip.py::test_yaml_frontmatter_roundtrip_preserves_block_uuid
+```
+
+Expected: all pass before `logos_parser.py` is changed.
+
+## Task 3: Route `StackMachineParser.parse()` through the private state
+
+**Files:**
+
+- Modify: `src/logseq_matryca_parser/logos_parser.py:696-1057`
+- Test: `tests/test_parser_lexical_state.py`
+- Test: `tests/test_logos_parser.py`
+- Test: `tests/test_pre_release_roundtrip.py`
+
+**Interfaces:**
+
+- Consumes: `_LexicalState` from Task 1 and `_LineClassification` already produced by `_classify_line()`.
+- Produces: the same `LogseqPage` result as before, with lexical flags no longer stored as local booleans in `parse()`.
+
+- [ ] **Step 1: Import and initialize only the private state object**
+
+Replace the six local lexical booleans in `parse()` with:
+
+```python
+from ._lexical_state import _LexicalState
+
+# inside StackMachineParser.parse()
+lexical_state = _LexicalState()
+```
+
+Keep `pending_list_key`, `pending_list_items`, `pending_list_indent`,
+`current_node`, `stack`, and all AST collections local to `parse()`.
+
+- [ ] **Step 2: Route YAML transitions without moving page-property ownership**
+
+Use `lexical_state.mode == "yaml"`,
+`lexical_state.begin_yaml_frontmatter()`, and
+`lexical_state.finish_yaml_frontmatter()` in the existing YAML branches. Keep
+the current `page_properties`, `page_properties_order`, and title-override
+updates in `parse()` exactly where they are.
+
+- [ ] **Step 3: Route query, fence, and drawer transitions without moving content handling**
+
+Replace only the mode/eligibility assignments in existing branches:
+
+```python
+lexical_state.consume_query_line(is_query_end=line.is_query_end)
+lexical_state.consume_code_line(is_code_fence=line.is_code_fence)
+keep_drawer_payload = lexical_state.consume_drawer_line(
+    is_drawer_end=line.is_drawer_end,
+    is_bullet=line.bullet_match is not None,
+)
+```
+
+When `keep_drawer_payload` is `False`, preserve the current `continue` behavior
+for `:END:` and preserve fall-through to normal bullet processing for a bullet.
+Do not move LOGBOOK metadata, CLOCK parsing, node refresh, or pending-list
+clearing into `_lexical_state.py`.
+
+- [ ] **Step 4: Route normal-mode eligibility updates**
+
+Replace each existing assignment to `frontmatter_active` or
+`properties_allowed` with the matching state transition:
+
+```python
+lexical_state.observe_structural_node()
+lexical_state.observe_property()
+lexical_state.observe_continuation(
+    is_code_fence=line.is_code_fence,
+    is_query_begin=line.is_query_begin,
+)
+lexical_state.observe_nonstructural_line_without_node()
+```
+
+Use `lexical_state.frontmatter_active` and
+`lexical_state.properties_allowed` in the unchanged property branches. Do not
+introduce a generic dispatcher or alter branch ordering.
+
+- [ ] **Step 5: Run focused equivalence and static validation**
+
+Run:
+
+```bash
+rtk uv run pytest -q \
+  tests/test_parser_lexical_state.py \
+  tests/test_logos_parser.py \
+  tests/test_pre_release_roundtrip.py \
+  tests/test_compat_corpus.py \
+  tests/test_parser_adversarial.py \
+  tests/test_parser_deep_refresh.py \
+  tests/test_parser_work_growth.py
+rtk uv run ruff check src/logseq_matryca_parser/_lexical_state.py src/logseq_matryca_parser/logos_parser.py tests/test_parser_lexical_state.py tests/test_logos_parser.py tests/test_pre_release_roundtrip.py
+rtk uv run mypy src/logseq_matryca_parser/_lexical_state.py src/logseq_matryca_parser/logos_parser.py
+```
+
+Expected: every targeted semantic, deep-refresh, corpus, and work-growth test passes; lint and typing pass.
+
+- [ ] **Step 6: Commit the routed parser slice**
+
+```bash
+rtk git add -- src/logseq_matryca_parser/_lexical_state.py src/logseq_matryca_parser/logos_parser.py tests/test_parser_lexical_state.py tests/test_logos_parser.py tests/test_pre_release_roundtrip.py
+rtk git commit -m "refactor(parser): route lexical modes through private state"
+```
+
+## Task 4: Qualify the exact head and update assurance records
+
+**Files:**
+
+- Modify: `docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md`
+- Modify: `docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md`
+
+**Interfaces:**
+
+- Consumes: the exact implementation SHA, terminal validation results, impact/cycle evidence, and independent review conclusion.
+- Produces: a precise M9 checkpoint that does not claim #108, #87, #103, #104, or #111 closure.
+
+- [ ] **Step 1: Run exact-head repository qualification**
+
+Run:
+
+```bash
+rtk make all
+rtk make vendor-name-check
+rtk git diff --check origin/main...HEAD
+```
+
+Expected: all commands pass from a clean worktree. If the dependency bootstrap blocks `make all`, leave documentation unchanged and recover the environment first.
+
+- [ ] **Step 2: Run final structural checks and inspect the complete diff**
+
+Run the repository's audit-code cycle check, then its change-impact command
+against `origin/main...HEAD`. Inspect every parser-related affected process and
+all direct dependents before review.
+
+Expected: zero source import cycles, no unexpected API or dependency impact,
+and a complete diff limited to the private lexical module, parser routing,
+tests, and the two evidence records.
+
+- [ ] **Step 3: Request an independent exact-head review**
+
+Give a low-cost reviewer only the exact base SHA, implementation SHA, changed
+files, focused test results, full-suite result, impact summary, and the
+requirement that it report only actionable correctness defects. The primary
+maintainer decides whether any finding is valid and runs a focused regression
+before accepting a correction.
+
+Expected: no unresolved actionable finding. A valid finding restarts the
+relevant focused test and exact-head qualification cycle.
+
+- [ ] **Step 4: Record only terminal evidence**
+
+Update the M7/M8 continuation and execution ledger in
+`docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md` with the exact
+M9 SHA, tested scope, validation results, reviewer conclusion, and residual
+boundary. Update `docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md` to point to the
+new checkpoint. State explicitly that this is a second private #108 slice and
+that the epic, #87, #103, #104, and #111 remain open.
+
+- [ ] **Step 5: Validate records and commit the evidence update**
+
+Run:
+
+```bash
+rtk make docs-check
+rtk make vendor-name-check
+rtk git diff --check origin/main...HEAD
+```
+
+Then commit only the two evidence records:
+
+```bash
+rtk git add -- docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+rtk git commit -m "docs(parser): record lexical state slice"
+```
+
+Expected: documentation validation and the vendor-name gate pass. The commit is local evidence only until a separately authorized push and PR.
+
+## Final review checklist
+
+- [ ] The private module contains only lexical state and standard-library imports.
+- [ ] `StackMachineParser.parse()` retains AST, identity, property-value, and recovery behavior.
+- [ ] The new direct-state tests and parser boundary regressions pass on the exact implementation head.
+- [ ] Corpus, round-trip, deep-refresh, adversarial, and work-growth evidence pass on the same head.
+- [ ] Full qualification, vendor-name check, diff check, impact review, zero-cycle check, and independent review are terminal.
+- [ ] Documentation records only verified evidence and does not close the parent epic or unrelated issues.
+- [ ] Push, PR creation, merge, issue changes, and release remain separate explicit gates.

--- a/docs/superpowers/specs/2026-08-20-parser-lexical-state-design.md
+++ b/docs/superpowers/specs/2026-08-20-parser-lexical-state-design.md
@@ -1,0 +1,152 @@
+---
+type: DesignSpecification
+title: Private parser lexical-state extraction
+description: A behavior-preserving second #108 parser phase slice after M7 line classification.
+status: proposed
+classification: active
+audience: maintainers
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-08-20
+verified: 2026-08-20
+stale_after: 2026-11-20
+parent_plan: docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+issue: 108
+base_commit: b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e
+---
+
+# Private parser lexical-state extraction
+
+## Purpose
+
+Deliver the next deliberately narrow implementation slice for issue #108. The
+current parser has already separated pure per-line classification (M7), but
+`StackMachineParser.parse()` still owns the lexical mode flags and their
+transitions directly. This slice makes that lexical state an explicit private
+unit without changing the parser's public API or observable output.
+
+The falsifiable outcome is that the parser produces the same page title,
+properties, root-node order, node UUIDs, parent and left links, source lines,
+references, and serialized semantic round trip for all existing corpus and
+regression inputs, while `parse()` delegates lexical-mode state ownership to a
+private module.
+
+## Verified starting point
+
+- `origin/main` was fetched on 2026-08-20 at
+  `b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e` after merged PR #175.
+- M7 / PR #170 already routes the parser through private `_LineClassification`
+  values. Repeating that extraction is out of scope.
+- `StackMachineParser.parse()` still carries state for YAML frontmatter, code
+  fences, query blocks, LOGBOOK drawers, page-frontmatter eligibility, and
+  block-property eligibility.
+- The indexed source import graph has zero cycles at this starting point.
+- An isolated all-extras baseline could not complete because the pinned Git
+  fetch for transitive `nltk` failed with an HTTP/2 transport error. It is not
+  a test result and must be retried before implementation qualification.
+
+## Selected approach
+
+Introduce a private lexical-state unit, owned only by the parser package. It
+will represent the existing six mode flags and provide named, deterministic
+transitions for the already-classified events that enter or leave those modes.
+`StackMachineParser.parse()` remains the sole owner of:
+
+- AST stack reduction and root-node attachment;
+- node construction, refresh, UUID/source-UUID registration, and references;
+- page property values and serialization-facing model construction;
+- error propagation, `strict_refs`, and file-entrypoint behavior.
+
+The lexical unit must not inspect Markdown independently, read files, mutate
+nodes, build diagnostics, or gain a package-root export. `_LineClassification`
+continues to recognize syntax. The new unit consumes those classification
+signals and the explicitly supplied parse context needed to preserve existing
+control flow.
+
+## Alternatives considered
+
+1. **Selected: lexical-state extraction.** It removes a cohesive private
+   responsibility while retaining the already-proven M7 classifier and the AST
+   reducer. The cost is a careful equivalence suite around mode transitions.
+2. **Fence/query-only extraction.** It would be smaller, but leaves YAML and
+   drawer eligibility state intertwined in `parse()` and does not create a
+   durable lexical boundary.
+3. **AST stack-reducer extraction.** It has a much larger blast radius across
+   immutable refresh, identities, hierarchy, and parser recovery. It is
+   deferred until the lexical boundary has its own exact evidence.
+
+## Required behavior
+
+The extracted state must preserve the current meanings of:
+
+- a first-line YAML delimiter, YAML properties, closing delimiter, and title
+  override;
+- code-fence entry and closure, including property eligibility after closure;
+- query macro entry and closure while content is appended to the active node;
+- LOGBOOK drawer entry, `:END:` closure, and a bullet that returns processing
+  to normal block handling;
+- the distinction between page-frontmatter eligibility and block-property
+  eligibility;
+- current pending-list finalization and continuation behavior at lexical-mode
+  boundaries.
+
+No behavior change is authorized for malformed Markdown, recovery, timing
+budgets, diagnostics, parsing of untracked files, graph construction, writer
+operations, or optional SYNAPSE integrations. If source inspection shows that
+any transition needs a new compatibility decision, stop this slice and record
+the decision instead of changing semantics incidentally.
+
+## Internal boundary
+
+The implementation may add one private module under
+`src/logseq_matryca_parser/` and private types/functions with underscore names.
+It may adjust `logos_parser.py` only to construct, query, and advance that
+state. The private module may depend on a narrow protocol or primitive values;
+it must not import `LogseqNode`, `LogseqPage`, graph, writer, CLI, or optional
+adapter modules. This keeps lexical state acyclic and independently testable.
+
+## Evidence and validation
+
+Before any parser edit, run fresh impact analysis on the exact
+`StackMachineParser.parse` hub and inspect direct callers. Do not proceed past
+an unresolved HIGH or CRITICAL finding without explicit maintainer approval.
+
+The implementation must add focused tests that exercise every listed
+transition, including mixed boundaries such as a property after a closed fence,
+a query closure followed by ordinary content, and a drawer terminated by a
+bullet. Existing compatibility-corpus, deep-refresh, adversarial, round-trip,
+and deterministic work-growth tests must preserve their current contracts.
+
+Qualification of the exact implementation head requires:
+
+```bash
+rtk make all
+rtk make vendor-name-check
+rtk git diff --check origin/main...HEAD
+```
+
+It also requires the focused parser, corpus, deep-refresh, adversarial, and
+work-growth selectors recorded in the implementation plan; a zero-cycle source
+check; a fresh exact-head impact review; and an independent final review. The
+runtime-evidence harness may be replayed as diagnostic evidence, but it is not
+a timing gate or a performance claim for this slice.
+
+## Security, licensing, and privacy
+
+The work remains Apache-2.0 clean-room. No external parser code, tests,
+fixtures, schemas, control flow, or documentation may be copied or adapted.
+No vault data, credentials, generated caches, or benchmark receipts may be
+committed. The slice introduces no network operation, dependency, public API,
+or filesystem authority.
+
+## Publication and completion boundary
+
+This specification authorizes only a second private #108 slice; it does not
+close issue #108. It does not close #87, #103, #104, or #111, and it makes no
+release, cross-machine, 1k/10k-scale, or performance-budget claim.
+
+After this specification is approved, a detailed TDD implementation plan will
+define exact file ownership, transition tests, commit checkpoints, validation,
+and review gates. Implementation, push, pull-request creation, merge, issue
+closure, and release remain separate maintainer gates.

--- a/src/logseq_matryca_parser/_lexical_state.py
+++ b/src/logseq_matryca_parser/_lexical_state.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+_LexicalMode = Literal["normal", "yaml", "code", "query", "drawer"]
+
+
+@dataclass
+class _LexicalState:
+    mode: _LexicalMode = "normal"
+    frontmatter_active: bool = True
+    properties_allowed: bool = True
+
+    def begin_yaml_frontmatter(self) -> None:
+        self.mode = "yaml"
+
+    def finish_yaml_frontmatter(self) -> None:
+        self.mode = "normal"
+        self.frontmatter_active = False
+
+    def begin_code_block(self) -> None:
+        self.mode = "code"
+        self.frontmatter_active = False
+        self.properties_allowed = False
+
+    def consume_code_line(self, *, is_code_fence: bool) -> None:
+        if is_code_fence:
+            self.mode = "normal"
+            self.properties_allowed = True
+        self.frontmatter_active = False
+
+    def begin_query_block(self) -> None:
+        self.mode = "query"
+        self.frontmatter_active = False
+        self.properties_allowed = False
+
+    def consume_query_line(self, *, is_query_end: bool) -> None:
+        if is_query_end:
+            self.mode = "normal"
+        self.frontmatter_active = False
+
+    def begin_drawer(self) -> None:
+        self.mode = "drawer"
+
+    def consume_drawer_line(self, *, is_drawer_end: bool, is_bullet: bool) -> bool:
+        if is_drawer_end or is_bullet:
+            self.mode = "normal"
+            return False
+        return True
+
+    def observe_structural_node(self) -> None:
+        self.frontmatter_active = False
+        self.properties_allowed = True
+
+    def observe_property(self) -> None:
+        self.frontmatter_active = False
+
+    def observe_continuation(self, *, is_code_fence: bool, is_query_begin: bool) -> None:
+        self.frontmatter_active = False
+        self.properties_allowed = False
+        if is_code_fence:
+            self.begin_code_block()
+        if is_query_begin:
+            self.begin_query_block()
+
+    def observe_nonstructural_line_without_node(self) -> None:
+        self.frontmatter_active = False

--- a/src/logseq_matryca_parser/logos_parser.py
+++ b/src/logseq_matryca_parser/logos_parser.py
@@ -21,6 +21,7 @@ from logseq_matryca_parser.logseq_paths import (
     derive_page_title_from_source_path,
 )
 
+from ._lexical_state import _LexicalState
 from .exceptions import BlockReferenceError
 from .logos_core import LogseqNode, LogseqPage
 
@@ -702,15 +703,10 @@ class StackMachineParser:
         page_properties: dict[str, Any] = {}
         page_properties_order: list[str] = []
         current_node: LogseqNode | None = None
-        frontmatter_active = True
-        properties_allowed = True
+        lexical_state = _LexicalState()
         pending_list_key: str | None = None
         pending_list_items: list[str] = []
         pending_list_indent: int | None = None
-        in_code_block = False
-        in_query_block = False
-        in_drawer = False
-        in_yaml_frontmatter = False
         line_number = 0
 
         for line_number, input_line in enumerate(text.splitlines(), start=1):
@@ -718,10 +714,9 @@ class StackMachineParser:
             raw_line = line.raw_line
             stripped_line = line.stripped_line
 
-            if in_yaml_frontmatter:
+            if lexical_state.mode == "yaml":
                 if line.is_yaml_delimiter:
-                    in_yaml_frontmatter = False
-                    frontmatter_active = False
+                    lexical_state.finish_yaml_frontmatter()
                     yaml_title = page_properties.get("title")
                     if isinstance(yaml_title, str) and yaml_title.strip():
                         page_title = yaml_title.strip()
@@ -736,42 +731,39 @@ class StackMachineParser:
                 continue
 
             if line_number == 1 and line.is_yaml_delimiter:
-                in_yaml_frontmatter = True
+                lexical_state.begin_yaml_frontmatter()
                 continue
 
-            if in_query_block and current_node is not None:
+            if lexical_state.mode == "query" and current_node is not None:
                 merged_content = f"{current_node.content}\n{raw_line}"
                 updated = self._refresh_node(current_node, merged_content, line_end=line_number)
                 self._replace_stack_tail_node(stack, root_nodes, updated)
                 current_node = updated
-                if line.is_query_end:
-                    in_query_block = False
-                frontmatter_active = False
+                lexical_state.consume_query_line(is_query_end=line.is_query_end)
                 pending_list_key = None
                 pending_list_items = []
                 pending_list_indent = None
                 continue
 
-            if in_code_block and current_node is not None:
+            if lexical_state.mode == "code" and current_node is not None:
                 merged_content = f"{current_node.content}\n{raw_line}"
                 updated = self._refresh_node(current_node, merged_content, line_end=line_number)
                 self._replace_stack_tail_node(stack, root_nodes, updated)
                 current_node = updated
-                if line.is_code_fence:
-                    in_code_block = False
-                    properties_allowed = True
-                frontmatter_active = False
+                lexical_state.consume_code_line(is_code_fence=line.is_code_fence)
                 pending_list_key = None
                 pending_list_items = []
                 pending_list_indent = None
                 continue
 
-            if in_drawer:
-                if line.is_drawer_end:
-                    in_drawer = False
-                    continue
-                if line.bullet_match:
-                    in_drawer = False
+            if lexical_state.mode == "drawer":
+                keep_drawer_payload = lexical_state.consume_drawer_line(
+                    is_drawer_end=line.is_drawer_end,
+                    is_bullet=line.bullet_match is not None,
+                )
+                if not keep_drawer_payload:
+                    if line.is_drawer_end:
+                        continue
                 else:
                     if current_node is not None:
                         properties = dict(current_node.properties)
@@ -806,7 +798,7 @@ class StackMachineParser:
                     continue
 
             if line.is_logbook_begin and current_node is not None:
-                in_drawer = True
+                lexical_state.begin_drawer()
                 properties = dict(current_node.properties)
                 properties.setdefault("logbook", [])
                 updated = self._refresh_node(
@@ -913,8 +905,7 @@ class StackMachineParser:
                 stack_indents.append(raw_indent)
                 current_node = node
                 self.registry.register(node)
-                frontmatter_active = False
-                properties_allowed = True
+                lexical_state.observe_structural_node()
                 continue
 
             heading_match = line.heading_match
@@ -948,8 +939,7 @@ class StackMachineParser:
                 stack_indents.append(raw_indent)
                 current_node = node
                 self.registry.register(node)
-                frontmatter_active = False
-                properties_allowed = True
+                lexical_state.observe_structural_node()
                 continue
 
             property_match = line.property_match
@@ -959,7 +949,7 @@ class StackMachineParser:
                 value = _sanitize_line(value)
                 value = value.strip().strip('"').strip("'")
 
-                if current_node is None and frontmatter_active:
+                if current_node is None and lexical_state.frontmatter_active:
                     page_properties[key] = value
                     if key not in page_properties_order:
                         page_properties_order.append(key)
@@ -968,11 +958,11 @@ class StackMachineParser:
                     continue
 
                 if current_node is None:
-                    frontmatter_active = False
+                    lexical_state.observe_nonstructural_line_without_node()
                     continue
 
                 block = current_node
-                if not properties_allowed:
+                if not lexical_state.properties_allowed:
                     pass
                 elif pending_list_key is not None:
                     finalized = self._finalize_pending_property_list(
@@ -990,7 +980,7 @@ class StackMachineParser:
                     pending_list_items = []
                     pending_list_indent = None
 
-                if properties_allowed and value.strip() == "":
+                if lexical_state.properties_allowed and value.strip() == "":
                     pending_list_key = key
                     pending_list_items = []
                     raw_prop_indent = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
@@ -1008,10 +998,10 @@ class StackMachineParser:
                         block = updated
                         current_node = block
                         self.registry.register(updated)
-                    frontmatter_active = False
+                    lexical_state.observe_property()
                     continue
 
-                if properties_allowed:
+                if lexical_state.properties_allowed:
                     properties = dict(block.properties)
                     properties[key] = value
                     properties_order = list(block.properties_order)
@@ -1032,11 +1022,11 @@ class StackMachineParser:
                     self._replace_stack_tail_node(stack, root_nodes, updated)
                     current_node = updated
                     self.registry.register(updated)
-                    frontmatter_active = False
+                    lexical_state.observe_property()
                     continue
 
             if not stack:
-                frontmatter_active = False
+                lexical_state.observe_nonstructural_line_without_node()
                 continue
 
             active_node = stack[-1]
@@ -1049,12 +1039,10 @@ class StackMachineParser:
                 line_number,
                 len(stack),
             )
-            frontmatter_active = False
-            properties_allowed = False
-            if line.is_code_fence:
-                in_code_block = True
-            if line.is_query_begin:
-                in_query_block = True
+            lexical_state.observe_continuation(
+                is_code_fence=line.is_code_fence,
+                is_query_begin=line.is_query_begin,
+            )
 
         if pending_list_key is not None and current_node is not None:
             current_node = self._finalize_pending_property_list(

--- a/tests/test_logos_parser.py
+++ b/tests/test_logos_parser.py
@@ -213,6 +213,51 @@ def test_query_block_shields_graph_tokens(
     assert "+BEGIN_QUERY" not in root.tags
 
 
+def test_lexical_boundaries_keep_properties_out_of_query_and_drawer(
+    parser: StackMachineParser,
+) -> None:
+    """Keep block text and properties separated across code/query/drawer boundaries."""
+    source = (
+        "- Root\n"
+        "  ```\n"
+        "  literal:: fence\n"
+        "  ```\n"
+        "  tags:: [[Visible]]\n"
+        "  #+BEGIN_QUERY\n"
+        "  query:: [[HiddenQuery]]\n"
+        "  #+END_QUERY\n"
+        "  :LOGBOOK:\n"
+        "  collapsed:: true\n"
+        "  :END:\n"
+        "  - Child"
+    )
+
+    page = parser.parse(source, page_title="lexical-boundaries")
+    root = page.root_nodes[0]
+
+    assert root.properties["tags"] == "[[Visible]]"
+    assert "query" not in root.properties
+    assert "collapsed" not in root.properties
+    assert "literal:: fence" in root.content
+    assert "query:: [[HiddenQuery]]" in root.content
+    assert "collapsed:: true" in root.properties["logbook"]
+    assert root.children[0].content == "Child"
+
+
+def test_nonstructural_preamble_closes_page_frontmatter_eligibility(
+    parser: StackMachineParser,
+) -> None:
+    """Non-structural preamble lines stop page property parsing."""
+    page = parser.parse(
+        "title:: Page title\nplain preamble\nalias:: MustNotBecomePageProperty\n- Root",
+        page_title="fallback",
+    )
+
+    assert page.title == "Page title"
+    assert page.properties == {"title": "Page title"}
+    assert page.root_nodes[0].content == "Root"
+
+
 def test_zero_to_four_space_fracture_binds_to_root(parser: StackMachineParser) -> None:
     """A direct 0->4 space jump is legal and binds to root."""
     content = "- Root\n    - Four space child"

--- a/tests/test_parser_lexical_state.py
+++ b/tests/test_parser_lexical_state.py
@@ -1,0 +1,47 @@
+from logseq_matryca_parser._lexical_state import _LexicalState
+
+
+def test_yaml_frontmatter_close_disables_page_frontmatter() -> None:
+    state = _LexicalState()
+    assert state.frontmatter_active is True
+    assert state.properties_allowed is True
+
+    state.begin_yaml_frontmatter()
+    assert state.mode == "yaml"
+
+    state.finish_yaml_frontmatter()
+    assert state.mode == "normal"
+    assert state.frontmatter_active is False
+
+
+def test_code_and_query_closures_restore_existing_eligibility() -> None:
+    state = _LexicalState()
+    state.begin_code_block()
+    state.consume_code_line(is_code_fence=True)
+    assert state.mode == "normal"
+    assert state.properties_allowed is True
+
+    state.begin_query_block()
+    state.consume_query_line(is_query_end=True)
+    assert state.mode == "normal"
+    assert state.frontmatter_active is False
+
+
+def test_drawer_bullet_returns_to_normal_processing() -> None:
+    state = _LexicalState()
+    state.begin_drawer()
+    assert state.mode == "drawer"
+
+    assert state.consume_drawer_line(is_drawer_end=False, is_bullet=True) is False
+    assert state.mode == "normal"
+
+
+def test_structural_property_and_continuation_events_match_current_flags() -> None:
+    state = _LexicalState()
+    state.observe_structural_node()
+    assert state.frontmatter_active is False
+    assert state.properties_allowed is True
+
+    state.observe_continuation(is_code_fence=True, is_query_begin=False)
+    assert state.mode == "code"
+    assert state.properties_allowed is False


### PR DESCRIPTION
## Description

Progresses #108 without closing it.

Extracts the parser's lexical-mode flags into a private, standard-library-only `_LexicalState` object and routes `StackMachineParser.parse()` through explicit state transitions. The change preserves parser branch order, AST construction, identity, property ownership, and pending-list behavior.

This PR also adds focused lexical-boundary regressions and records the M9 assurance slice in the maintained execution plan and goal.

## Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] Internal behavior-preserving refactor

## 🛡️ Sovereign Developer Checklist
- [x] I have read `CONTRIBUTING.md`.
- [x] I have executed `make all` locally, and all linters (Ruff), type-checkers (Mypy), and tests (Pytest) pass successfully.
- [x] I have added/updated tests for my changes.
- [x] I have updated the relevant documentation.
- [x] No `CHANGELOG.md` entry is required because this refactor does not change user-visible behavior.
- [x] My code follows the project's typing conventions.

## 🤖 AI assistance and data handling
- [x] Meaningful AI assistance was used; the maintainer reviewed the complete diff and remains responsible for the submitted work.
- [x] No private vault data, credentials, tokens, or unpublished security details were uploaded.
- [x] The complete diff was reviewed under the AI-assisted contribution policy.

## 🧭 Contract impact
- [x] The parser assurance plan and persistent goal were updated.
- [x] This PR does not claim a GitHub setting, release provenance result, AAIF status, or external protocol support without a current receipt.
- [x] This slice does not close #108, #87, #103, #104, or #111.

## Validation

- `make all`: 685 passed
- Coverage: 89.73% (required floor: 80%)
- Ruff: passed
- Mypy: passed
- Documentation check: passed
- Vendor-name check: passed
- Import-cycle check: 0 cycles
- Final independent review: no Critical, Important, or Minor findings
- Qualified head: `a8558aca305c43bbadb66b884b9def945f8af36c`

## Screenshots / CLI Output

Not applicable.