### PR TITLE
fix: use stable registry source for NLTK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Stable NLTK supply-chain source (#186)** — the optional AI and development
+  dependency graph now constrains NLTK to the patched PyPI release line at
+  `>=3.10.3`, replacing the mutable `v3.10.0-rc1` VCS tag declaration. The
+  lightweight base installation remains unchanged.
+
 ### Fixed
 
 - **Incremental graph reloads (#103)** — backlink indexes are rebuilt from the

--- a/docs/reference/DEPENDENCY_LICENSE_POLICY.md
+++ b/docs/reference/DEPENDENCY_LICENSE_POLICY.md
@@ -8,9 +8,9 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-19
-verified: 2026-08-19
-stale_after: 2026-11-17
+last_verified: 2026-08-24
+verified: 2026-08-24
+stale_after: 2026-11-22
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -63,9 +63,9 @@ records an immutable commit does not cure a top-level dependency declaration
 that still names a mutable branch or tag: re-resolution begins from the
 declaration. Prefer a qualified registry release; when a VCS dependency remains
 necessary, declare its full commit and require the lock and generated PURL to
-resolve to that same revision. Issue
-[#186](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/186)
-tracks the current NLTK declaration debt.
+resolve to that same revision. The NLTK declaration uses a qualified stable
+registry release rather than a VCS source; the lock and generated inventory
+must preserve that registry provenance.
 
 The inventory is evidence, not legal advice and not an automatic compatibility
 opinion. A license change, new copyleft obligation, unknown direct license,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,10 +85,8 @@ dev = [
 [tool.uv]
 constraint-dependencies = [
     "aiohttp>=3.14.3",
+    "nltk>=3.10.3",
     "setuptools>=83.0.0",
-]
-override-dependencies = [
-    "nltk @ git+https://github.com/nltk/nltk@v3.10.0-rc1",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_quality_gate_contract.py
+++ b/tests/test_quality_gate_contract.py
@@ -4,9 +4,32 @@ from __future__ import annotations
 
 import re
 import subprocess
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_nltk_security_floor_uses_a_stable_registry_constraint() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    constraints = pyproject["tool"]["uv"]["constraint-dependencies"]
+
+    assert "nltk>=3.10.3" in constraints
+
+
+def test_nltk_is_not_declared_as_a_vcs_override() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    overrides = pyproject["tool"]["uv"].get("override-dependencies", [])
+
+    assert not any(dependency.startswith("nltk") for dependency in overrides)
+
+
+def test_nltk_lock_uses_a_patched_registry_release() -> None:
+    lock = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
+    nltk = next(package for package in lock["package"] if package["name"] == "nltk")
+
+    assert nltk["source"] == {"registry": "https://pypi.org/simple"}
+    assert tuple(int(part) for part in nltk["version"].split(".")) >= (3, 10, 3)
 
 
 def _dry_run(target: str) -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -9,9 +9,9 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "aiohttp", specifier = ">=3.14.3" },
+    { name = "nltk", specifier = ">=3.10.3" },
     { name = "setuptools", specifier = ">=83.0.0" },
 ]
-overrides = [{ name = "nltk", git = "https://github.com/nltk/nltk?rev=v3.10.0-rc1" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1467,14 +1467,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.10.0"
-source = { git = "https://github.com/nltk/nltk?rev=v3.10.0-rc1#16a32d680d070254d5744e33fa83f9c0056d5a1f" }
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the mutable NLTK VCS tag override with the qualified PyPI constraint `nltk>=3.10.3`
- regenerate the lock with registry wheel and sdist hashes while preserving NLTK as optional/transitive
- add regression contracts and update the changelog and dependency policy

## Verification
- `uv sync --locked --all-extras`
- base and all-extras audits: no known vulnerabilities (fully pinned exports, `--no-deps --disable-pip`)
- generated SBOM and dependency inventory: `pkg:pypi/nltk@3.10.3`, registry, optional, Apache-2.0
- `make all`: 760 tests, 91.20% coverage
- `make vendor-name-check`
- wheel and sdist build; wheel contract and Twine 6.2.0 checks
- fresh base-wheel install imports successfully with NLTK absent

Closes #186