### PR TITLE
test: guard canonical LENS alias nodes

### DIFF
--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -84,6 +84,24 @@ def test_graph_visualizer_skips_unresolved_wikilinks_with_graph(
     assert "GhostPage" not in visualizer.graph
 
 
+def test_graph_visualizer_resolves_alias_wikilink_to_canonical_page(
+    tmp_path: Path,
+) -> None:
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir()
+    (pages_dir / "P.md").write_text(
+        "alias:: Alt\n- See [[Alt]]\n",
+        encoding="utf-8",
+    )
+
+    graph = LogseqGraph.load_directory(tmp_path)
+    visualizer = GraphVisualizer(list(graph.iter_canonical_pages()), graph=graph)
+    visualizer.build_network()
+
+    assert set(visualizer.graph.nodes) == {"P"}
+    assert "Alt" not in visualizer.graph
+
+
 def test_lens_module_imports_without_viz_dependencies() -> None:
     import importlib
 


### PR DESCRIPTION
## Description

Fixes #92

Adds the missing graph-aware LENS regression for a page `P` whose alias is `Alt` and whose content links to `[[Alt]]`. The final NetworkX node set must remain exactly `{"P"}`; no duplicate `Alt` page node is allowed.

This PR is test-only. The released production behavior already resolves the alias to the canonical page title, so no parser, graph, LENS implementation, documentation, or changelog change is needed.

## Type of change

- [x] 🐛 Bug fix (non-breaking regression coverage)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update

## Verification

- Historical mutation RED: replacing graph-aware title resolution with the literal reference produced `{"P", "Alt"}` and failed the new assertion.
- Current implementation GREEN: the dedicated regression passed.
- Focused LENS/alias suite: `12 passed, 47 deselected`.
- Full quality gate: `762 passed`, total coverage `91.20%`.
- Package contract: wheel contract passed; Twine 6.2.0 accepted both wheel and sdist.
- Final diff: one test file, 18 added lines, no production change.

## 🛡️ Sovereign Developer Checklist

- [x] I have read the contribution guidance.
- [x] I have executed `make all` locally, and all linters, type-checkers, documentation checks, and tests pass.
- [x] I have added the focused regression test.
- [x] Documentation is unchanged because this PR only records already documented and released behavior.
- [x] No changelog entry is needed because there is no user-visible behavior change.
- [x] The test follows the project's typing conventions.

## 🤖 AI assistance and data handling

- [x] AI assistance was used; the maintainer reviewed the complete diff and remains responsible for it.
- [x] No private vault data, credentials, tokens, or unpublished security details were uploaded.
- [x] The complete diff follows the AI-assisted contribution policy.

## 🧭 Contract impact

- [x] No documented API or runtime contract changes.
- [x] This PR makes no unsupported external or release-provenance claim.

## Screenshots / CLI Output

Not applicable.
