### PR TITLE
docs: reconcile post-v1.8.1 programme

### DIFF
--- a/docs/ROADMAP_2026-2027.md
+++ b/docs/ROADMAP_2026-2027.md
@@ -8,8 +8,8 @@ audience: contributors
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-24
-verified: 2026-08-24
+last_verified: 2026-08-25
+verified: 2026-08-25
 stale_after: 2026-11-17
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -41,31 +41,31 @@ roadmap, not a release promise or an AAIF submission claim.
 |---|---|---|---|---|
 | M0 — Public baseline | Waiting for evidence | Maintainer | Valid GitHub API access | Exact `main` SHA, rulesets, Actions permissions, security features, and issue/PR/project receipt |
 | M1 — Governance minimum | Completed locally | Maintainer | Documentation review | Governance, maintainers, support, citation, and AI-contribution documents linked and passing the docs gate |
-| M2 — Supply-chain proof | In progress; declaration debt open | Release owner | M0 and a real tag | Hosted release evidence plus an immutable optional-dependency declaration and resolved-revision inventory ([#186](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/186)) |
+| M2 — Supply-chain proof | Completed for v1.8.1 | Release owner | M0 and a real tag | v1.8.1 hosted release evidence plus the stable NLTK registry declaration, regenerated lock, package contract, SBOM, dependency/license inventory, checksums, and attestations ([#186](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/186)) |
 | M3 — Documentation convergence | Migration gate recorded | Documentation owner | Matryca Knowledge profile decision | Current provenance references, dual-profile audit, and reviewed projection evidence without rewriting history |
-| M4 — Semantic assurance | In progress | Parser owner | Exact-head parser evidence | Coherent graph mutation publication ([#103](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/103)), bounded property generation built on existing semantic profiles ([#104](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/104)), and reproducible performance decisions ([#111](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/111)) |
+| M4 — Semantic assurance | In progress | Parser owner | Exact-head parser evidence | Coherent graph mutation publication is complete in v1.8.1 ([#103](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/103)); remaining exits are bounded property generation built on existing semantic profiles ([#104](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/104)) and reproducible performance decisions ([#111](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/111)) |
 | M5 — Community durability | In progress | Maintainers | M0 and sustained contributor activity | Triage policy, current label taxonomy, public roadmap, response measurement, and independent reviewer path |
 | M6 — Interoperability and adoption | Research only; adapters deferred | Product and community | M4 and permissioned use cases | Synthetic Logseq DB export-conformance report ([#185](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/185)); any adapter remains a later decision |
 | M7 — AAIF decision gate | NO-GO recorded | Maintainer and legal reviewer | M0–M6 | A future reconsideration record supported by a completed evidence matrix |
 
 ## Current delivery focus
 
-1. Complete [#103](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/103)
-   through publication of the implementation branch, exact-head hosted checks,
-   independent review, and controlled merge of draft
-   [#180](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/180).
-2. Resolve the mutable NLTK declaration in
-   [#186](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/186)
-   through advisory re-evaluation and a qualified stable release or full VCS
-   commit, followed by the complete supply-chain and package gates.
-3. Extend [#104](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/104)
+1. Extend [#104](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/104)
    with bounded Hypothesis strategies that reuse `semantic_roundtrip_v1`, the
    fixture-specific identity policy, deterministic replay, and the existing
    classification vocabulary.
-4. Use [#111](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/111)
+2. Use [#111](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/111)
    to compare serial, thread, and process execution plus repeated unchanged
    loads. Record separate GO/NO-GO decisions before proposing a persistent cache
    or changing the default executor.
+3. Continue [#108](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/108)
+   only through bounded child slices for the residual reducer, semantic
+   enrichment, final equivalence, and benchmark gates. The delivered line
+   classifier and lexical-state object remain accepted foundations.
+4. Reconcile [#109](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/109)
+   and [#110](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/110)
+   against the maintained documentation and diagnostics contracts. Close only
+   the acceptance criteria proven by exact source and private-profile evidence.
 5. Run [#185](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/185)
    as a synthetic, read-only Logseq DB export-conformance study. Classify
    semantics as preserved, transformed, lost, unsupported, or unknown without
@@ -78,8 +78,8 @@ roadmap, not a release promise or an AAIF submission claim.
 
 | Decision | Existing surface | Entry gate | Exit evidence | No automatic inference |
 |---|---|---|---|---|
-| Coherent in-process graph mutations | #103 / draft #180 | Exact implementation head published | Full local and hosted checks plus independent concurrency review | No cross-process or deep-immutable snapshot claim |
-| Immutable NLTK source | #186 | Original advisory and current releases rechecked | Immutable declaration, regenerated lock, audit, inventory, package and full quality gates | No blanket advisory or license exception |
+| Coherent in-process graph mutations | #103 / merged #180 | Completed in v1.8.1 | Full local and hosted checks plus independent concurrency review | No cross-process or deep-immutable snapshot claim |
+| Stable NLTK registry source | #186 / merged #189 | Completed in v1.8.1 | Stable declaration, regenerated lock, audit, inventory, package and full quality gates | No blanket advisory or license exception |
 | Property-based parser assurance | #104 | Existing corpus and projections remain authoritative | Bounded strategies, deterministic replay, semantic/invariant regressions | No byte-equality or universal synthetic-UUID promise |
 | Cache and executor choice | #111 | Thresholds and resource envelope declared before measurement | Source-free comparative receipts and two explicit GO/NO-GO decisions | No cache or `ProcessPoolExecutor` implementation from source inspection alone |
 | Logseq DB interoperability | #185 | Synthetic versioned export available | Reproducible conformance report with observed transformation classes | No SQLite dependency, reader, writer, migration, or sync commitment |
@@ -89,9 +89,10 @@ roadmap, not a release promise or an AAIF submission claim.
 - The public [Evidence-Gated Roadmap project](https://github.com/users/MarcoPorcellato/projects/5)
   mirrors operational status, track, evidence level, risk, and next gate. This
   versioned roadmap remains the canonical programme contract.
-- **Parser Assurance: M3-M7** remains open for #103, #104, #108, and #111.
-- **Evidence-gated improvements** contains the supply-chain and bounded research
-  items #185 and #186.
+- **Parser Assurance: M3-M7** remains open for #104, #108, and #111; #103 is
+  complete.
+- **Evidence-gated improvements** retains research item #185; completed
+  supply-chain item #186 remains attached as milestone evidence.
 - The legacy **v1.0 GUI** milestone is closed; issue #3 remains an adoption-gated
   RFC without a release commitment.
 - The **v1.6 Clean Architecture** milestone is closed as completed historical

--- a/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
+++ b/docs/goals/LSDOC_PARSER_ASSURANCE_GOAL.md
@@ -8,8 +8,8 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-21
-verified: 2026-08-21
+last_verified: 2026-08-25
+verified: 2026-08-25
 stale_after: 2027-02-17
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -90,7 +90,17 @@ and ignored global graph input in self-test mode. These corrections are now
 published through PR #168; the M5 privacy and non-retention boundary remains
 part of the supported contract.
 
-The v1.8.0 release gates are complete. Release preparation merged through
+The v1.8.1 release gates are complete. The release commit and tag are
+`bb8ec6b758e0e7b3429de49ca252ae8b62f97689`. The release closes the bounded
+#87 pathological-depth and refresh work, publishes #103's coherent
+single-process graph mutation boundary, includes the accepted #108 lexical-state
+slice and #111 runtime-evidence foundation, and replaces #186's mutable NLTK tag
+with the patched stable registry constraint. Issues #104, #108, and #111 remain
+open for their explicitly residual scopes; the release does not promote a
+persistent cache, process-pool default, universal performance budget, parser
+rewrite, or external oracle.
+
+The v1.8.0 release gates are also complete. Release preparation merged through
 [PR #171](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/171) as
 `06a1d6cb3dcbb215c6aa108ce82d37da530d52a5`, and tag `v1.8.0` published through
 the exact [release workflow run](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/32324328464).
@@ -98,8 +108,9 @@ The run passed both Python pre-flight jobs, package contract, SBOM and license
 evidence, checksum verification, GitHub attestations, PyPI publication, and
 GitHub Release creation. The public [GitHub Release](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases/tag/v1.8.0)
 and [PyPI package](https://pypi.org/project/logseq-matryca-parser/1.8.0/)
-were checked after publication. The broader #104, #103, #87, #111, and #108
-acceptance work remains open where the plan still marks it incomplete.
+were checked after publication. At that release boundary, the broader #104,
+#103, #87, #111, and #108 work remained open; the v1.8.1 record above
+supersedes that operational status without rewriting the v1.8.0 receipt.
 
 Post-release #87 work has two bounded stages. PR #174 delivered iterative
 1024-level traversal and a linear model-copy budget after the v1.8.0 source had
@@ -112,11 +123,12 @@ growth at 3 and 300 continuations; the full gate passed 691 tests with 89.82%
 coverage, and the focused parser suite passed 33 tests. On the privacy-clean
 1,148-line seed (`sha256:4c2b1e87367d2b7b9c16ee62441f05c21c46c86c954703c5f7892789ca148a5d`),
 the final local 3-warm-up/21-sample observation had a 0.02702-second median and
-0.02739-second p95 with one canonical result in-process. These measurements are
-diagnostic on one host, not a hosted-validation, release, cross-machine,
-universal-speedup, or vault-scale claim. #111 still owns wall-time, p95, RSS,
-reload, search, and RAG-chunk benchmark evidence. Hosted validation, merge,
-release, and issue closure for local commit `c188556` remain separate gates.
+0.02739-second p95 with one canonical result in-process. These measurements
+remain diagnostic on one host, not a cross-machine, universal-speedup, or
+vault-scale claim. The corrected implementation was subsequently merged,
+qualified, released in v1.8.1, and issue #87 was closed. #111 still owns
+comparative wall-time, p95, RSS, repeated-load, executor, search, and RAG-chunk
+benchmark decisions.
 
 The initial checkpoint `8806205c35b104ed65d00a273acc9eeca572ae38` is rejected
 pre-correction evidence. Corrective implementation

--- a/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
+++ b/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
@@ -1,0 +1,258 @@
+# Post-v1.8.1 backlog execution record — 2026-08-25
+
+This document is the durable execution record for the first repository
+reconciliation after v1.8.1. It is an operational checkpoint, not a release,
+merge, or universal quality claim.
+
+## Frozen starting point
+
+- Repository: `MarcoPorcellato/logseq-matryca-parser`
+- Canonical source: `origin/main`
+- Exact source commit:
+  `bb8ec6b758e0e7b3429de49ca252ae8b62f97689`
+- Isolated branch: `agent/post-v1.8.1-backlog-reconciliation`
+- Isolated worktree:
+  `/private/tmp/logseq-matryca-parser-post-v181-20260825`
+- Primary checkout: preserved and not used as the writer workspace
+- Dependency state: `uv sync --locked --all-extras` completed
+- Baseline gate: `make all` completed with 760 tests and 91.20% statement
+  coverage; Ruff, Mypy, documentation, vendor-name, and package-independent
+  quality checks passed
+
+The baseline proves only the exact source, dependency lock, host, and command
+recorded above. Hosted checks, a future head, publication, and release remain
+separate evidence.
+
+## Objective
+
+Reconcile the post-v1.8.1 programme without inflating completed work or deleting
+uncertain history:
+
+1. update the public roadmap, milestones, and Project #5;
+2. close or narrow issues only where exact evidence supports the decision;
+3. reconcile checklists in #104, #108, #109, #110, and #111;
+4. review all seven pull requests open at the frozen starting point;
+5. establish #104 as the next implementation tranche and #111 as its successor;
+6. investigate and, after design approval, fix bounded LENS bug #92 separately;
+7. delete only remote branches proven merged or superseded and not attached to
+   an open pull request;
+8. qualify and publish each independently reviewable tranche.
+
+## Governing boundaries
+
+- Markdown files and exact live Git/GitHub state outrank cached reports and
+  worker summaries.
+- All repository-facing text and maintainer messages are English.
+- One controller writes. Delegated workers are read-only unless a later task
+  explicitly grants a narrow isolated writer role.
+- A checked box requires an exact source, test, documentation, workflow, PR, or
+  release receipt. Partial evidence remains partial.
+- No issue is closed merely because adjacent infrastructure exists.
+- No pull request is merged from stale or conflicting evidence. Contributor
+  work is preserved or closed only with a concise evidence-based explanation.
+- `main`, `gh-pages`, every open-PR branch, and every uncertain remote branch
+  are protected from cleanup.
+- Issue #92 follows a separate bounded design and test-first cycle. Backlog
+  reconciliation does not silently authorize production behavior changes.
+- Push, pull-request creation, merge, release, and destructive cleanup are
+  distinct external mutations. Existing user instructions authorize the
+  repository reconciliation and proven obsolete-branch cleanup, but every
+  mutation still requires an exact target and readback.
+- No private vault content, credentials, local cache, host identity, or
+  source-derived sensitive data enters receipts.
+
+## Frozen live backlog
+
+At the starting point, GitHub reported:
+
+- 38 open issues;
+- 24 open issues labelled `good first issue`;
+- 7 open pull requests:
+  - contributor: #84, #99, #147;
+  - automated dependency updates: #181, #182, #183, #184;
+- milestone **Parser Assurance: M3-M7** with #104, #108, and #111 open;
+- milestone **Evidence-gated improvements** with #185 open and #186 closed;
+- 42 remote branches including `main` and `gh-pages`.
+
+Every count is a dated snapshot and must be refreshed before final publication.
+
+## Work packages and completion gates
+
+### R1 — Programme reconciliation
+
+Update `docs/ROADMAP_2026-2027.md` and the assurance goal to record that:
+
+- #103 is merged and its coherent in-process graph-mutation boundary shipped;
+- #186 is closed and its stable NLTK registry dependency shipped in v1.8.1;
+- M2 supply-chain declaration debt is complete for v1.8.1;
+- #104 is the next parser-assurance tranche;
+- #111 follows #104 and must not promote budgets before retained measurements;
+- #185 remains a research-only interoperability study;
+- #108 retains only its residual reducer, semantic-enrichment, equivalence, and
+  benchmark gates.
+
+Exit gate:
+
+- active documents agree on status, ordering, and exclusions;
+- historical documents are not rewritten as if they were current plans;
+- `make docs-check`, `make vendor-name-check`, and `git diff --check` pass.
+
+### R2 — Issue and milestone reconciliation
+
+For #104, #108, #109, #110, and #111:
+
+1. preserve the original intent;
+2. mark only items supported by exact evidence;
+3. rewrite ambiguous residual work as verifiable acceptance criteria;
+4. add a dated reconciliation note or update the body;
+5. close only when all acceptance criteria are met, otherwise keep the issue
+   open with a smaller explicit scope.
+
+Milestone disposition:
+
+- keep **Parser Assurance: M3-M7** open while #104, #108, or #111 remains;
+- keep **Evidence-gated improvements** open while #185 remains;
+- do not create a release milestone merely to mirror a published tag.
+
+Exit gate:
+
+- GitHub readback matches the versioned roadmap;
+- Project #5 uses the same statuses and next gates;
+- no completed item remains described as current focus.
+
+### R3 — Pull-request portfolio
+
+Review #84, #99, #147, and #181–#184 against current `main`.
+
+Each pull request receives one disposition:
+
+- refresh/rebase because unique useful work remains;
+- close as superseded, with exact replacement evidence;
+- merge only after conflict resolution, exact-head full checks, and review;
+- keep open only when an identified external dependency prevents a decision.
+
+Exit gate:
+
+- no open PR is left without a current maintainer decision;
+- automated updates are not merged solely because they are newer;
+- contributor messages are short, simple, specific, and respectful.
+
+### R4 — Bounded LENS bug #92
+
+Before implementation:
+
+- reproduce or disprove the alias-resolution failure on the current exact base;
+- trace the LENS-to-graph resolution path;
+- present a short bounded design covering files, behavior, and tests;
+- obtain explicit approval for that design.
+
+Implementation gate:
+
+- add the smallest real regression test and observe the expected RED failure;
+- make the smallest production change needed for GREEN;
+- run focused LENS/graph tests and the complete quality gate;
+- update user documentation only if supported behavior changes.
+
+Issue #92 remains separate from #104 and cannot delay documentation-only
+backlog reconciliation.
+
+### R5 — Next implementation sequence
+
+#### First: #104 property-based parser assurance
+
+The tranche must reuse existing compatibility fixtures, projectors, semantic
+profiles, diagnostic classes, and deterministic replay. It must not create a
+second oracle or claim byte-for-byte equivalence where identity policy allows
+derived values.
+
+Required planning output:
+
+- bounded Hypothesis strategy grammar;
+- explicit size and time limits;
+- deterministic seed and minimized replay contract;
+- invariant matrix for structure, identity, source lines, references, and
+  parse/serialize/parse semantics;
+- focused and scheduled workflow placement;
+- exact checklist-to-receipt mapping.
+
+#### Second: #111 reproducible performance decisions
+
+Keep the existing small profile immutable. Add large profiles only outside
+default CI and preserve source-free receipts. Compare cold load, incremental
+edit, controlled search, and context-chunk scenarios. Retain at least three
+eligible exact-environment observations before proposing numeric budgets.
+
+No cache, process-pool default, or public performance claim follows
+automatically from source inspection or one host.
+
+### R6 — Proven branch cleanup
+
+For each remote branch:
+
+1. identify whether it backs an open PR;
+2. test exact ancestry against `origin/main`;
+3. locate the merged PR, replacement commit, or release when ancestry alone is
+   insufficient;
+4. classify it as protected, deletable, or uncertain;
+5. delete only the explicitly enumerated deletable set;
+6. fetch/prune and confirm each deleted ref is absent.
+
+The cleanup report must retain branch name, proof, deletion result, and
+recovery source. No wildcard deletion is permitted.
+
+## Delegation ledger
+
+| Worker tier | Scope | Authority | Required return |
+|---|---|---|---|
+| GPT-5.3 Codex Spark | issue/checklist evidence audit | read-only | checklist evidence and close/narrow/keep recommendations |
+| GPT-5.6 Luna | seven-PR portfolio review | read-only | exact-head disposition and concise maintainer message |
+| GPT-5.6 Luna | issue #92 reproduction and design | read-only | reproduction, blast radius, RED test, minimal design |
+| GPT-5.3 Codex Spark | remote-branch provenance | read-only | protected/deletable/uncertain table with exact proof |
+| Controller | synthesis, writes, GitHub mutations, verification | sole writer | committed diff, live readbacks, qualification receipts |
+
+Worker reports are leads, not proof. The controller independently checks every
+claim used for a source edit, GitHub mutation, merge, issue closure, or branch
+deletion.
+
+## Publication units
+
+Prefer independently reviewable pull requests:
+
+1. roadmap, goal, and backlog reconciliation record;
+2. issue #92 code fix, if the approved design and reproduction support it;
+3. #104 implementation design and plan, followed by its own TDD branch;
+4. #111 design only after #104 stabilizes;
+5. branch cleanup receipt, if a public record adds durable value.
+
+Do not stack behavior changes into the documentation reconciliation PR.
+
+## Restart protocol
+
+On resume:
+
+1. verify `git status --short --branch`, `git rev-parse HEAD`, and
+   `git rev-parse origin/main`;
+2. preserve any drift or uncommitted work;
+3. read this record and the current public roadmap;
+4. refresh GitHub issue, PR, milestone, project, and branch state;
+5. resume the first incomplete work package;
+6. rerun the gate appropriate to every changed file;
+7. record exact heads and live readbacks before claiming completion.
+
+## Completion definition
+
+This programme is complete only when:
+
+- active roadmap and assurance documents match live GitHub state;
+- the five strategic issue checklists are evidence-reconciled;
+- milestones and Project #5 match the documented sequence;
+- all seven starting PRs have a documented current disposition;
+- #104 is publication-ready as the next implementation tranche and #111 is
+  explicitly sequenced behind it;
+- #92 is either fixed and qualified or retained with a precise evidence-backed
+  blocker;
+- every deleted remote branch has exact proof and post-deletion readback;
+- the final exact head passes the full applicable local gate and hosted checks
+  are reported separately;
+- commits, pushes, PRs, merges, and issue/branch mutations have durable URLs or
+  hashes.

--- a/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
+++ b/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
@@ -100,13 +100,17 @@ The starting pull-request portfolio received these dispositions:
   as `9a3b58dcb5dd71c229b70b01f5049ad0ac78b302`;
 - #183: rebased after #182, exact-head checks passed, and the `setup-uv` action
   update was squash-merged as `c43218a8c8527ef31cedf7335de6fcd6fdab97ae`;
-- #184: update required because its immutable attestation-action pin changed
-  without the matching release-contract expectation.
+- #184: rebased onto `main`, updated with the matching release-contract
+  expectation, fully requalified, and squash-merged as
+  `9ba89162205624f910f630d2cd5eb6f63130072e`.
 
-Issue #92 was disproved as a current production bug on the frozen base. The
-remaining work is one graph-aware LENS regression test that proves alias
-wikilinks resolve to the canonical page node. No production-code change is
-justified unless that test fails against the current implementation.
+Issue #92 was disproved as a current production bug on the frozen base. A
+separate test-only tranche then added the missing graph-aware LENS regression,
+proved that the historical literal-reference behavior creates a duplicate
+alias node, and confirmed that the current implementation preserves only the
+canonical page node. PR #192 was squash-merged as
+`2e3e3689df68d8ab134422f4202f5814a447618d` and closed #92 without a production
+or user-documentation change.
 
 Remote-branch cleanup completed with an explicit, no-wildcard deletion of 36
 branches whose work was merged or superseded. The recovery source is the
@@ -162,8 +166,47 @@ synchronized: its README now records the `#104 -> #111 -> #108` sequence;
 #104 is **In Progress**; #111 and residual #108 are **Todo**, with #108 marked
 blocked on its prerequisites; completed M5, M6, #87, and #186 gates were
 corrected; and #92, #109, #110, and #191 were added with explicit evidence,
-risk, status, and next-gate fields. Both open milestone descriptions were also
-updated to the same post-v1.8.1 boundaries.
+risk, status, and next-gate fields. After PR #192 merged, #92 moved to **Done**
+with an E2 maintained-corpus receipt. Both open milestone descriptions were
+also updated to the same post-v1.8.1 boundaries.
+
+## Final implementation receipts — 2026-08-25
+
+### PR #184 — immutable attestation action
+
+- Branch base before the corrective commit:
+  `8852bab86628112b626d589759720034bdf9a8de`.
+- Corrective head: `c8e4dac56e0cdbfddd39aea611c51d0c6d3a6dd2`.
+- RED: the focused release-evidence contract failed because it still required
+  the v4.2.1 pin while the workflow used the qualified v4.2.2 pin twice.
+- GREEN: the one-line contract update passed; `make all` passed with 761 tests
+  and 91.20% statement coverage; the wheel contract and Twine 6.2.0 checks
+  accepted both distributions.
+- Hosted receipt: all eight checks succeeded on the corrective head, including
+  Python 3.12, Python 3.13, dependency review, CodeQL, and package-contract.
+- Result: [PR #184](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/184)
+  squash-merged as `9ba89162205624f910f630d2cd5eb6f63130072e`.
+
+### PR #192 — canonical LENS alias regression
+
+- Exact base: `9ba89162205624f910f630d2cd5eb6f63130072e`.
+- Test head: `64e550ba9ece8b1e0b3c59a574adfcdcc5249caf`.
+- Historical mutation RED: literal reference handling produced node set
+  `{"P", "Alt"}` instead of the required `{"P"}`.
+- Current implementation GREEN: 12 focused LENS and alias tests passed; the
+  complete gate passed with 762 tests and 91.20% statement coverage; the wheel
+  contract and Twine 6.2.0 checks accepted both distributions.
+- Final diff: 18 added test lines in `tests/test_lens.py`; no production,
+  changelog, or user-documentation change.
+- Hosted receipt: all eight checks succeeded on the test head.
+- Result: [PR #192](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/192)
+  squash-merged as `2e3e3689df68d8ab134422f4202f5814a447618d`,
+  automatically closing #92.
+
+Final branch readback retained only `main`, `gh-pages`, and the open #191
+documentation branch. The temporary #192 branch was explicitly deleted after
+the merge and the remote readback confirmed its absence. At this checkpoint,
+`origin/main` is `2e3e3689df68d8ab134422f4202f5814a447618d`.
 
 ## Work packages and completion gates
 
@@ -242,8 +285,8 @@ Implementation gate:
 - run focused LENS/graph tests and the complete quality gate;
 - update user documentation only if supported behavior changes.
 
-Issue #92 remains separate from #104 and cannot delay documentation-only
-backlog reconciliation.
+Issue #92 was delivered separately from #104 and did not alter the
+documentation-only backlog reconciliation diff.
 
 ### R5 — Next implementation sequence
 
@@ -308,7 +351,8 @@ deletion.
 Prefer independently reviewable pull requests:
 
 1. roadmap, goal, and backlog reconciliation record;
-2. issue #92 code fix, if the approved design and reproduction support it;
+2. issue #92 regression tranche, with production changes only if required by
+   the approved RED/GREEN result;
 3. #104 implementation design and plan, followed by its own TDD branch;
 4. #111 design only after #104 stabilizes;
 5. branch cleanup receipt, if a public record adds durable value.

--- a/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
+++ b/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
@@ -153,8 +153,13 @@ test/meaningful-coverage-2026-08-24
 
 Post-deletion GitHub readback returned only `main`, `gh-pages`, the #191
 documentation branch, and the three open Dependabot branches for #182-#184.
-Project #5 synchronization remains an external authentication gate until the
-maintainer grants `read:project` and `project` scopes.
+The maintainer then granted GitHub Projects scopes and Project #5 was
+synchronized: its README now records the `#104 -> #111 -> #108` sequence;
+#104 is **In Progress**; #111 and residual #108 are **Todo**, with #108 marked
+blocked on its prerequisites; completed M5, M6, #87, and #186 gates were
+corrected; and #92, #109, #110, and #191 were added with explicit evidence,
+risk, status, and next-gate fields. Both open milestone descriptions were also
+updated to the same post-v1.8.1 boundaries.
 
 ## Work packages and completion gates
 

--- a/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
+++ b/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
@@ -91,11 +91,15 @@ M3-M7** therefore remains open with #104, #108, and #111; milestone
 The starting pull-request portfolio received these dispositions:
 
 - #84 and #99: contributor update and rebase required;
-- #147: merge candidate after a current-main refresh and fresh review;
+- #147: rebased by the maintainer, requalified, approved, and squash-merged as
+  `8852bab86628112b626d589759720034bdf9a8de`; its `Fixes #130` link closed the
+  associated issue;
 - #181: closed because Hatchling's Metadata 2.5 output is incompatible with
   the repository's current Twine 6.2 package-contract toolchain;
-- #182 and #183: merge candidates after current-main refresh and controlled
-  exact-head verification;
+- #182: exact-head checks passed and the CodeQL action update was squash-merged
+  as `9a3b58dcb5dd71c229b70b01f5049ad0ac78b302`;
+- #183: rebased after #182, exact-head checks passed, and the `setup-uv` action
+  update was squash-merged as `c43218a8c8527ef31cedf7335de6fcd6fdab97ae`;
 - #184: update required because its immutable attestation-action pin changed
   without the matching release-contract expectation.
 

--- a/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
+++ b/docs/internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md
@@ -76,6 +76,86 @@ At the starting point, GitHub reported:
 
 Every count is a dated snapshot and must be refreshed before final publication.
 
+## Execution update — 2026-08-25
+
+The documentation reconciliation was rebased from the frozen starting point
+onto `origin/main@bc601e11d93f634ced88451b42a7f9ab02a3d308`, committed as
+`c745b3da66295f21cfe3bfd27a58f29b153c28f9`, and published as pull request
+[#191](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/191).
+
+Live issue readback confirmed that #104, #108, #109, #110, and #111 retain
+only their evidence-supported residual scope. Milestone **Parser Assurance:
+M3-M7** therefore remains open with #104, #108, and #111; milestone
+**Evidence-gated improvements** remains open with research-only #185.
+
+The starting pull-request portfolio received these dispositions:
+
+- #84 and #99: contributor update and rebase required;
+- #147: merge candidate after a current-main refresh and fresh review;
+- #181: closed because Hatchling's Metadata 2.5 output is incompatible with
+  the repository's current Twine 6.2 package-contract toolchain;
+- #182 and #183: merge candidates after current-main refresh and controlled
+  exact-head verification;
+- #184: update required because its immutable attestation-action pin changed
+  without the matching release-contract expectation.
+
+Issue #92 was disproved as a current production bug on the frozen base. The
+remaining work is one graph-aware LENS regression test that proves alias
+wikilinks resolve to the canonical page node. No production-code change is
+justified unless that test fails against the current implementation.
+
+Remote-branch cleanup completed with an explicit, no-wildcard deletion of 36
+branches whose work was merged or superseded. The recovery source is the
+corresponding merged pull request, except `chore--enterprise-hardening`, whose
+head was already an ancestor of `main`, and `release/v1.8.1`, which was
+superseded by merged #190 and tag `v1.8.1`.
+
+Deleted branches:
+
+```text
+agent/api-stability-contract
+agent/docs-deterministic-gate
+agent/english-documentation
+agent/graph-title-collision-contract
+agent/lsdoc-reference-study
+agent/parser-adversarial-m3
+agent/parser-arbitrary-depth-refresh
+agent/parser-assurance-post-m9
+agent/parser-line-classifier-m7-next
+agent/parser-oracle-boundary-m2
+agent/parser-privacy-assurance-m5-next
+agent/parser-source-location-m6-next
+agent/parser-work-growth-m4
+agent/post-release-1.7.0
+agent/post-release-1.7.1
+agent/readme-release-highlights
+agent/release-1.7.0
+agent/release-1.8.0
+agent/security-lock-2026-08-08
+agent/stack-merge-readiness
+agent/stellar-repository-roadmap
+agent/structured-diagnostics-foundation
+agent/writer-vault-containment
+chore--enterprise-hardening
+docs/evidence-gated-roadmap-2026-08-24
+docs/performance-evidence-design
+docs/v1.8.0-release-receipt
+feat/graph-mutation-coherence-103
+fix/immutable-nltk-source-186
+fix/package-contract-validation
+fix/parser-pathological-depth
+fix/parser-pathological-refresh-87
+refactor/parser-lexical-state-m9
+release/v1.8.1-refresh
+release/v1.8.1
+test/meaningful-coverage-2026-08-24
+```
+
+Post-deletion GitHub readback returned only `main`, `gh-pages`, the #191
+documentation branch, and the three open Dependabot branches for #182-#184.
+Project #5 synchronization remains an external authentication gate until the
+maintainer grants `read:project` and `project` scopes.
+
 ## Work packages and completion gates
 
 ### R1 — Programme reconciliation

--- a/docs/log.md
+++ b/docs/log.md
@@ -38,8 +38,10 @@ superseded_by: null
   portfolio, published the programme record in PR #191, and deleted 36
   explicitly enumerated merged or superseded remote branches. GitHub readback
   retained only `main`, `gh-pages`, the #191 branch, and the three open
-  Dependabot branches; Project #5 synchronization remains gated on the
-  maintainer granting GitHub Projects scopes.
+  Dependabot branches. Synchronized Project #5 and both active milestone
+  descriptions with the `#104 -> #111 -> #108` sequence, corrected stale
+  completed gates, and added #92, #109, #110, and #191 with explicit status,
+  evidence, risk, and next-gate fields.
 
 ## 2026-08-24
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -42,11 +42,21 @@ superseded_by: null
   descriptions with the `#104 -> #111 -> #108` sequence, corrected stale
   completed gates, and added #92, #109, #110, and #191 with explicit status,
   evidence, risk, and next-gate fields.
-- Rebased, requalified, and merged dependency PRs #182 and #183 in order as
-  `9a3b58dc` and `c43218a8`; then refreshed contributor PR #147, dismissed its
-  satisfied change request, recorded a fresh approval, and merged it as
-  `8852bab8`, automatically closing #130. PR #184 remains open until its
-  immutable pin and release-contract expectation are updated together.
+- Rebased, requalified, and merged dependency PRs #182, #183, and #184 in order
+  as `9a3b58dc`, `c43218a8`, and `9ba89162`; then refreshed contributor PR #147,
+  dismissed its satisfied change request, recorded a fresh approval, and
+  merged it as `8852bab8`, automatically closing #130. The #184 correction
+  synchronized the immutable attestation-action pin and release-contract
+  expectation, passed 761 local tests at 91.20% coverage plus the package
+  contract, and received eight successful hosted checks on its exact head.
+- Delivered the bounded LENS alias regression in test-only
+  [PR #192](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/192).
+  A historical literal-reference mutation produced duplicate nodes `P` and
+  `Alt` (RED); the current graph-aware implementation retained only canonical
+  `P` (GREEN). Twelve focused tests, 762 full-suite tests at 91.20% coverage,
+  wheel and Twine contracts, and eight hosted checks passed. The PR merged as
+  `2e3e3689`, closed #92, and moved its Project #5 item to **Done** with E2
+  maintained-corpus evidence.
 
 ## 2026-08-24
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -42,6 +42,11 @@ superseded_by: null
   descriptions with the `#104 -> #111 -> #108` sequence, corrected stale
   completed gates, and added #92, #109, #110, and #191 with explicit status,
   evidence, risk, and next-gate fields.
+- Rebased, requalified, and merged dependency PRs #182 and #183 in order as
+  `9a3b58dc` and `c43218a8`; then refreshed contributor PR #147, dismissed its
+  satisfied change request, recorded a fresh approval, and merged it as
+  `8852bab8`, automatically closing #130. PR #184 remains open until its
+  immutable pin and release-contract expectation are updated together.
 
 ## 2026-08-24
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -8,8 +8,8 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-24
-verified: 2026-08-24
+last_verified: 2026-08-25
+verified: 2026-08-25
 stale_after: 2027-02-17
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -18,6 +18,26 @@ superseded_by: null
 ---
 
 # Documentation evolution log
+
+## 2026-08-25
+
+- Published v1.8.1 at
+  `bb8ec6b758e0e7b3429de49ca252ae8b62f97689` after the coherent graph,
+  bounded parser, local-assurance, runtime-evidence, stable NLTK, package,
+  supply-chain, and release gates completed.
+- Reconciled the active roadmap after release: #103, #186, and the bounded #87
+  work are complete; #104 is the next semantic-assurance tranche, followed by
+  #111; #108 retains only reducer, semantic-enrichment, equivalence, and
+  benchmark work; #185 remains research-only.
+- Added the internal
+  [post-v1.8.1 backlog execution record](internal/POST_V1_8_1_BACKLOG_EXECUTION_2026-08-25.md)
+  with exact source, baseline, authority boundaries, issue and PR gates,
+  cost-aware delegation, branch-cleanup proof requirements, and restart
+  instructions.
+- Began an evidence-only reconciliation of strategic issue checklists, seven
+  open pull requests, milestones, and Project #5. GitHub mutations and branch
+  deletions remain subject to exact-target readback and are not implied by this
+  documentation checkpoint.
 
 ## 2026-08-24
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -34,10 +34,12 @@ superseded_by: null
   with exact source, baseline, authority boundaries, issue and PR gates,
   cost-aware delegation, branch-cleanup proof requirements, and restart
   instructions.
-- Began an evidence-only reconciliation of strategic issue checklists, seven
-  open pull requests, milestones, and Project #5. GitHub mutations and branch
-  deletions remain subject to exact-target readback and are not implied by this
-  documentation checkpoint.
+- Reconciled the five strategic issue checklists and the seven-PR starting
+  portfolio, published the programme record in PR #191, and deleted 36
+  explicitly enumerated merged or superseded remote branches. GitHub readback
+  retained only `main`, `gh-pages`, the #191 branch, and the three open
+  Dependabot branches; Project #5 synchronization remains gated on the
+  maintainer granting GitHub Projects scopes.
 
 ## 2026-08-24
 


### PR DESCRIPTION
## Summary

- reconcile the public roadmap and parser-assurance goal with the shipped `v1.8.1` state;
- preserve the remaining scope of #104, #108, #109, #110, #111, and #185;
- establish #104 as the next implementation tranche, followed by #111 and then residual #108;
- record the seven-PR starting portfolio, milestone and Project #5 synchronization, and proof-based removal of 36 obsolete remote branches;
- add the final receipts for merged dependency PRs #182–#184, contributor PR #147, and test-only LENS regression PR #192, which closed #92.

## Validation

Exact head: `b22ba2fe270f7f9353f5b44aaca1f82171730420`

Exact base: `2e3e3689df68d8ab134422f4202f5814a447618d`

- `make all`: 762 tests passed; total statement coverage 91.20%; Ruff, Mypy, maintained-documentation, and vendor-name checks passed;
- `git diff --check origin/main...HEAD`: passed;
- hosted CI: all eight checks succeeded on the exact head, including Python 3.12, Python 3.13, dependency review, CodeQL, and package-contract.

## Boundaries

This pull request changes documentation only. It records completed #92 work but does not contain that test implementation. Issue #104 implementation and #111 benchmark work remain separate future execution units. The board is operational metadata, not a release promise.
