### PR TITLE
chore: prepare v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-08-24
+
 ### Security
 
 - **Stable NLTK supply-chain source (#186)** — the optional AI and development
@@ -14,12 +16,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `>=3.10.3`, replacing the mutable `v3.10.0-rc1` VCS tag declaration. The
   lightweight base installation remains unchanged.
 
+### Added
+
+- **Reproducible runtime evidence foundation (#111)** — add a deterministic,
+  offline synthetic-vault generator and a source-free measurement runner for
+  parser, cold-load, reload, search, and optional SYNAPSE scenarios. The runner
+  records semantic validity and bounded runtime observations outside the
+  default CI gate. It establishes a measurement protocol, not vault-scale
+  budgets or a universal performance claim; #111 remains open.
+
+### Changed
+
+- **Private lexical-state extraction (#108 M9)** — move YAML, code, query,
+  drawer, frontmatter, and block-property eligibility transitions into a
+  private standard-library-only state object. `StackMachineParser.parse()`
+  retains line classification, reduction, AST construction, identities,
+  semantic enrichment, and public behavior. The broader #108 epic remains
+  open.
+
 ### Fixed
 
-- **Incremental graph reloads (#103)** — backlink indexes are rebuilt from the
-  current page set after a tracked page is deleted or reloaded. Title and alias
-  changes delivered through a filesystem move now match a cold load; no public
-  API or performance claim changes.
+- **Coherent incremental graph mutations (#103)** — reloads, deletions, and
+  filesystem moves now publish page routing, node and backlink registries, and
+  collision diagnostics as one coherent graph snapshot. Conflicting title or
+  alias participants can recover deterministically, bounded writes serialize
+  their source read and reload transaction, and watcher callbacks observe the
+  published state in order. Stable public APIs remain unchanged.
 - **Pathological nested outlines (#87)** — parse and file-entrypoint traversal
   now remain iterative for a 1024-level valid outline, while parser-owned tree
   construction avoids quadratic immutable-ancestor copies. Derived metadata is
@@ -30,6 +52,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source paths, semantic snapshots, and the stable public API are preserved.
   Deterministic tests bound refresh growth; local timing observations remain
   diagnostic only and do not add a vault-scale performance claim.
+- **Bounded local-assurance timeout cleanup (#188)** — a timed-out isolated
+  assurance worker is terminated and joined before its result queue is closed,
+  preventing queue-thread cleanup from extending the bounded failure path.
+
+### Tests
+
+- Expand privacy-safe local-assurance regression coverage across traversal and
+  byte limits, guarded reads, parser aggregation, report validation, denied
+  network entry points, worker lifecycle, and failure cleanup without exposing
+  vault content or weakening the repository coverage floor.
 
 ## [1.8.0] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.8.1] - 2026-08-24
+## [1.8.1] - 2026-08-25
 
 ### Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ User-facing behavior is documented in:
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — LOGOS, SYNAPSE, `LogseqGraph`, agents, and data flow
 - [`docs/internal/LOCAL_CODE_STUDY.md`](docs/internal/LOCAL_CODE_STUDY.md) — maintainer local code audit runbook (not for public issues/CHANGELOG)
 - [`docs/logseq_ast_primer.md`](docs/logseq_ast_primer.md) — Logseq Spatial Markdown domain rules
-- [`CHANGELOG.md`](CHANGELOG.md) — shipped releases (current: **1.8.0**) and **Unreleased** changes (Keep a Changelog)
+- [`CHANGELOG.md`](CHANGELOG.md) — shipped releases (current: **1.8.1**) and **Unreleased** changes (Keep a Changelog)
 - [`docs/RELEASE_PROCESS.md`](docs/RELEASE_PROCESS.md) — version bump, tag, and PyPI publish checklist
 - [`docs/CODEQL.md`](docs/CODEQL.md) — CodeQL default setup (no custom `codeql.yml`)
 - [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) — curated starter tasks for new contributors

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Read the complete [release highlights](RELEASE_HIGHLIGHTS.md), the exhaustive
 [changelog](CHANGELOG.md), or the signed artifacts on
 [GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
 
+- **v1.8.1** — Hardened deep-outline parsing, coherent incremental graph mutations, bounded assurance cleanup, and stable provenance for optional NLTK.
 - **v1.8.0** — Added bounded privacy-safe local graph assurance, source-location contracts, and the first internal parser line-classification phase.
 - **v1.7.1** — Added the runnable offline SYNAPSE RAG example and tightened release-note and optional-dependency security checks.
 - **v1.7.0** — Hardened parser correctness, graph diagnostics, writer safety, API stability, documentation governance, and release provenance.

--- a/RELEASE_HIGHLIGHTS.md
+++ b/RELEASE_HIGHLIGHTS.md
@@ -5,6 +5,34 @@ For the exhaustive change history, see the [changelog](CHANGELOG.md). For
 published artifacts and attestations, see
 [GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
 
+## v1.8.1
+
+Patch release — hardens deep-outline parsing, coherent incremental graph
+updates, local assurance cleanup, and optional dependency provenance. **No
+intentional breaking changes** to stable package imports or CLI behavior.
+
+| Area | Change |
+| :--- | :--- |
+| **Parser resilience** | Valid 1024-level outlines stay iterative; derived metadata is finalized once per node; strict-reference state is page-local; returned-node registry identity is preserved. |
+| **Graph coherence** | Reloads, deletions, moves, bounded writes, collision recovery, diagnostics, and watcher callbacks share a serialized publication boundary so readers observe a coherent in-memory snapshot. |
+| **Parser internals** | A private lexical-state object now owns syntax-region eligibility transitions while AST construction, identities, semantics, dependencies, and public behavior remain unchanged. |
+| **Local evidence** | A deterministic offline synthetic-vault harness produces source-free diagnostic observations; expanded assurance tests cover filesystem, validation, isolation, and timeout paths without creating a universal performance claim. |
+| **Dependency security** | Optional AI and development installs use the patched NLTK `>=3.10.3` release from the stable package registry; the lightweight base install is unchanged. |
+| **Test suite** | **760** pytest cases with **91.20%** statement coverage on the release candidate. |
+
+## v1.8.0
+
+Minor release — adds project-owned parser assurance, bounded local graph checks,
+and stronger release supply-chain evidence. **No intentional breaking changes**
+to stable package imports or CLI behavior.
+
+| Area | Change |
+| :--- | :--- |
+| **Parser assurance** | Versioned compatibility fixtures, deterministic adversarial cases, work-growth evidence, and one-based source-line contracts protect semantics without adopting an external parser oracle. |
+| **Local graph assurance** | New bounded `matryca-parse assure` command runs in a fresh worker and emits aggregate-only results without retaining vault content, paths, titles, UUIDs, or exception text. |
+| **Parser internals** | The first private line-classification phase preserves parser reduction, identities, public imports, and dependencies. |
+| **Supply chain** | Release jobs produce a CycloneDX SBOM, dependency/license inventory, checksums, and provenance attestations for the exact published distributions. |
+
 ## v1.7.1
 
 Patch release — completes the promised SYNAPSE example and closes the security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Security fixes are provided **only for the latest released version** on [PyPI](h
 
 | Version | Supported |
 | ------- | --------- |
-| **1.8.0** (latest) | Yes |
-| 1.7.1 and older | No |
+| **1.8.1** (latest) | Yes |
+| 1.8.0 and older | No |
 
 We recommend always running the current release and upgrading promptly when a security advisory is published.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -642,7 +642,7 @@ Recursive and character-budget chunkers assume **approximately flat prose**. Log
 | [`index.md`](index.md) | Canonical maintained knowledge-bundle entry point |
 | [`design-docs/README.md`](design-docs/README.md) | Warning before using historical DDD blueprints |
 
-### Quality gate (v1.8.0)
+### Quality gate (v1.8.1)
 
 Local and CI parity: `uv sync --all-extras` → `make lint` → `make check` →
 `make test` → `make vendor-name-check` → `make docs-check`. These targets are

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -8,9 +8,9 @@ audience: contributors
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-20
-verified: 2026-08-20
-stale_after: 2027-02-02
+last_verified: 2026-08-24
+verified: 2026-08-24
+stale_after: 2027-02-17
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -19,7 +19,7 @@ superseded_by: null
 
 # Clean Code & Clean Architecture — Logseq Matryca Parser
 
-**Version:** documents **v1.8.0** maintainer contracts (v1 structural backlog complete; M5–M7 assurance slices merged)
+**Version:** documents **v1.8.1** maintainer contracts (v1 structural backlog complete; parser, graph-coherence, and local-assurance slices merged)
 **Audience:** contributors and Cursor agents patching `src/logseq_matryca_parser/`  
 **Companion:** [`ARCHITECTURE.md`](ARCHITECTURE.md) (LOGOS domain contract) · [`BUG_HUNT_REPORT.md`](BUG_HUNT_REPORT.md) (audit evidence) · [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -21,6 +21,12 @@ superseded_by: null
 
 ## 2026-08-24
 
+- Prepared the v1.8.1 release candidate from
+  `main@2c919fcdef1cb187c30b70b9dd130fa571738b72`, reconciled the changelog
+  with the merged parser, graph-coherence, local-assurance, and NLTK work, and
+  restored reader-focused v1.8.0 highlights that were missing from the release
+  archive. Historical receipts remain bound to their original versions and
+  commits.
 - Reconciled the public roadmap with live GitHub state and established an
   evidence-gated sequence: finish #103/#180, qualify the mutable NLTK
   declaration in #186, extend existing semantic assurance through #104, make

--- a/src/logseq_matryca_parser/_version.py
+++ b/src/logseq_matryca_parser/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the distribution version."""
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/tests/test_check_wheel_contract.py
+++ b/tests/test_check_wheel_contract.py
@@ -32,7 +32,7 @@ def _wheel(
 
 
 def test_source_version_reads_lightweight_version_module() -> None:
-    assert source_version() == "1.8.0"
+    assert source_version() == "1.8.1"
 
 
 def test_valid_wheel_contract(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- bump the package and release contract to v1.8.1;
- curate the post-v1.8.0 parser, graph, local-assurance, runtime-evidence, and NLTK changes into the versioned changelog;
- add reader-focused v1.8.1 highlights and restore the missing v1.8.0 highlights;
- keep the README release history to one line per release;
- align SECURITY, CONTRIBUTING, architecture, Clean Architecture metadata, and the documentation evolution log;
- preserve historical v1.8.0 receipts and RFC statements unchanged;
- bind the versioned changelog to the actual 2026-08-25 release date.

## Release scope

This is a patch release with no intentional breaking change to stable package imports or CLI behavior. The lightweight base dependency set remains unchanged.

## Verification

Exact candidate: `65004f5faba9ad8f85117b7c8a21e98f9fcf1fa3`  
Base: `main@2c919fcdef1cb187c30b70b9dd130fa571738b72`

- `make all`: PASS
  - Ruff: PASS
  - Mypy: 77 source files, PASS
  - maintained documentation and terminology gates: PASS
  - Pytest: 760 passed
  - statement coverage: 91.20%
- `python -m scripts.check_release_contract --tag v1.8.1`: PASS
- wheel contract: PASS for `logseq_matryca_parser-1.8.1-py3-none-any.whl`
- Twine 6.2.0: PASS for wheel and sdist
- locked supply-chain evidence: 130 components, 14 direct, all direct licenses resolved, zero VCS components
- NLTK evidence: `pkg:pypi/nltk@3.10.3`, registry source, Apache-2.0

Local exact-candidate digests:

```text
cbb1c1588a1c88110c610775fa9252e555f2b8c3118c6359d59fb4d2e3f9a726  logseq_matryca_parser-1.8.1-py3-none-any.whl
a45222628a65b739a9bbdf1dd91a40f4510b18ee24cff16b11eaceaa6a2c4cf0  logseq_matryca_parser-1.8.1.tar.gz
f31900908855a31efc3099611b06a56a39ef6e2f9cd8d7356e3cf6a0b4dae146  SBOM.cdx.json
a8949c1e64ddcae9a223fef0a7ccc2a0c5eb5a5dec704543cb1a4a4bdb2524c5  DEPENDENCY_LICENSES.json
```

The hosted release workflow retains the canonical resolving advisory audit and remains the authoritative tag gate.

## Boundaries

This PR does not create or move a tag, publish to PyPI, create a GitHub Release, or merge itself. Exact-tag hosted checks, attestations, publication, and downloaded-asset verification remain separate maintainer gates.