### PR TITLE
perf(parser): bound pathological soft-break refresh work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   API or performance claim changes.
 - **Pathological nested outlines (#87)** — parse and file-entrypoint traversal
   now remain iterative for a 1024-level valid outline, while parser-owned tree
-  construction avoids quadratic immutable-ancestor copies. Tree order, parent
-  and left relationships, source paths, and stable public API are preserved.
-  Local timing observations are diagnostic only; this does not add a vault-scale
-  performance claim.
+  construction avoids quadratic immutable-ancestor copies. Derived metadata is
+  refreshed once after tree construction instead of repeatedly across mutable
+  soft-break ancestors, and parser registries are rebuilt from the exact final
+  nodes returned by parse and file entry points. Strict reference validation is
+  confined to the current page. Tree order, parent and left relationships,
+  source paths, semantic snapshots, and the stable public API are preserved.
+  Deterministic tests bound refresh growth; local timing observations remain
+  diagnostic only and do not add a vault-scale performance claim.
 
 ## [1.8.0] - 2026-08-20
 

--- a/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
+++ b/docs/LSDOC_REFERENCE_STUDY_AND_EXECUTION_PLAN_2026-08-16.md
@@ -53,13 +53,13 @@ Markdown source-of-truth model.
 | Item | Verified state | Evidence |
 |---|---|---|
 | Source repository | `MarcoPorcellato/logseq-matryca-parser` | `origin/main` fetched 2026-08-21 |
-| Source base | `2a3679e176772bfcc57ed49b2c7c63d9d7d72346` | PR #176 squash merge; current source anchor verified on 2026-08-21 |
+| Source base | `60082bb725b80904572a43ac01c3849766a242a0` | PR #177 squash merge; current source anchor verified on 2026-08-21 |
 | Source license | Apache License 2.0 | [`LICENSE`](../LICENSE) |
 | Reference repository | `martinkoutecky/lsdoc` release `v0.5.5` | [reference commit `c79cb059`](https://github.com/martinkoutecky/lsdoc/commit/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3) |
 | Reference license | `AGPL-3.0-only` | [`Cargo.toml`](https://github.com/martinkoutecky/lsdoc/blob/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3/Cargo.toml) and [`LICENSE`](https://github.com/martinkoutecky/lsdoc/blob/c79cb059da5b4360ebde2e5fd953fa1f43ddabc3/LICENSE) |
 | Parent roadmap | current repository-wide quality SSOT | [stellar roadmap](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) |
 | M0 publication | merged as [PR #159](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/159) | source head `a6056413`, squash merge `30946446`, terminal validation recorded in the PR |
-| Existing delivery anchors | #87, #103, #104, and #111 remain open; #106, #108, #113, and #165 are closed | live GitHub issue reads on 2026-08-21; reactivation of #108 is planned after the source PR is reviewable |
+| Existing delivery anchors | #87, #103, #104, #108, and #111 remain open; #106, #113, and #165 are closed | live GitHub issue reads on 2026-08-21; #108 was reopened after PR #177 became reviewable |
 | Local implementation checkpoint | `8806205c35b104ed65d00a273acc9eeca572ae38` | clean local commit on `agent/parser-assurance-m1`; exact-head tests passed, but independent oracle review rejected publication |
 | M1 delivery | merged | [PR #161](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/161) merged the project-owned compatibility-corpus foundation; it remains only the first #104 tranche |
 | M2–M4 delivery | merged | M3 [PR #162](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/162), M4 [PR #163](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/163), and M2 [PR #164](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/164) are in `main` as `172be70`, `5d38e01`, and `98bc5aa` respectively |
@@ -67,7 +67,8 @@ Markdown source-of-truth model.
 | M6 delivery | merged | Source-location contract and RFC merged through [PR #169](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/169) |
 | M7 delivery | merged | Internal line-classification slice merged through [PR #170](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/170); issue [#165](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/165) is closed |
 | M9 delivery | merged through [PR #176](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/176) | Source head `a8558aca305c43bbadb66b884b9def945f8af36c`, squash merge `2a3679e176772bfcc57ed49b2c7c63d9d7d72346`; [CodeQL run 32434564524](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434564524), [Dependency Review run 32434567688](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567688), and [Logos Protocol CI run 32434567730](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567730) completed successfully |
-| Current milestone | v1.8.0 released; M9 merged; broader assurance work remains | current source `2a3679e`; tag `v1.8.0`, exact workflow run `32324328464`, PyPI publication, GitHub Release, checksums, attestations, and PR #176 hosted checks were verified on 2026-08-21 |
+| Documentation reconciliation | merged through [PR #177](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/177) | Source head `02bd6f293276faa5001aab05be5c4c19e99364fa`, squash merge `60082bb725b80904572a43ac01c3849766a242a0`; eight hosted checks completed successfully and #108 is open |
+| Current milestone | v1.8.0 released; M9 and its maintained-status reconciliation merged; broader assurance work remains | current source `60082bb`; tag `v1.8.0`, exact workflow run `32324328464`, PyPI publication, GitHub Release, checksums, attestations, and PR #176/#177 hosted checks were verified on 2026-08-21 |
 
 Drift-prone anchors must be re-verified before issue edits, implementation,
 publication, or qualification.
@@ -578,6 +579,27 @@ converted into a pass or silently added to an allowlist.
 - An incomplete work model can miss uninstrumented library or regex costs;
   timing and profiling remain complementary.
 
+#### Current #87 bounded qualification
+
+PR #174 already delivered iterative 1024-level traversal and the linear
+model-copy guard. Local code commit `c188556`, based on the PR #177 merge,
+addresses the remaining pathological soft-break behavior by finalizing derived
+metadata once per node in iterative post-order. It also resets strict-reference
+state for each page and rebuilds registries from the exact final nodes returned
+by direct, same-tab, detected-tab, and empty-file entry points.
+
+The exact local gate passed 691 tests with 89.82% coverage, while the focused
+parser suite passed 33 tests. The regression compares metadata-helper calls at
+3 and 300 continuations, the 1024-level strict and file paths remain iterative,
+and semantic snapshots plus returned-node registry identity are preserved. A
+privacy-clean 1,148-line seed with SHA-256
+`4c2b1e87367d2b7b9c16ee62441f05c21c46c86c954703c5f7892789ca148a5d`
+produced one canonical in-process result across 21 measured samples after 3
+warm-ups; local median was 0.02702 seconds and p95 was 0.02739 seconds. These
+times are platform-labelled diagnostics only. Hosted validation, merge, and
+issue closure remain separate gates, while #111 retains all vault-scale,
+cross-machine, RSS, reload, search, and RAG-chunk performance ownership.
+
 ### M5 — Privacy-safe local graph assurance tool
 
 **Outcome**
@@ -758,7 +780,7 @@ converted into a pass or silently added to an allowlist.
 **Hosted publication and reconciliation**
 
 - The M9 source was published through [PR #176](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/176): source head `a8558aca305c43bbadb66b884b9def945f8af36c` was squash-merged as `2a3679e176772bfcc57ed49b2c7c63d9d7d72346`. [CodeQL run 32434564524](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434564524), [Dependency Review run 32434567688](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567688), and [Logos Protocol CI run 32434567730](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567730) all completed successfully.
-- Issue [#108](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/108) is currently CLOSED with reason `completed`. Reactivation is planned after the source PR is reviewable; until then, the residual scope is reducer, semantic enrichment, final equivalence, and benchmark gates.
+- Issue [#108](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/108) was reopened after PR #177 became reviewable and remains open. The residual scope is reducer, semantic enrichment, final equivalence, and benchmark gates.
 
 **Terminal local evidence**
 
@@ -916,10 +938,9 @@ It must not replace the requirements in this plan.
 - [x] The first #108 extraction slice is covered by semantic and work-growth
   gates through PR #170; the broader extraction scope remains unfinished.
 - [x] The second private #108 lexical-state slice was published through PR
-  #176 and its hosted checks completed. Issue #108 is currently CLOSED with
-  reason `completed`; reducer, semantic enrichment, final equivalence, and
-  benchmark gates remain, and reactivation is planned after the source PR is
-  reviewable.
+  #176 and its hosted checks completed. PR #177 reconciled the maintained
+  status and merged with eight successful hosted checks; issue #108 is open for
+  reducer, semantic enrichment, final equivalence, and benchmark gates.
 - [ ] No AGPL-covered expression entered Apache-only source, tests, fixtures,
   schemas, or documentation.
 - [ ] Documentation, issue state, and public claims match the delivered behavior.
@@ -932,7 +953,9 @@ Completion is unproven until every applicable item has authoritative evidence.
 
 | Date | Anchor | Result | Evidence and residual boundary |
 |---|---|---|---|
-| 2026-08-21 | M9 hosted publication / PR #176 | merged and hosted-validated | Source head `a8558aca305c43bbadb66b884b9def945f8af36c` was squash-merged as `2a3679e176772bfcc57ed49b2c7c63d9d7d72346`; [CodeQL `32434564524`](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434564524), [Dependency Review `32434567688`](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567688), and [Logos Protocol CI `32434567730`](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567730) completed successfully. PR #174 merged as `8801498a31251dc9b8b6f0e1106835d87e083e16` and PR #175 as `b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e`. Issue #108 is currently CLOSED with reason `completed`; reactivation is planned after the source PR is reviewable. Residual scope remains reducer, semantic enrichment, final equivalence, and benchmark gates. |
+| 2026-08-21 | #87 soft-break metadata refresh `c188556` | locally qualified; hosted validation pending | Based on `60082bb`, the code commit defers derived metadata until iterative finalization, makes strict-reference state page-local, and rebuilds registries from exact returned nodes. `make all` passed 691 tests at 89.82% coverage; the focused suite passed 33 tests; Ruff, mypy, documentation, vendor, deterministic work-growth, deep traversal, semantic, identity, and diff gates passed. The privacy-clean seed's 3-warm-up/21-sample local observation had a 0.02702-second median and 0.02739-second p95 with one canonical in-process result. These times are diagnostic only; PR, hosted checks, merge, release, and #111 performance claims remain separate. |
+| 2026-08-21 | Maintained-status reconciliation / PR #177 | merged and hosted-validated | Source head `02bd6f293276faa5001aab05be5c4c19e99364fa` was squash-merged as `60082bb725b80904572a43ac01c3849766a242a0`; all eight checks passed across [CodeQL `32442416999`](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32442416999), [Dependency Review `32442419152`](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32442419152), and [Logos Protocol CI `32442419151`](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32442419151). Issue #108 is open with bounded reducer, semantic-enrichment, final-equivalence, and benchmark residual scope. |
+| 2026-08-21 | M9 hosted publication / PR #176 | merged and hosted-validated | Source head `a8558aca305c43bbadb66b884b9def945f8af36c` was squash-merged as `2a3679e176772bfcc57ed49b2c7c63d9d7d72346`; [CodeQL `32434564524`](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434564524), [Dependency Review `32434567688`](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567688), and [Logos Protocol CI `32434567730`](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567730) completed successfully. PR #174 merged as `8801498a31251dc9b8b6f0e1106835d87e083e16` and PR #175 as `b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e`. Residual #108 scope was subsequently reopened and reconciled through PR #177. |
 | 2026-08-20 | M9 lexical-state implementation `d3dd316` | local implementation checkpoint / docs checkpointing | Native make all ran from exact base `b56c0c6a6f9f2bc4766c07736c6c566da8c77c3e` to `d3dd316d4536ea428747dc3a4895ad633ffa6993`; it passed 685 tests (89.73%), Ruff, mypy, documentation checks, vendor-name check, git diff check, and zero-cycle audit. Focused suite passed with 288 tests. Complete-range review on `Luna` found no actionable correctness or scope defects. This second private #108 slice does not close #108, #87, #103, #104, or #111; no publication or GitHub-release claim is made. |
 | 2026-08-16 | M0 / PR #159 | merged | Source head `a6056413`, squash merge `30946446`; PR records 535 passing tests, 91.95% coverage, documentation/package/vendor gates, and zero cycles. No parser behavior changed. |
 | 2026-08-16 | M1 activation | verified | Clean `agent/parser-assurance-m1` at `e2a3f9a`, matching `origin/main`; no tracked M1 changes at activation. |

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -49,8 +49,8 @@ and closes child issue [#165](https://github.com/MarcoPorcellato/logseq-matryca-
 The private line-classification extraction preserves parser state reduction,
 node creation, identities, graph behavior, public imports, and dependencies.
 The broader #108 epic remains unfinished for later gated phase slices. Issue
-#108 is currently CLOSED with reason `completed`; it will be reopened only
-after this source PR is reviewable.
+#108 was reopened on 2026-08-21 after the reconciliation source became
+reviewable and remains open for its bounded residual scope.
 
 M9 is merged through [PR #176](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/176): source head
 `a8558aca305c43bbadb66b884b9def945f8af36c` was squash-merged as
@@ -64,10 +64,15 @@ standard-library-only state object while leaving parser semantics and ownership
 in `StackMachineParser.parse()`. Native `make all` passed with 685 tests and
 89.73% coverage; the focused suite passed 288 tests; static, documentation,
 vendor, diff, impact, zero-cycle, and independent-review gates are recorded in
-the canonical plan. Issue #108 is currently CLOSED with reason `completed`;
-reactivation is planned after the source PR is reviewable. Until then, the
-residual scope is reducer, semantic enrichment, final equivalence, and benchmark
-gates. This does not claim closure of #87,
+the canonical plan. The maintained-status reconciliation then merged through
+[PR #177](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/177):
+source head `02bd6f293276faa5001aab05be5c4c19e99364fa` was squash-merged as
+`60082bb725b80904572a43ac01c3849766a242a0`. All eight hosted checks completed
+successfully across [CodeQL run 32442416999](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32442416999),
+[Dependency Review run 32442419152](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32442419152), and
+[Logos Protocol CI run 32442419151](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32442419151).
+Issue #108 is now open; residual scope remains reducer, semantic enrichment,
+final equivalence, and benchmark gates. This does not claim closure of #87,
 #103, #104, or #111.
 
 M2 is complete through the accepted negative
@@ -96,16 +101,22 @@ and [PyPI package](https://pypi.org/project/logseq-matryca-parser/1.8.0/)
 were checked after publication. The broader #104, #103, #87, #111, and #108
 acceptance work remains open where the plan still marks it incomplete.
 
-Post-release #87 work is in delivery on a local branch and is not yet a release
-or hosted-validation claim. On source code identical to v1.8.0, a valid
-1024-level nested outline raised `RecursionError`; profiling also identified
-quadratic Pydantic ancestor copies during incremental tree construction. The
-bounded correction replaces parser-owned recursive traversals with iterative
-ones and forbids immutable ancestor rebuilding in the test-only work model. The
-new checks preserve tree order, parent and left relationships, source paths,
-and a linear model-copy budget. Local elapsed observations remain diagnostic
-only; #111 still owns vault-scale wall-time, p95, RSS, reload, search, and
-RAG-chunk benchmark evidence.
+Post-release #87 work has two bounded stages. PR #174 delivered iterative
+1024-level traversal and a linear model-copy budget after the v1.8.0 source had
+shown `RecursionError` and quadratic immutable-ancestor copies. Local commit
+`c188556` now defers derived metadata refresh until iterative post-order
+finalization, resets strict-reference state for each page, and rebuilds the
+registry from the exact normalized or source-enriched nodes returned by every
+parse and file entry point. The deterministic regression compares helper-call
+growth at 3 and 300 continuations; the full gate passed 691 tests with 89.82%
+coverage, and the focused parser suite passed 33 tests. On the privacy-clean
+1,148-line seed (`sha256:4c2b1e87367d2b7b9c16ee62441f05c21c46c86c954703c5f7892789ca148a5d`),
+the final local 3-warm-up/21-sample observation had a 0.02702-second median and
+0.02739-second p95 with one canonical result in-process. These measurements are
+diagnostic on one host, not a hosted-validation, release, cross-machine,
+universal-speedup, or vault-scale claim. #111 still owns wall-time, p95, RSS,
+reload, search, and RAG-chunk benchmark evidence. Hosted validation, merge,
+release, and issue closure for local commit `c188556` remain separate gates.
 
 The initial checkpoint `8806205c35b104ed65d00a273acc9eeca572ae38` is rejected
 pre-correction evidence. Corrective implementation

--- a/docs/log.md
+++ b/docs/log.md
@@ -28,10 +28,22 @@ superseded_by: null
   `2a3679e176772bfcc57ed49b2c7c63d9d7d72346`.
 - PR #176's [CodeQL run 32434564524](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434564524), [Dependency Review run 32434567688](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567688),
   and [Logos Protocol CI run 32434567730](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32434567730) completed successfully.
-- Issue #108 is currently CLOSED with reason `completed`; reactivation is
-  planned after the source PR is reviewable. Until then, residual scope is
-  reducer, semantic enrichment, final equivalence, and benchmark gates. No v1.8.1, universal speedup, #87 closure, or
-  completion of #103, #104, or #111 is claimed.
+- Reconciled maintained status through [PR #177](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/177): source head
+  `02bd6f293276faa5001aab05be5c4c19e99364fa` was squash-merged as
+  `60082bb725b80904572a43ac01c3849766a242a0`; all eight hosted checks passed.
+  Issue #108 is now open with residual reducer, semantic-enrichment, final
+  equivalence, and benchmark gates.
+- Locally qualified the bounded #87 soft-break correction as code commit
+  `c188556`. Derived metadata is finalized once per node, strict-reference state
+  is page-local, and parser registries contain the exact returned nodes across
+  direct and file entry points. `make all` passed 691 tests at 89.82% coverage;
+  the focused parser suite passed 33 tests; deterministic helper-call growth,
+  1024-level traversal, semantic snapshots, registry identity, Ruff, mypy,
+  documentation, and vendor gates passed. The 1,148-line privacy-clean seed had
+  a local 3-warm-up/21-sample median of 0.02702 seconds and p95 of 0.02739
+  seconds. This is diagnostic local evidence only: no v1.8.1, hosted #87
+  validation, universal speedup, or completion of #103, #104, or #111 is
+  claimed.
 
 ## 2026-08-20
 

--- a/docs/superpowers/plans/2026-08-21-post-m9-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-21-post-m9-reconciliation.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Reconcile the maintained parser-assurance documentation with the merged PR #176 receipt while keeping the unfinished #108 epic historically accurate. Issue #108 is currently CLOSED with reason `completed`; reactivation is planned after the source PR is reviewable.
+**Goal:** Reconcile the maintained parser-assurance documentation with the merged PR #176 receipt while keeping the unfinished #108 epic historically accurate. At plan creation, issue #108 was closed with reason `completed`; the plan required reactivation after the source PR became reviewable.
 
 **Architecture:** Update only current maintained status and chronology surfaces. Preserve the accepted M9 design and implementation plan as historical records of the pre-publication boundary. Reopen #108 as a controller-owned GitHub action after the source documentation is reviewable; do not imply that reducer, semantic-enrichment, benchmark, or release gates are complete.
 
@@ -31,11 +31,11 @@
 
 **Interfaces:**
 - Consumes: PR #176 head `a8558aca305c43bbadb66b884b9def945f8af36c`, squash merge `2a3679e176772bfcc57ed49b2c7c63d9d7d72346`, successful CodeQL run `32434564524`, successful Dependency Review run `32434567688`, and successful Logos Protocol CI run `32434567730`.
-- Produces: current maintained documentation that describes M9 as merged and hosted-validated while recording #108 as CLOSED with reason `completed`; reactivation is planned after the source PR is reviewable, with reducer, semantic enrichment, final equivalence, and benchmark gates remaining.
+- Produces: maintained documentation that describes M9 as merged and hosted-validated while recording the then-current closed state and the required later reactivation, with reducer, semantic enrichment, final equivalence, and benchmark gates remaining.
 
 - [x] **Step 1: Update authoritative anchors and M9 status**
 
-  In the canonical execution plan, replace the local-only M9 anchor with the exact PR, source-head, merge, and hosted-check receipts. Update the current source anchor to `2a3679e176772bfcc57ed49b2c7c63d9d7d72346`. State that #108 is currently CLOSED with reason `completed`; reactivation is planned after the source PR is reviewable because the merged artifacts delivered only the second private slice.
+  In the canonical execution plan, replace the local-only M9 anchor with the exact PR, source-head, merge, and hosted-check receipts. Update the source anchor to the then-current `2a3679e176772bfcc57ed49b2c7c63d9d7d72346`. Record that #108 was closed with reason `completed` at this step and required reactivation after the source PR became reviewable because the merged artifacts delivered only the second private slice.
 
 - [x] **Step 2: Preserve the M9 local receipt and add the publication receipt**
 
@@ -47,7 +47,7 @@
 
 - [x] **Step 4: Add the newest-first documentation log entry**
 
-  Add `## 2026-08-21` above the existing `2026-08-20` entry. Record PR #174, PR #175, and PR #176 as distinct post-v1.8.0 deliveries; explain that #108 is currently CLOSED with reason `completed` and reactivation is planned after the source PR is reviewable. Update `last_verified`, `verified`, and `stale_after` using the repository validator's accepted dates.
+  Add `## 2026-08-21` above the existing `2026-08-20` entry. Record PR #174, PR #175, and PR #176 as distinct post-v1.8.0 deliveries; explain the then-current closed #108 state and the required reactivation after the source PR became reviewable. Update `last_verified`, `verified`, and `stale_after` using the repository validator's accepted dates.
 
 - [x] **Step 5: Run focused documentation validation**
 
@@ -61,9 +61,9 @@
 
   Expected: all commands exit 0 and no historical design/plan file changes.
 
-  Task 1 status: documentation edits, focused validation, and independent
-  review are complete. Publication of this reconciliation and #108
-  reactivation remain pending.
+  Task 1 status at its checkpoint: documentation edits, focused validation, and
+  independent review were complete. Publication and #108 reactivation were
+  still pending and were completed in Task 2 below.
 
 - [x] **Step 6: Commit the documentation reconciliation**
 
@@ -82,7 +82,7 @@
 
 **Interfaces:**
 - Consumes: Task 1 exact commit and successful documentation gates.
-- Produces: reviewed source change, planned reactivation of currently CLOSED issue #108 after the source PR is reviewable, and a durable hosted receipt.
+- Produces: reviewed source change, reactivation of issue #108 after the source PR is reviewable, and a durable hosted receipt.
 
 - [x] **Step 1: Run exact-head repository gates**
 
@@ -125,9 +125,14 @@
   was reopened after PR #177 became reviewable and received the bounded residual
   scope comment.
 
-- [ ] **Step 5: Verify hosted state**
+- [x] **Step 5: Verify hosted state**
 
   Verify the PR base/head SHA, draft state, mergeability, checks, and issue #108 state separately. Do not merge until every exact-head required check and review is terminally successful.
+
+  PR #177 source head `02bd6f293276faa5001aab05be5c4c19e99364fa`
+  completed all eight hosted checks and was squash-merged as
+  `60082bb725b80904572a43ac01c3849766a242a0` on 2026-08-21. Issue #108 is
+  `OPEN` with reason `REOPENED`.
 
 ## Completion checklist
 
@@ -136,4 +141,5 @@
 - [x] Matryca-v1 maintained metadata and links pass deterministically.
 - [x] Issue #108 is reactivated after the source PR is reviewable and describes the residual reducer, semantic enrichment, final equivalence, and benchmark scope.
 - [x] #87, #103, #104, and #111 ownership is unchanged.
-- [ ] The reconciliation PR is reviewable with exact-head local and hosted evidence.
+- [x] The reconciliation PR completed exact-head local and hosted evidence and
+  merged as `60082bb725b80904572a43ac01c3849766a242a0`.

--- a/src/logseq_matryca_parser/logos_parser.py
+++ b/src/logseq_matryca_parser/logos_parser.py
@@ -696,6 +696,7 @@ class StackMachineParser:
 
     def parse(self, text: str, page_title: str = "untitled") -> LogseqPage:
         """Parse Logseq markdown text into a `LogseqPage`."""
+        self.registry = PageRegistry()
         stack: list[LogseqNode] = []
         stack_columns: list[int] = []
         stack_indents: list[str] = []
@@ -1054,8 +1055,10 @@ class StackMachineParser:
                 line_number,
             )
 
+        root_nodes = self._finalize_node_metadata(root_nodes)
         self._validate_references(root_nodes)
         root_nodes = self._normalize_indent_levels(root_nodes)
+        self._rebuild_registry(root_nodes)
         page_refs = self._collect_page_refs(root_nodes)
         page_prop_wikilinks, page_prop_tags, page_prop_block_refs = _extract_property_graph_tokens(
             page_properties
@@ -1095,6 +1098,7 @@ class StackMachineParser:
         """Parse a markdown file and return a graph-native page model."""
         path = Path(path)
         content = path.read_text(encoding="utf-8-sig")
+        self.registry = PageRegistry()
         detected_tab = detect_tab_size_from_markdown(content)
         if not content.strip():
             logger.warning("File %s is empty.", path)
@@ -1102,7 +1106,7 @@ class StackMachineParser:
             title_segments = [segment for segment in page_title.split("/") if segment]
             namespace_chain = title_segments[:-1] if len(title_segments) > 1 else []
             graph_root = self._derive_graph_root(path)
-            return LogseqPage(
+            page = LogseqPage(
                 title=page_title,
                 raw_content=content,
                 namespace_chain=namespace_chain,
@@ -1110,6 +1114,8 @@ class StackMachineParser:
                 graph_root=str(graph_root),
                 tab_size=detected_tab,
             )
+            self._rebuild_registry(page.root_nodes)
+            return page
 
         page_title = self._derive_page_title(path)
         if detected_tab != self.tab_size:
@@ -1125,7 +1131,7 @@ class StackMachineParser:
         if updated_at is None:
             updated_at = int(os.path.getmtime(path))
         source_path = str(path.resolve())
-        return page.model_copy(
+        page = page.model_copy(
             update={
                 "source_path": source_path,
                 "graph_root": str(graph_root),
@@ -1135,6 +1141,8 @@ class StackMachineParser:
                 "root_nodes": self._apply_source_path(page.root_nodes, source_path),
             }
         )
+        self._rebuild_registry(page.root_nodes)
+        return page
 
     def _derive_page_title(self, path: Path) -> str:
         return derive_page_title_from_source_path(path)
@@ -1350,6 +1358,18 @@ class StackMachineParser:
             pending.extend(reversed(node.children))
         return collected
 
+    def _rebuild_registry(self, roots: list[LogseqNode]) -> None:
+        """Replace registry contents with the normalized nodes returned by parse()."""
+        registry = PageRegistry()
+        pending = list(reversed(roots))
+
+        while pending:
+            node = pending.pop()
+            registry.register(node)
+            pending.extend(reversed(node.children))
+
+        self.registry = registry
+
     def _resolve_block_ref_on_page(self, block_ref: str) -> LogseqNode | None:
         """Resolve a block UUID against the current page registry (synthetic, ``source_uuid``, ``id``)."""
         stripped = block_ref.strip()
@@ -1379,6 +1399,30 @@ class StackMachineParser:
                     )
             pending.extend(reversed(node.children))
 
+    def _finalize_node_metadata(self, nodes: list[LogseqNode]) -> list[LogseqNode]:
+        """Rebuild finalized nodes bottom-up without recursive traversal."""
+        finalized: dict[int, LogseqNode] = {}
+        pending = [(node, False) for node in reversed(nodes)]
+
+        while pending:
+            node, children_finalized = pending.pop()
+            if not children_finalized:
+                pending.append((node, True))
+                pending.extend((child, False) for child in reversed(node.children))
+                continue
+
+            finalized_node = self._refresh_node(
+                node.model_copy(
+                    update={"children": [finalized[id(child)] for child in node.children]}
+                ),
+                node.content,
+                refresh_derived=True,
+            )
+            finalized[id(node)] = finalized_node
+            self.registry.register(finalized_node)
+
+        return [finalized[id(node)] for node in nodes]
+
     def _refresh_node(
         self,
         node: LogseqNode,
@@ -1386,6 +1430,8 @@ class StackMachineParser:
         properties_override: dict[str, Any] | None = None,
         properties_order_override: list[str] | None = None,
         line_end: int | None = None,
+        *,
+        refresh_derived: bool = False,
     ) -> LogseqNode:
         properties = dict(node.properties) if properties_override is None else dict(properties_override)
         properties_order = (
@@ -1393,6 +1439,15 @@ class StackMachineParser:
             if properties_order_override is None
             else list(properties_order_override)
         )
+        updates: dict[str, Any] = {
+            "content": content,
+            "properties": properties,
+            "properties_order": properties_order,
+            "line_end": line_end if line_end is not None else node.line_end,
+        }
+        if not refresh_derived:
+            return node.model_copy(update=updates)
+
         time_properties = _extract_time_properties(content)
         scheduled_at: int | None = None
         deadline_at: int | None = None
@@ -1419,11 +1474,8 @@ class StackMachineParser:
         )
         wikilinks = [*_extract_wikilinks(content), *property_wikilinks]
         tags = [*_extract_tags(content), *property_tags]
-        return node.model_copy(
-            update={
-                "content": content,
-                "properties": properties,
-                "properties_order": properties_order,
+        updates.update(
+            {
                 "clean_text": clean_node_content(content, properties),
                 "task_status": task_status,
                 "task_priority": task_priority,
@@ -1437,11 +1489,11 @@ class StackMachineParser:
                 "assets": _extract_assets(content),
                 "refs": _merge_refs(wikilinks, tags),
                 "block_refs": [*_extract_block_refs(content), *property_block_refs],
-                "line_end": line_end if line_end is not None else node.line_end,
                 "created_at": _first_normalized_timestamp(properties, CREATED_AT_KEYS),
                 "updated_at": _first_normalized_timestamp(properties, UPDATED_AT_KEYS),
             }
         )
+        return node.model_copy(update=updates)
 
     def _normalize_indent_levels(
         self, nodes: list[LogseqNode], depth: int = 0

--- a/tests/parser_assurance/work_growth.py
+++ b/tests/parser_assurance/work_growth.py
@@ -273,6 +273,8 @@ class InstrumentedStackMachineParser(StackMachineParser):
         properties_override: dict[str, Any] | None = None,
         properties_order_override: list[str] | None = None,
         line_end: int | None = None,
+        *,
+        refresh_derived: bool = False,
     ) -> LogseqNode:
         self._add(node_refreshes=1)
         return super()._refresh_node(
@@ -281,6 +283,7 @@ class InstrumentedStackMachineParser(StackMachineParser):
             properties_override=properties_override,
             properties_order_override=properties_order_override,
             line_end=line_end,
+            refresh_derived=refresh_derived,
         )
 
     def _replace_stack_tail_node(

--- a/tests/test_logos_parser.py
+++ b/tests/test_logos_parser.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from logseq_matryca_parser.exceptions import BlockReferenceError
+from logseq_matryca_parser.logos_core import LogseqNode
 from logseq_matryca_parser.logos_parser import (
     LogosParser,
     StackMachineParser,
@@ -69,6 +70,45 @@ def test_fenced_code_shields_graph_tokens(parser: StackMachineParser) -> None:
     assert "Outer" in root.wikilinks
     assert "InnerNoise" not in root.wikilinks
     assert "inner-tag" not in root.tags
+
+
+def test_parser_defers_incremental_metadata_until_node_finalization(
+    parser: StackMachineParser, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Large soft-break nodes should refresh metadata minimally after finalization."""
+    import logseq_matryca_parser.logos_parser as logos_parser
+
+    calls = 0
+
+    original_shield = logos_parser._shield_inline_code
+
+    def counting_shield(content: str) -> tuple[str, list[str]]:
+        nonlocal calls
+        calls += 1
+        return original_shield(content)
+
+    monkeypatch.setattr(logos_parser, "_shield_inline_code", counting_shield)
+
+    def parse_case(continuations: int) -> tuple[LogseqNode, int]:
+        nonlocal calls
+        calls = 0
+        content_lines = [
+            "- Start [[Start]] `inline code with [[Ignored]] and #ignored`"
+        ] + [
+            f"  Continuation line {index} with `inline code [[Ignored{index}]] and #ignored{index}`"
+            for index in range(continuations)
+        ] + ["  final [[Target]] #topic"]
+        page = parser.parse("\n".join(content_lines), page_title="refresh-boundary")
+        return page.root_nodes[0], calls
+
+    _, short_calls = parse_case(3)
+    root, long_calls = parse_case(300)
+
+    assert root.line_end == 302
+    assert root.wikilinks == ["Start", "Target"]
+    assert root.tags == ["topic"]
+    assert root.refs == ["Start", "Target", "topic"]
+    assert long_calls <= short_calls + 2
 
 
 def test_macro_embed_extracts_nested_wikilinks(parser: StackMachineParser) -> None:
@@ -353,6 +393,31 @@ def test_strict_refs_allows_resolved_block_reference() -> None:
     assert page.root_nodes[0].children[0].block_refs == [existing_uuid]
 
 
+def test_parse_resets_registry_for_strict_current_page_validation() -> None:
+    """Reusing a parser must not resolve references from a previous page."""
+    previous_uuid = "33333333-3333-3333-3333-333333333333"
+    parser = StackMachineParser(strict_refs=True)
+
+    parser.parse(f"- First page\n  id:: {previous_uuid}", page_title="first-page")
+
+    with pytest.raises(BlockReferenceError, match=previous_uuid):
+        parser.parse(
+            f"- Second page with stale ref (({previous_uuid}))",
+            page_title="second-page",
+        )
+
+
+def test_registry_matches_normalized_returned_nodes() -> None:
+    """Registry entries must be the normalized nodes returned by parse()."""
+    parser = StackMachineParser()
+
+    page = parser.parse("- Root\n    - Child", page_title="normalized-registry")
+    child = page.root_nodes[0].children[0]
+
+    assert child.indent_level == 1
+    assert parser.registry.resolve(child.uuid) is child
+
+
 @pytest.mark.parametrize(
     "noise_line",
     [
@@ -403,6 +468,50 @@ def test_parse_page_file_zero_byte_returns_empty_page(tmp_path: Path) -> None:
     assert page.root_nodes == []
     assert page.title == "dangling-link"
     assert page.raw_content == ""
+
+
+def test_parse_file_registry_matches_source_path_nodes(tmp_path: Path) -> None:
+    """Compatibility file parsing must register the exact returned source-path nodes."""
+    page_path = tmp_path / "graph" / "pages" / "same-tab.md"
+    page_path.parent.mkdir(parents=True, exist_ok=True)
+    page_path.write_text("- Root\n  - Child\n", encoding="utf-8")
+    parser = StackMachineParser(tab_size=2)
+
+    roots = parser.parse_file(page_path)
+    root = roots[0]
+    child = root.children[0]
+
+    assert root.source_path == str(page_path.resolve())
+    assert parser.registry.resolve(root.uuid) is root
+    assert parser.registry.resolve(child.uuid) is child
+
+
+def test_parse_page_file_transfers_registry_from_detected_tab_parser(tmp_path: Path) -> None:
+    """Detected-tab delegation must populate the caller's current-page registry."""
+    page_path = tmp_path / "graph" / "pages" / "detected-tab.md"
+    page_path.parent.mkdir(parents=True, exist_ok=True)
+    page_path.write_text("- Root\n  - Child\n", encoding="utf-8")
+    parser = StackMachineParser(tab_size=4)
+
+    page = parser.parse_page_file(page_path)
+    root = page.root_nodes[0]
+
+    assert page.tab_size == 2
+    assert parser.registry.resolve(root.uuid) is root
+
+
+def test_parse_page_file_empty_resets_registry(tmp_path: Path) -> None:
+    """An empty file must leave no entries from an earlier parsed page."""
+    page_path = tmp_path / "graph" / "pages" / "empty.md"
+    page_path.parent.mkdir(parents=True, exist_ok=True)
+    page_path.write_text("", encoding="utf-8")
+    parser = StackMachineParser()
+    parser.parse("- Previous", page_title="previous")
+
+    page = parser.parse_page_file(page_path)
+
+    assert page.root_nodes == []
+    assert parser.registry.blocks == {}
 
 
 def test_parse_page_file_decodes_percent_encoded_title(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- defer derived metadata extraction until one iterative post-order finalization per node
- keep strict reference validation page-local and rebuild registries from the exact final returned nodes
- preserve 1024-level iterative parsing, semantic snapshots, tree relationships, source paths, and the stable public API
- document the bounded local qualification and the separate #111 benchmark boundary

Closes #87.

## Validation

- `make all`: 691 passed, 89.82% coverage
- focused parser regression suite: 33 passed
- Ruff, mypy, maintained-documentation validation, vendor-name policy, and `git diff --check`: passed
- deterministic metadata-helper growth: bounded between 3 and 300 continuations
- strict and file-entrypoint 1024-level regressions: passed
- independent final implementation review: PASS
- independent documentation correction re-review: PASS

## Local diagnostic receipt

Privacy-clean seed: 1,148 lines, 67,321 bytes, SHA-256 `4c2b1e87367d2b7b9c16ee62441f05c21c46c86c954703c5f7892789ca148a5d`.

After 3 warm-ups, 21 local samples had a 0.02702-second median and 0.02739-second p95, with one canonical in-process result. These times are a single-host diagnostic, not a CI budget, cross-machine comparison, universal speed claim, release qualification, or vault-scale benchmark. Issue #111 retains wall-time, p95, RSS, reload, search, and RAG-chunk benchmark ownership.

## Commits

- `c188556`: production code and regression tests
- `8689976`: maintained documentation and receipt reconciliation

AI assistance was used for bounded implementation and review. The maintainer retains merge and release authority.