### PR TITLE
ci: adopt native cross-platform GitHub assurance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   # Keep GitHub Actions current (reads .github/workflows/ci.yml).
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: Logos Protocol CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,68 +14,137 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  quality:
+    name: Quality (Python 3.12)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.7"
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Sync locked dependencies
+        run: uv sync --locked --all-extras
+
+      - name: Lint
+        run: make lint
+
+      - name: Type check
+        run: make check
+
+      - name: Validate repository policy
+        run: make vendor-name-check
+
+      - name: Validate documentation
+        run: make docs-check
+
+      - name: Verify checkout unchanged
+        run: make verify-clean
+
+  tests:
+    name: Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.12", "3.13" ]
-
+        os: [ubuntu-24.04, macos-15, windows-2025]
+        python-version: ["3.12", "3.13"]
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-      with:
-        python-version: ${{ matrix.python-version }}
-        enable-cache: true
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.7"
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
 
-    - name: Sync dependencies
-      run: uv sync --all-extras
+      - name: Sync locked dependencies
+        run: uv sync --locked --all-extras
 
-    - name: Audit dependencies
-      run: |
-        uv export --no-dev --no-emit-workspace --no-hashes -o "${{ runner.temp }}/requirements-audit.txt"
-        uv run pip-audit -r "${{ runner.temp }}/requirements-audit.txt"
+      - name: Run complete test suite
+        run: >-
+          uv run pytest
+          --cov=src/logseq_matryca_parser
+          --cov-report=term-missing
+          --cov-fail-under=80
+          -v tests/
 
-    - name: Lint
-      run: make lint
+  dependency-audit:
+    name: Production dependency audit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-    - name: Type check
-      run: make check
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.7"
+          python-version: "3.12"
+          enable-cache: true
 
-    - name: Test
-      run: make test
+      - name: Sync locked dependencies
+        run: uv sync --locked --all-extras
 
-    - name: Documentation check (non-mutating)
-      run: make docs-check
+      - name: Export every production dependency
+        run: >-
+          uv export
+          --all-extras
+          --no-dev
+          --no-emit-workspace
+          --output-file "${{ runner.temp }}/requirements-audit.txt"
 
-    - name: Verify checkout unchanged
-      run: make verify-clean
+      - name: Audit exported dependencies
+        run: uv run pip-audit --no-deps --disable-pip -r "${{ runner.temp }}/requirements-audit.txt"
 
   package-contract:
-    runs-on: ubuntu-latest
-
+    name: Wheel and source distribution contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-      with:
-        python-version: "3.12"
-        enable-cache: true
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.7"
+          python-version: "3.12"
+          enable-cache: true
 
-    - name: Build wheel and source distribution
-      run: uv build --out-dir dist-contract
+      - name: Sync locked dependencies
+        run: uv sync --locked --all-extras
 
-    - name: Verify wheel metadata and PEP 561 marker
-      run: uv run python scripts/check_wheel_contract.py dist-contract/*.whl
+      - name: Build wheel and source distribution
+        run: uv build --out-dir dist-contract
 
-    - name: Verify downstream typing from the wheel
-      run: |
-        uv venv "${{ runner.temp }}/typing-venv"
-        uv pip install --python "${{ runner.temp }}/typing-venv/bin/python" mypy dist-contract/*.whl
-        cd "${{ runner.temp }}"
-        "${{ runner.temp }}/typing-venv/bin/python" -m mypy --strict "${{ github.workspace }}/tests/typing_samples/public_api.py"
+      - name: Verify wheel metadata and PEP 561 marker
+        run: uv run python scripts/check_wheel_contract.py dist-contract/*.whl
+
+      - name: Validate distribution metadata
+        run: uvx --from twine==6.2.0 twine check dist-contract/*
+
+      - name: Verify downstream typing from the wheel
+        run: |
+          uv venv "${{ runner.temp }}/typing-venv"
+          uv pip install --python "${{ runner.temp }}/typing-venv/bin/python" mypy==1.20.2 dist-contract/*.whl
+          cd "${{ runner.temp }}"
+          "${{ runner.temp }}/typing-venv/bin/python" -m mypy --strict "${{ github.workspace }}/tests/typing_samples/public_api.py"

--- a/.github/workflows/daily-metrics.yml
+++ b/.github/workflows/daily-metrics.yml
@@ -19,16 +19,19 @@ env:
 jobs:
   save-metrics:
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
       - name: Checkout trusted default branch
+        # zizmor: ignore[artipacked] -- this trusted main-only job must push metrics.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0
           token: ${{ github.token }}
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/dependency-hygiene.yml
+++ b/.github/workflows/dependency-hygiene.yml
@@ -1,40 +1,37 @@
-name: Parser Adversarial Laboratory
+name: Dependency Hygiene Audit
 
 on:
   schedule:
-    - cron: "17 4 * * 3"
+    - cron: "23 4 1 * *"
   workflow_dispatch:
 
 concurrency:
-  group: parser-adversarial-${{ github.repository }}
+  group: dependency-hygiene-${{ github.repository }}
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  bounded-generated-assurance:
+  deptry:
+    name: Check dependency declarations
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
-
+    timeout-minutes: 5
     steps:
-      - name: Checkout code
+      - name: Checkout without credentials
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - name: Install uv
+      - name: Install pinned uv without a shared cache
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.7"
           python-version: "3.12"
-          enable-cache: true
+          enable-cache: false
 
-      - name: Sync dependencies
+      - name: Sync locked project environment
         run: uv sync --locked --all-extras
 
-      - name: Run bounded broad profile
-        run: uv run python -m tests.parser_assurance.adversarial --profile broad
-
-      - name: Verify checkout unchanged
-        run: make verify-clean
+      - name: Check dependency declarations
+        run: uv run --with deptry==0.25.1 deptry . --github-output

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,7 +13,8 @@ concurrency:
 jobs:
   dependency-review:
     name: Block newly introduced vulnerable dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout dependency manifests
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -15,7 +15,8 @@ permissions:
 jobs:
   pre-flight:
     name: Pre-flight checks (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -23,21 +24,23 @@ jobs:
     steps:
       - name: Checkout exact tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.7"
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
+          enable-cache: false
 
       - name: Sync locked dependencies
         run: uv sync --locked --all-extras
 
       - name: Audit production dependencies
         run: |
-          uv export --no-dev --no-emit-workspace --no-hashes -o "${{ runner.temp }}/requirements-audit.txt"
-          uv run pip-audit -r "${{ runner.temp }}/requirements-audit.txt"
+          uv export --all-extras --no-dev --no-emit-workspace -o "${{ runner.temp }}/requirements-audit.txt"
+          uv run pip-audit --no-deps --disable-pip -r "${{ runner.temp }}/requirements-audit.txt"
 
       - name: Run full quality gate
         run: make all
@@ -48,7 +51,8 @@ jobs:
   build:
     name: Build immutable release bundle
     needs: pre-flight
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write
@@ -58,13 +62,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.7"
           python-version: "3.12"
-          enable-cache: true
+          enable-cache: false
 
       - name: Sync locked dependencies
         run: uv sync --locked --all-extras
@@ -154,7 +159,8 @@ jobs:
   publish:
     name: Publish exact distributions to PyPI
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     environment:
       name: pypi
       url: https://pypi.org/p/logseq-matryca-parser
@@ -182,7 +188,8 @@ jobs:
   github-release:
     name: Publish GitHub Release from exact distributions
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -199,15 +206,16 @@ jobs:
             | sha256sum --check -
 
       - name: Create GitHub Release with verified artifacts
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          body_path: release-bundle/RELEASE_NOTES.md
-          files: |
-            release-bundle/dist/*
-            release-bundle/SBOM.cdx.json
-            release-bundle/DEPENDENCY_LICENSES.json
-            release-bundle/SHA256SUMS
-          generate_release_notes: false
-          make_latest: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            release-bundle/dist/* \
+            release-bundle/SBOM.cdx.json \
+            release-bundle/DEPENDENCY_LICENSES.json \
+            release-bundle/SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-bundle/RELEASE_NOTES.md \
+            --latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,7 +11,8 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/workflow-analysis.yml
+++ b/.github/workflows/workflow-analysis.yml
@@ -1,0 +1,59 @@
+name: Workflow Static Analysis
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/dependabot.yml"
+      - ".pre-commit-config.yaml"
+      - "zizmor.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/dependabot.yml"
+      - ".pre-commit-config.yaml"
+      - "zizmor.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-analysis:
+    name: Validate workflow semantics and security
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pinned uv without a shared cache
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.7"
+          python-version: "3.12"
+          enable-cache: false
+
+      - name: Install checksum-verified actionlint 1.7.12
+        run: |
+          archive="${RUNNER_TEMP}/actionlint_1.7.12_linux_amd64.tar.gz"
+          curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+            --output "$archive" \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  $archive" \
+            | sha256sum --check --strict
+          tar --extract --gzip --file "$archive" --directory "$RUNNER_TEMP" actionlint
+
+      - name: Validate workflow semantics
+        run: |
+          "$RUNNER_TEMP/actionlint" -color
+
+      - name: Audit workflow security
+        run: uvx --from zizmor==1.29.0 zizmor --strict-collection --format=github .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+-   repo: https://github.com/rhysd/actionlint
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # v1.7.12
+    hooks:
+    -   id: actionlint
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ backlinks, exports, visualizations, and AI chunks are derived views.
   [`docs/reference/API_STABILITY.md`](docs/reference/API_STABILITY.md).
 - For architecture and ownership boundaries, use
   [`docs/CLEAN_CODE_ARCHITECTURE.md`](docs/CLEAN_CODE_ARCHITECTURE.md).
+- For pull-request, scheduled, settings-managed, and release checks, use
+  [`docs/CI_ASSURANCE.md`](docs/CI_ASSURANCE.md).
 - For the maintained machine-readable knowledge map, use
   [`docs/index.md`](docs/index.md).
 - For historical release capabilities, use
@@ -66,7 +68,7 @@ Protocol integrations remain optional and deferred under
 ## Repository working contract
 
 ```bash
-uv sync --all-extras
+uv sync --locked --all-extras
 make all
 make vendor-name-check
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Native cross-platform GitHub assurance** — replace the public-repository
+  receipt-routing experiment with SHA-pinned GitHub-hosted quality, packaging,
+  dependency, CodeQL, Linux, macOS, and Windows checks. Local maintainer
+  guidance now treats hosted Actions as the authoritative public CI path.
+
+### Fixed
+
+- **Windows assurance portability** — open local-assurance inputs in binary
+  mode so CRLF files retain their measured byte length, use platform-neutral
+  byte and path fixtures, preserve POSIX permission assertions only where the
+  operating system provides those semantics, and fold CLI diagnostic
+  identifiers instead of replacing their final characters with an ellipsis.
+
 ## [1.8.1] - 2026-08-25
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ User-facing behavior is documented in:
 - [`docs/logseq_ast_primer.md`](docs/logseq_ast_primer.md) — Logseq Spatial Markdown domain rules
 - [`CHANGELOG.md`](CHANGELOG.md) — shipped releases (current: **1.8.1**) and **Unreleased** changes (Keep a Changelog)
 - [`docs/RELEASE_PROCESS.md`](docs/RELEASE_PROCESS.md) — version bump, tag, and PyPI publish checklist
+- [`docs/CI_ASSURANCE.md`](docs/CI_ASSURANCE.md) — pull-request, scheduled, settings-managed, and release checks
 - [`docs/CODEQL.md`](docs/CODEQL.md) — CodeQL default setup (no custom `codeql.yml`)
 - [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) — curated starter tasks for new contributors
 - [`docs/COOKBOOK.md`](docs/COOKBOOK.md) — integration recipes (Synapse, graph query, watcher)
@@ -80,7 +81,7 @@ New to the codebase? Start here:
 
 1. **Pick a task** from [`docs/GOOD_FIRST_ISSUES.md`](docs/GOOD_FIRST_ISSUES.md) (label: `good first issue` on GitHub).
 2. **Comment on the issue** so others know you are working on it.
-3. **Set up** with `uv sync --all-extras` and confirm `make all` is green on `main`.
+3. **Set up** with `uv sync --locked --all-extras` and confirm `make all` is green on `main`.
 4. **Branch** using `feat/…`, `test/…`, or `docs/…` naming (see workflow below).
 5. **Submit** one PR per issue, branched from `main` (`Fixes #123`).
 

--- a/docs/CI_ASSURANCE.md
+++ b/docs/CI_ASSURANCE.md
@@ -1,0 +1,157 @@
+---
+type: Document
+title: Continuous integration assurance
+description: Canonical map of pull-request, scheduled, settings-managed, and release checks.
+status: stable
+classification: canonical
+audience: contributors
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-08-30
+verified: 2026-08-30
+stale_after: 2027-02-26
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# Continuous integration assurance
+
+GitHub Actions is the repository's hosted continuous-integration system. This
+page explains which checks exist, when they run, and what their results prove.
+It is the shared map for contributors, maintainers, and AI agents; focused
+security and release documents remain authoritative for their own boundaries.
+
+## Pull-request and main checks
+
+[`Logos Protocol CI`](../.github/workflows/ci.yml) runs for every pull request,
+every push to `main`, and manual dispatch. Each job is independent so a failure
+identifies the affected contract directly.
+
+| Job | Platform | Purpose |
+|---|---|---|
+| `quality` | Ubuntu 24.04, Python 3.12 | Ruff, Mypy, documentation validation, repository policy, and clean-checkout verification |
+| `tests` | Ubuntu 24.04, macOS 15, Windows 2025; Python 3.12 and 3.13 | Complete Pytest suite and the 80% coverage floor on all six supported runtime cells |
+| `dependency-audit` | Ubuntu 24.04, Python 3.12 | `pip-audit` over locked base and optional production dependencies |
+| `package-contract` | Ubuntu 24.04, Python 3.12 | Wheel/sdist build, package metadata, PEP 561, Twine, and downstream strict typing |
+
+[`Dependency Review`](../.github/workflows/dependency-review.yml) is a separate
+pull-request check. It rejects newly introduced runtime or development
+dependencies with known vulnerabilities of moderate severity or higher. It
+uses the unprivileged `pull_request` event, not `pull_request_target`, and does
+not receive repository secrets.
+
+[`Workflow Static Analysis`](../.github/workflows/workflow-analysis.yml) runs
+when workflow, Dependabot, pre-commit, or workflow-security configuration
+changes. It validates workflow semantics with a checksum-verified actionlint
+binary and audits workflow security offline with a pinned zizmor release. It is
+path-scoped, so it must not be configured as a globally required check: GitHub
+can leave path-filtered required workflows pending when they do not run.
+
+All project environments synchronize with `uv.lock`. External actions are
+pinned to complete commit SHAs, read-only checkouts discard credentials, jobs
+have explicit timeouts, and standard runner images are versioned.
+
+## Scheduled and settings-managed assurance
+
+| Assurance | Trigger | Boundary |
+|---|---|---|
+| [`Parser Adversarial Laboratory`](../.github/workflows/parser-adversarial.yml) | Weekly and manual | Bounded generated parser cases; no vault source is uploaded |
+| [`Dependency Hygiene Audit`](../.github/workflows/dependency-hygiene.yml) | Monthly and manual | Detects unused, missing, and transitive dependency declarations with pinned deptry |
+| [`OpenSSF Scorecard`](../.github/workflows/scorecard.yml) | Push to `main` and weekly | Publishes supply-chain posture as SARIF and a short-retention artifact |
+| [`Daily Metrics Saver`](../.github/workflows/daily-metrics.yml) | Daily and manual | Main-only traffic archive; the [metrics threat model](security/DAILY_METRICS_THREAT_MODEL.md) governs its write token and data boundary |
+| CodeQL default setup | GitHub-managed | Python SAST without a custom workflow; see [`CODEQL.md`](CODEQL.md) |
+| Secret scanning and push protection | GitHub settings | Repository-level secret detection; source files cannot prove that the settings are enabled |
+| Dependabot alerts and security updates | GitHub settings | Advisory detection and security-update pull requests; routine version updates follow [`.github/dependabot.yml`](../.github/dependabot.yml) |
+
+Scheduled workflow files express intended behavior. A current claim requires a
+successful hosted run on the exact workflow revision. Settings-managed features
+require a live Settings or API readback; documentation is not a substitute.
+
+## Release assurance
+
+[`Release`](../.github/workflows/pypi_publish.yml) starts only from a `v*` tag
+and remains sequential:
+
+```text
+Python 3.12/3.13 pre-flight
+  -> exact tag/version/changelog contract
+  -> one wheel and sdist build
+  -> wheel, Twine, SBOM, license inventory, and checksum contracts
+  -> GitHub provenance and SBOM attestations with in-job verification
+  -> PyPI Trusted Publishing
+  -> GitHub Release from the same downloaded bundle
+```
+
+Release jobs do not restore dependency caches. Read-only checkouts do not keep
+credentials. Only the exact build job receives attestation permissions, the
+PyPI job receives OIDC for Trusted Publishing, and the final GitHub Release job
+receives `contents: write`. Follow [`RELEASE_PROCESS.md`](RELEASE_PROCESS.md)
+for preparation, failure handling, and post-publication verification.
+
+## Contributor workflow
+
+Before opening a pull request, run:
+
+```bash
+uv sync --locked --all-extras
+make all
+make vendor-name-check
+```
+
+When automation files change, also run actionlint and zizmor using the pinned
+versions documented in `workflow-analysis.yml`. When packaging changes, build
+wheel and sdist, run `scripts/check_wheel_contract.py`, Twine 6.2.0, and the
+downstream strict-Mypy sample.
+
+Do not add secrets to workflow files, caches, fixtures, artifacts, logs, or
+pull-request comments. A contributor pull request must never be changed to
+`pull_request_target` merely to gain a token or secret.
+
+## Maintainer ruleset guidance
+
+After the first exact-head hosted run confirms the new job names, protect
+`main` with the always-emitted CI and Dependency Review checks. Require a pull
+request, require the branch to be current before merge, dismiss stale
+approvals when the protected diff changes, and block force pushes and branch
+deletion. Keep path-scoped workflow analysis outside the global required-check
+list, while treating any emitted failure as blocking review evidence.
+
+Verify CodeQL default setup, Dependabot alerts/security updates, secret
+scanning, push protection, Actions SHA-pinning policy, and the PyPI environment
+directly in repository settings. Do not claim any setting from this file.
+
+## Cache and fork safety
+
+Development jobs may use the uv cache. Pull-request caches are scoped by
+GitHub's event and merge reference and contain only downloaded dependencies;
+they must not contain tokens, credentials, source snapshots, or release
+artifacts. Release and workflow-analysis jobs disable shared dependency caches.
+
+Fork pull requests run untrusted repository code with read-only permissions and
+without secrets. No privileged workflow checks out or executes a contributor's
+head through `pull_request_target`, `workflow_run`, an issue comment, or another
+indirect trigger.
+
+## Evidence boundaries
+
+| Evidence label | What is required | What it proves |
+|---|---|---|
+| **Local PASS** | Fresh complete commands and a clean diff on one exact commit | Source contracts pass on the recorded local OS and Python runtime |
+| **Hosted PASS** | Successful GitHub Actions jobs on the exact head SHA | Those workflow jobs passed on their recorded hosted runners |
+| **Settings PASS** | Current authenticated Settings or API readback | The named repository security or ruleset option is enabled at readback time |
+| **Publication PASS** | Exact-tag workflow success plus downloaded artifact, checksum, and attestation verification | The named package and release artifacts match the qualified tag |
+
+One label never implies another. In particular, local workflow validation does
+not prove hosted Windows behavior, and a workflow source file does not prove a
+repository setting or a published release.
+
+## Related authorities
+
+- [`CODEQL.md`](CODEQL.md) — default-setup boundary and status navigation
+- [`RELEASE_PROCESS.md`](RELEASE_PROCESS.md) — release execution and recovery
+- [`reference/DEPENDENCY_LICENSE_POLICY.md`](reference/DEPENDENCY_LICENSE_POLICY.md) — dependency, SBOM, checksum, license, and attestation contract
+- [`security/DAILY_METRICS_THREAT_MODEL.md`](security/DAILY_METRICS_THREAT_MODEL.md) — self-mutating metrics workflow boundary
+- [`DOCUMENTATION_SYSTEM.md`](DOCUMENTATION_SYSTEM.md) — documentation lifecycle and authority

--- a/docs/CODEQL.md
+++ b/docs/CODEQL.md
@@ -13,6 +13,12 @@ GitHub does not allow **default setup** and a custom **advanced** CodeQL workflo
 
 Default setup is the recommended path for this repository: GitHub maintains the analysis configuration, runs on current runner images (Node 24+), and scans Python without duplicating CI.
 
+CodeQL is settings-managed assurance. Its source documentation records the
+intended configuration, but only a current authenticated Settings/API readback
+and an exact-head hosted result establish current status. See the
+[continuous integration assurance map](CI_ASSURANCE.md) for the distinction
+between local, hosted, settings, and publication evidence.
+
 ## Where to see results
 
 - **Security → Code scanning** on the repository
@@ -38,6 +44,7 @@ Do not re-enable default setup while an advanced workflow is active.
 
 - [`SECURITY.md`](../SECURITY.md) — vulnerability reporting
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — local quality gates (`make all`)
+- [`CI_ASSURANCE.md`](CI_ASSURANCE.md) — complete CI map and evidence boundaries
 - [`GOOD_FIRST_ISSUES.md`](GOOD_FIRST_ISSUES.md) — starter tasks for new contributors
 - [`reference/DEPENDENCY_LICENSE_POLICY.md`](reference/DEPENDENCY_LICENSE_POLICY.md) — SBOM, dependency/license, and release provenance contract
 - [Troubleshooting: default setup enabled](https://docs.github.com/en/code-security/reference/code-scanning/sarif-files/troubleshoot-sarif-uploads/default-setup-enabled)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,9 @@ audience: contributors
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-20
-verified: 2026-08-20
-stale_after: 2027-02-20
+last_verified: 2026-08-30
+verified: 2026-08-30
+stale_after: 2027-02-26
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -37,6 +37,7 @@ entry points.
 | :--- | :--- | :--- |
 | [`index.md`](index.md) | Tools, maintainers | Canonical machine entry point for the maintained knowledge bundle |
 | [`DOCUMENTATION_SYSTEM.md`](DOCUMENTATION_SYSTEM.md) | Contributors, maintainers | Canonical documentation governance, metadata, lifecycle, validation, and federation workflow |
+| [`CI_ASSURANCE.md`](CI_ASSURANCE.md) | Contributors, maintainers, agents | Pull-request, scheduled, settings-managed, and release assurance map |
 | [`AI_CONTRIBUTION_POLICY.md`](AI_CONTRIBUTION_POLICY.md) | Contributors, maintainers | AI assistance disclosure, privacy, human accountability, and review rules |
 | [`ISSUE_TRIAGE_POLICY.md`](ISSUE_TRIAGE_POLICY.md) | Contributors, maintainers | Labels, priorities, good-first issue lifecycle, stale work, and closure policy |
 | [`ROADMAP_2026-2027.md`](ROADMAP_2026-2027.md) | Contributors, maintainers | Current milestones, dependencies, owners, and evidence gates |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -25,6 +25,9 @@ Every external action is pinned to a full commit SHA. The uploaded Actions
 artifact is transport only; `SHA256SUMS` is verified again before both public
 publication stages. The release workflow also pins the `uv` binary version so
 lock interpretation and SBOM generation do not float between tag runs.
+Release jobs use pinned standard runner images, explicit timeouts, no dependency
+cache, and credential-free read-only checkouts. The broader pull-request and
+settings boundary is documented in [`CI_ASSURANCE.md`](CI_ASSURANCE.md).
 
 ---
 
@@ -167,3 +170,4 @@ only explanatory text — are wrong.
 - [`GOOD_FIRST_ISSUES.md`](GOOD_FIRST_ISSUES.md) — contributor task index
 - [`scripts/extract_changelog.py`](../scripts/extract_changelog.py)
 - [`reference/DEPENDENCY_LICENSE_POLICY.md`](reference/DEPENDENCY_LICENSE_POLICY.md)
+- [`CI_ASSURANCE.md`](CI_ASSURANCE.md) — pull-request, scheduled, settings, and release evidence boundaries

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-20
-verified: 2026-08-20
-stale_after: 2027-02-20
+last_verified: 2026-08-30
+verified: 2026-08-30
+stale_after: 2027-02-26
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -32,6 +32,7 @@ navigation layers only.
 | [AI agent guide](../AGENTS.md) | Product map, execution contract, safety boundaries, and repository gates |
 | [LLM discovery index](../llms.txt) | Concise standard-format project and capability map for inference-time discovery |
 | [Documentation system](DOCUMENTATION_SYSTEM.md) | Canonical governance, lifecycle, metadata, and federation guide |
+| [Continuous integration assurance](CI_ASSURANCE.md) | Pull-request, scheduled, settings-managed, and release checks with evidence boundaries |
 | [AI contribution policy](AI_CONTRIBUTION_POLICY.md) | Human accountability, privacy, disclosure, and review rules for AI-assisted work |
 | [Agent action contract](reference/AGENT_ACTION_CONTRACT.md) | Read/write authority, provenance, prompt-injection boundary, and approval matrix |
 | [Support and compatibility matrix](reference/CONFORMANCE_SUPPORT_MATRIX.md) | Supported runtimes, public API tiers, optional adapters, and explicit limits |

--- a/docs/log.md
+++ b/docs/log.md
@@ -8,9 +8,9 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-25
-verified: 2026-08-25
-stale_after: 2027-02-17
+last_verified: 2026-08-30
+verified: 2026-08-30
+stale_after: 2027-02-26
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -18,6 +18,21 @@ superseded_by: null
 ---
 
 # Documentation evolution log
+
+## 2026-08-30
+
+- Added the maintained
+  [continuous integration assurance map](CI_ASSURANCE.md), separating
+  pull-request, scheduled, settings-managed, and release checks and defining
+  distinct local, hosted, settings, and publication evidence labels.
+- Documented the native GitHub Actions architecture: locked Python 3.12/3.13
+  quality and package gates, a six-cell Linux/macOS/Windows runtime matrix,
+  pull-request dependency review, path-scoped workflow analysis, monthly
+  dependency hygiene, scheduled parser and Scorecard assurance, and the
+  existing single-build release chain.
+- Reconciled contributor, agent, CodeQL, release, human-index, machine-index,
+  and quality navigation without claiming an unexecuted hosted run or an
+  unverified repository setting.
 
 ## 2026-08-25
 

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -21,6 +21,7 @@ maintained_documents = [
   "docs/index.md",
   "docs/README.md",
   "docs/DOCUMENTATION_SYSTEM.md",
+  "docs/CI_ASSURANCE.md",
   "docs/AI_CONTRIBUTION_POLICY.md",
   "docs/AAIF_ALIGNMENT.md",
   "docs/CLEAN_CODE_ARCHITECTURE.md",

--- a/docs/quality/README.md
+++ b/docs/quality/README.md
@@ -8,9 +8,9 @@ audience: maintainers
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-06
-verified: 2026-08-06
-stale_after: 2027-02-02
+last_verified: 2026-08-30
+verified: 2026-08-30
+stale_after: 2027-02-26
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -26,6 +26,7 @@ Maintainer-facing triage and backlog for Clean Architecture / Clean Code work.
 | [`ISSUE_RECONCILIATION_2026-08-06.md`](ISSUE_RECONCILIATION_2026-08-06.md) | Current disposition of every open GitHub issue and stellar-roadmap integration |
 | [`../REPOSITORY_STELLAR_ROADMAP_2026-08-06.md`](../REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Current repository-wide evidence, priorities and MKQ-4 plan |
 | [`../DOCUMENTATION_SYSTEM.md`](../DOCUMENTATION_SYSTEM.md) | Canonical documentation authority, metadata, lifecycle, and federation contract |
+| [`../CI_ASSURANCE.md`](../CI_ASSURANCE.md) | Canonical GitHub Actions and repository-settings assurance map |
 | [`GITHUB_CLEAN_ARCH_ROADMAP.md`](GITHUB_CLEAN_ARCH_ROADMAP.md) | Milestone, project board, epic + phase issues (v1.6) |
 | [`ISSUE_TRIAGE_2026-07.md`](ISSUE_TRIAGE_2026-07.md) | Superseded July 2026 backlog baseline |
 | [`CLEAN_ARCH_BACKLOG.md`](CLEAN_ARCH_BACKLOG.md) | v1 structural debt **complete** — v2 epic (`logos_parser` split) |

--- a/docs/superpowers/plans/2026-08-30-native-github-actions.md
+++ b/docs/superpowers/plans/2026-08-30-native-github-actions.md
@@ -1,0 +1,307 @@
+# Native GitHub Actions Assurance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the repository's optional local CI coordination path with a complete, secure, locked, cross-platform GitHub Actions assurance system for pull requests, schedules, and releases.
+
+**Architecture:** Keep one primary CI workflow with independently readable quality, test-matrix, dependency-audit, and package-contract jobs. Add path-scoped workflow analysis and monthly dependency-declaration hygiene, while hardening the existing specialized and release workflows without changing release artifact identity or order.
+
+**Tech Stack:** GitHub Actions, Python 3.12/3.13, uv 0.11.7, Pytest, Ruff, Mypy, pip-audit, deptry 0.25.1, actionlint 1.7.12, zizmor 1.29.0, Twine 6.2.0.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-native-github-actions-design.md`
+
+## Global Constraints
+
+- Start from `origin/main` commit `044b81d0b0ed869ac5213d4a79e10949b9930633` in the isolated `ci/native-github-actions` worktree.
+- Use only standard GitHub-hosted runner images: `ubuntu-24.04`, `macos-15`, and `windows-2025`.
+- Support Python `3.12` and `3.13` in the complete runtime test matrix.
+- Pin every external action to a full 40-character commit SHA.
+- Pin uv to `0.11.7` and use `uv sync --locked --all-extras` for project environments.
+- Keep pull-request jobs read-only, secret-free, timeout-bounded, and free of `pull_request_target`.
+- Keep CodeQL on GitHub default setup; do not add `.github/workflows/codeql.yml`.
+- Keep the release build single-use and preserve SBOM, license inventory, checksum, attestation, PyPI, and GitHub Release order.
+- Preserve the coverage floor at 80% or higher.
+- Keep all repository documentation and workflow messages in English.
+
+---
+
+### Task 1: Portable Makefile and native CI contract
+
+**Files:**
+- Modify: `tests/test_quality_gate_contract.py`
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: the existing Makefile targets `all`, `lint`, `lint-fix`, `check`, `vendor-name-check`, `docs-check`, `test`, and `verify-clean`.
+- Produces: `_read_makefile_recipes(target: str, makefile: Path = ROOT / "Makefile") -> list[str]` and the stable jobs `quality`, `tests`, `dependency-audit`, and `package-contract`.
+
+- [x] **Step 1: Add failing CI contract tests**
+
+  Add assertions that require the four stable job identifiers, explicit timeouts,
+  pinned standard runner labels, a six-cell OS/Python test matrix, locked sync,
+  credential-free checkouts, a single dependency audit, Twine package validation,
+  and no `pull_request_target`.
+
+  ```python
+  def test_ci_uses_locked_cross_platform_native_actions_jobs() -> None:
+      workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+      for job in ("quality", "tests", "dependency-audit", "package-contract"):
+          assert f"\n  {job}:\n" in workflow
+      for runner in ("ubuntu-24.04", "macos-15", "windows-2025"):
+          assert runner in workflow
+      assert '["3.12", "3.13"]' in workflow
+      assert "uv sync --locked --all-extras" in workflow
+      assert "twine==6.2.0" in workflow
+      assert "pull_request_target" not in workflow
+  ```
+
+- [x] **Step 2: Run the new contract and confirm RED**
+
+  Run: `uv run pytest tests/test_quality_gate_contract.py -q`
+
+  Expected: FAIL because the baseline workflow has only `build` and
+  `package-contract`, uses moving runner labels, and does not lock development
+  synchronization.
+
+- [x] **Step 3: Replace GNU Make subprocess inspection with a deterministic reader**
+
+  Implement `_read_makefile_recipes` inside the test module. It accepts only
+  simple target declarations and tab-prefixed recipes, expands reachable
+  prerequisites depth-first, rejects duplicates, cycles, unresolved
+  prerequisites, orphan recipes, and reachable continuation recipes, and
+  returns the exact commands asserted by the existing tests.
+
+- [x] **Step 4: Implement the four-job CI workflow**
+
+  Use a quality job on Ubuntu/Python 3.12, a full six-cell runtime matrix, one
+  production dependency audit, and one package build. Keep caches enabled only
+  for pull-request/main development jobs and end quality with `make verify-clean`.
+
+- [x] **Step 5: Run the focused contract and confirm GREEN**
+
+  Run: `uv run pytest tests/test_quality_gate_contract.py -q`
+
+  Expected: PASS.
+
+### Task 2: Workflow security and dependency hygiene
+
+**Files:**
+- Create: `.github/workflows/workflow-analysis.yml`
+- Create: `.github/workflows/dependency-hygiene.yml`
+- Modify: `.github/dependabot.yml`
+- Modify: `.pre-commit-config.yaml`
+- Create: `zizmor.yml`
+- Modify: `pyproject.toml`
+- Modify: `tests/test_quality_gate_contract.py`
+
+**Interfaces:**
+- Consumes: every `.github/workflows/*.yml` file, `uv.lock`, and Python import metadata.
+- Produces: path-scoped `Workflow Static Analysis`, scheduled/manual `Dependency Hygiene Audit`, and seven-day Dependabot cooldowns.
+
+- [x] **Step 1: Add failing hygiene contract tests**
+
+  Require SHA-pinned checkout, no persisted credentials, explicit timeout,
+  checksum-verified actionlint `1.7.12`, strict zizmor `1.29.0`, monthly
+  deptry `0.25.1`, no pull-request trigger for deptry, and two Dependabot
+  cooldown blocks.
+
+- [x] **Step 2: Run the focused tests and confirm RED**
+
+  Run: `uv run pytest tests/test_quality_gate_contract.py -q`
+
+  Expected: FAIL because the workflow-analysis, dependency-hygiene, and zizmor
+  files do not yet exist.
+
+- [x] **Step 3: Add the path-scoped workflow analysis**
+
+  Download the pinned actionlint archive with TLS-only curl, verify SHA-256
+  `8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8`,
+  run it over the workflow tree, then execute:
+
+  ```bash
+  uvx --from zizmor==1.29.0 zizmor --strict-collection --format=github .
+  ```
+
+- [x] **Step 4: Add monthly deptry and measured configuration**
+
+  Run deptry only on schedule/manual dispatch after locked synchronization:
+
+  ```bash
+  uv run --with deptry==0.25.1 deptry . --github-output
+  ```
+
+  Configure only the measured exclusions needed by the repository; do not add
+  blanket rule suppression.
+
+- [x] **Step 5: Add Dependabot cooldowns and the actionlint pre-commit hook**
+
+  Pin the actionlint hook to commit
+  `914e7df21a07ef503a81201c76d2b11c789d3fca` and add `default-days: 7`
+  cooldowns to both package ecosystems.
+
+- [x] **Step 6: Run the focused contract and confirm GREEN**
+
+  Run: `uv run pytest tests/test_quality_gate_contract.py -q`
+
+  Expected: PASS.
+
+### Task 3: Specialized workflow and release hardening
+
+**Files:**
+- Modify: `.github/workflows/dependency-review.yml`
+- Modify: `.github/workflows/parser-adversarial.yml`
+- Modify: `.github/workflows/scorecard.yml`
+- Modify: `.github/workflows/daily-metrics.yml`
+- Modify: `.github/workflows/pypi_publish.yml`
+- Modify: `tests/test_quality_gate_contract.py`
+
+**Interfaces:**
+- Consumes: existing dependency-review, adversarial, Scorecard, metrics, and release behavior.
+- Produces: pinned standard runners, explicit timeouts, locked environments, and credential-minimized checkouts without changing triggers or release ordering.
+
+- [x] **Step 1: Add failing hardening contract tests**
+
+  Assert that every job has `timeout-minutes`, every runner uses a pinned
+  standard image, all read-only checkouts set `persist-credentials: false`, the
+  metrics checkout explicitly retains credentials, adversarial sync is locked,
+  and release setup disables caches.
+
+- [x] **Step 2: Run the focused tests and confirm RED**
+
+  Run: `uv run pytest tests/test_quality_gate_contract.py -q`
+
+  Expected: FAIL on missing timeouts, moving runner labels, unlocked
+  adversarial synchronization, and release cache usage.
+
+- [x] **Step 3: Harden specialized workflows minimally**
+
+  Preserve all current events and permissions. Add only the approved runner,
+  timeout, lock, uv-version, and checkout-credential controls.
+
+- [x] **Step 4: Harden release without changing artifact identity**
+
+  Keep `pre-flight -> build -> publish -> github-release`, one `uv build`, three
+  checksum verifications, two GitHub attestations, and the same release bundle.
+  Add timeouts, pinned Ubuntu, credential-free read-only checkouts, and disabled
+  caches.
+
+- [x] **Step 5: Run the focused contract and confirm GREEN**
+
+  Run: `uv run pytest tests/test_quality_gate_contract.py -q`
+
+  Expected: PASS.
+
+### Task 4: Canonical CI documentation
+
+**Files:**
+- Create: `docs/CI_ASSURANCE.md`
+- Modify: `docs/README.md`
+- Modify: `docs/index.md`
+- Modify: `docs/maintained.toml`
+- Modify: `CONTRIBUTING.md`
+- Modify: `AGENTS.md`
+- Modify: `docs/CODEQL.md`
+- Modify: `docs/RELEASE_PROCESS.md`
+- Modify: `docs/quality/README.md`
+- Modify: `docs/log.md`
+- Modify: `tests/test_quality_gate_contract.py`
+
+**Interfaces:**
+- Consumes: final workflow names, triggers, job identifiers, and evidence boundaries.
+- Produces: one maintained CI assurance map linked from human, machine, contributor, maintainer, and agent entry points.
+
+- [x] **Step 1: Add a failing documentation contract test**
+
+  Require `docs/CI_ASSURANCE.md` to exist, be listed in `docs/maintained.toml`,
+  and be linked from `docs/README.md`, `docs/index.md`, `CONTRIBUTING.md`, and
+  `AGENTS.md`.
+
+- [x] **Step 2: Run the documentation contract and confirm RED**
+
+  Run: `uv run pytest tests/test_quality_gate_contract.py -q`
+
+  Expected: FAIL because the canonical assurance document does not exist.
+
+- [x] **Step 3: Write the maintained assurance map**
+
+  Include frontmatter, pull-request jobs, scheduled workflows, settings-managed
+  security, release gates, contributor commands, maintainer ruleset guidance,
+  fork safety, cache policy, and an evidence table separating local, hosted,
+  settings, and publication claims.
+
+- [x] **Step 4: Reconcile focused documentation**
+
+  Link rather than duplicate. `CODEQL.md` remains the CodeQL authority,
+  `RELEASE_PROCESS.md` remains the release authority, and the metrics threat
+  model remains the self-mutating workflow authority.
+
+- [x] **Step 5: Run documentation and focused tests and confirm GREEN**
+
+  Run: `uv run pytest tests/test_quality_gate_contract.py tests/test_check_documentation.py -q`
+
+  Expected: PASS.
+
+### Task 5: Full source qualification and local checkpoint
+
+**Files:**
+- Review: all modified files
+
+**Interfaces:**
+- Consumes: Tasks 1-4.
+- Produces: a clean, locally committed branch ready for hosted validation.
+
+- [x] **Step 1: Run workflow-specific analyzers**
+
+  Run actionlint `1.7.12` with its verified archive, zizmor `1.29.0`,
+  and deptry `0.25.1`. Record exact exit codes.
+
+- [x] **Step 2: Run the full repository gate**
+
+  Run: `make all`
+
+  Expected: Ruff PASS, Mypy PASS, documentation PASS, 80% or higher coverage,
+  and all tests PASS.
+
+- [x] **Step 3: Run the complete package contract**
+
+  Build wheel and sdist in a temporary directory, run
+  `scripts/check_wheel_contract.py`, Twine `6.2.0`, and strict downstream Mypy
+  against the installed wheel.
+
+- [x] **Step 4: Review diff and source state**
+
+  Run `git diff --check`, inspect `git diff --stat` and `git diff`, verify no
+  generated caches or private evidence are tracked, and confirm the exact base
+  and branch head.
+
+- [x] **Step 5: Commit the verified local checkpoint**
+
+  Stage only reviewed files and commit with:
+
+  ```text
+  ci: adopt native cross-platform GitHub assurance
+  ```
+
+- [x] **Step 6: Stop before external mutation**
+
+  Do not push, open a pull request, alter repository settings, update required
+  checks, tag, publish, or merge. Report which hosted and settings gates remain
+  unverified.
+
+## Execution record
+
+The isolated branch was qualified locally on 2026-08-30 before publication:
+
+- `make all`: PASS on Python 3.12; 786 tests passed with 91.20% coverage.
+- Complete test suite: PASS on Python 3.13; 786 tests passed with 91.20% coverage.
+- actionlint 1.7.12: PASS using the checksum-verified release archive.
+- zizmor 1.29.0: PASS with strict collection and no findings.
+- deptry 0.25.1: PASS with no dependency issues.
+- Hash-preserving dependency export and pip-audit: PASS with no known vulnerabilities.
+- Wheel contract, Twine 6.2.0, and downstream Mypy 1.20.2: PASS.
+- Luna final diff audit: the clean-runner blocker it found was corrected, release
+  dependency-audit scope was aligned with CI, and no remaining blocker was reported.
+
+Hosted Linux, macOS, and Windows execution, repository rulesets, GitHub default
+CodeQL, and publication remain explicitly unverified until the branch is pushed
+and reviewed through GitHub.

--- a/docs/superpowers/specs/2026-08-30-native-github-actions-design.md
+++ b/docs/superpowers/specs/2026-08-30-native-github-actions-design.md
@@ -1,0 +1,148 @@
+# Native GitHub Actions Assurance Design
+
+## Status
+
+Approved by the maintainer on 2026-08-30.
+
+## Objective
+
+Make standard GitHub-hosted Actions the repository's complete continuous
+integration and release assurance surface. The design must remain readable to
+contributors, reproducible from `uv.lock`, secure for pull requests from forks,
+and explicit about which checks run on pull requests, schedules, and tags.
+
+## Baseline
+
+The approved implementation starts from `origin/main` commit
+`044b81d0b0ed869ac5213d4a79e10949b9930633`. That source already provides:
+
+- Python 3.12 and 3.13 testing on Linux;
+- a wheel and source-distribution contract;
+- pull-request dependency review;
+- weekly parser adversarial assurance;
+- OpenSSF Scorecard publication;
+- a sequential PyPI and GitHub Release workflow with OIDC, SBOMs, checksums,
+  provenance attestations, and immutable artifact reuse.
+
+The baseline gaps are duplicated quality work across the Python matrix,
+unlocked dependency synchronization in development workflows, incomplete job
+timeouts, Linux-only runtime testing despite an OS-independent package claim,
+and no committed workflow-semantic/security analysis or dependency-declaration
+hygiene workflow.
+
+## Architecture
+
+### Pull-request and main CI
+
+`.github/workflows/ci.yml` is the primary required workflow and exposes four
+independent job families:
+
+1. `quality` runs Ruff, Mypy, documentation validation, repository policy
+   checks, and the clean-checkout assertion once on Python 3.12/Linux.
+2. `tests` runs the complete Pytest suite on Python 3.12 and 3.13 across pinned
+   standard Linux, macOS, and Windows runner images.
+3. `dependency-audit` audits the locked base and optional production
+   dependency set once on Python 3.12/Linux.
+4. `package-contract` builds the wheel and source distribution once, validates
+   wheel metadata and PEP 561, runs Twine metadata validation, and type-checks a
+   downstream consumer installed from the wheel.
+
+Every job has a timeout, read-only permissions, immutable action pins,
+credential-free checkout, a pinned `uv` version, and `uv sync --locked` where a
+project environment is required. Pull requests may restore caches only within
+GitHub's event-scoped cache boundary; release jobs do not use dependency
+caches.
+
+### Cross-platform test portability
+
+The tests must not require GNU Make merely to inspect the Makefile contract.
+The quality-contract test reads the repository's deliberately small Makefile
+syntax directly, expands reachable prerequisites in deterministic depth-first
+order, and fails closed on unsupported or ambiguous declarations. This keeps
+the same assertions executable on Windows without weakening the Makefile
+contract.
+
+### Workflow and dependency hygiene
+
+`.github/workflows/workflow-analysis.yml` runs only when automation-related
+files change. It validates workflow semantics with a checksum-verified pinned
+actionlint archive and audits workflow security with a pinned zizmor release.
+It has no secrets and no write permission.
+
+`.github/workflows/dependency-hygiene.yml` runs monthly and on manual dispatch.
+It checks declared dependencies with a pinned deptry release against the locked
+environment. It is diagnostic maintenance assurance, not a required
+pull-request check.
+
+Dependabot retains weekly Python and GitHub Actions updates and adds a
+seven-day cooldown for routine version updates. Security updates remain
+governed by GitHub's security-update setting.
+
+### Existing specialized workflows
+
+- Dependency Review remains pull-request-only and blocks newly introduced
+  moderate-or-higher vulnerabilities.
+- Parser Adversarial Laboratory remains scheduled/manual and uses locked
+  dependencies.
+- Scorecard remains scheduled and default-branch scoped.
+- Daily Metrics remains the only workflow that intentionally persists checkout
+  credentials and writes to `main`; its existing threat model remains
+  authoritative.
+- CodeQL remains GitHub default setup. No advanced `codeql.yml` is added.
+
+### Release
+
+The release graph remains sequential: exact-tag pre-flight, one immutable
+build, checksums and supply-chain evidence, GitHub attestations, PyPI Trusted
+Publishing, then GitHub Release publication from the same downloaded bundle.
+The change pins standard runner images, disables checkout credential
+persistence in read-only release jobs, disables dependency caches, and adds
+bounded timeouts without changing artifact identity or publication order.
+
+## Security boundaries
+
+- Never use `pull_request_target` for code execution.
+- Keep workflow-level permissions read-only and grant write permissions only to
+  the exact release, SARIF, attestation, or metrics job that needs them.
+- Pin every external action to a full 40-character commit SHA.
+- Do not expose repository secrets to pull-request jobs.
+- Do not cache credentials, tokens, build artifacts, or mutable source trees.
+- Treat hosted green checks as evidence only for the exact commit and runner
+  matrix that produced them.
+
+## Documentation
+
+Create `docs/CI_ASSURANCE.md` as the canonical human and AI map of pull-request,
+scheduled, settings-managed, and release assurance. Link it from the human and
+machine documentation indexes, the contributor guide, and the agent
+orientation. Keep `docs/CODEQL.md`, `docs/RELEASE_PROCESS.md`, and the daily
+metrics threat model as focused authorities for their respective subsystems.
+
+## Verification and completion
+
+Local source qualification requires:
+
+```text
+uv sync --locked --all-extras
+make all
+make vendor-name-check
+actionlint over every workflow
+zizmor offline workflow audit
+deptry declaration audit
+wheel/sdist build, wheel contract, Twine check, and downstream Mypy check
+clean Git status
+```
+
+Local qualification does not prove Windows, Linux, hosted CodeQL, repository
+settings, or release publication. After a pull request is opened, all hosted
+matrix and security checks must pass on its exact head before ruleset changes or
+merge. CodeQL default setup, secret scanning, push protection, and required
+checks must be verified live through GitHub settings after authentication.
+
+## Explicit non-goals
+
+- No self-hosted or larger runners.
+- No custom CodeQL advanced workflow.
+- No release tag or package publication.
+- No reduction of the 80% coverage floor.
+- No changes to parser, graph, writer, or public API behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,9 @@ ignore = ["E501"]
 "src/logseq_matryca_parser/kinetic.py" = ["B008", "E402"]
 "src/logseq_matryca_parser/kinetic_commands.py" = ["B008"]
 "tests/**" = ["SIM117"]
+
+[tool.deptry]
+extend_exclude = ["legacy"]
+
+[tool.deptry.per_rule_ignores]
+DEP004 = ["logseq_matryca_parser"]

--- a/src/logseq_matryca_parser/kinetic_commands.py
+++ b/src/logseq_matryca_parser/kinetic_commands.py
@@ -65,8 +65,8 @@ def _build_stats_table(pages: list[LogseqPage]) -> Table:
 def _build_broken_references_table(diagnostics: list[Diagnostic]) -> Table:
     table = Table(title="Broken Block References")
     table.add_column("Page", style="cyan")
-    table.add_column("Block UUID", style="magenta")
-    table.add_column("Missing Block Ref", style="bold red")
+    table.add_column("Block UUID", style="magenta", overflow="fold")
+    table.add_column("Missing Block Ref", style="bold red", overflow="fold")
 
     for diagnostic in diagnostics:
         table.add_row(

--- a/src/logseq_matryca_parser/local_graph_assurance.py
+++ b/src/logseq_matryca_parser/local_graph_assurance.py
@@ -199,7 +199,7 @@ def _read_regular_file(root: Path, path: Path, max_bytes: int) -> bytes | None:
         resolved = path.resolve(strict=True)
         resolved.relative_to(root)
         before = resolved.stat()
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
         descriptor = os.open(resolved, flags)
     except (OSError, RuntimeError, ValueError):
         return None

--- a/tests/test_kinetic.py
+++ b/tests/test_kinetic.py
@@ -100,7 +100,9 @@ def test_scan_command_reports_broken_refs(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "Broken Block References" in result.output
-    assert "((00000000-0000-0000-0000-00000" in result.output
+    assert f"(({fake_uuid[:23]}" in result.output
+    assert f"{fake_uuid[-6:]}))" in result.output
+    assert "…" not in result.output
 
 
 def test_scan_command_reports_machine_readable_diagnostics(tmp_path: Path) -> None:

--- a/tests/test_local_graph_assurance.py
+++ b/tests/test_local_graph_assurance.py
@@ -174,15 +174,21 @@ def test_guarded_read_requests_binary_mode_when_the_platform_supports_it(
     root = _vault(tmp_path)
     path = root / "pages" / "entry.md"
     path.write_bytes(b"- safe\r\n")
-    binary_flag = 1 << 29
+    binary_marker = 1 << 29
+    platform_binary_flag = getattr(local_graph_assurance.os, "O_BINARY", 0)
     real_open = local_graph_assurance.os.open
 
     def require_binary_mode(candidate: Path, flags: int) -> int:
-        if not flags & binary_flag:
+        if not flags & binary_marker:
             raise OSError("text-mode descriptor rejected")
-        return real_open(candidate, flags & ~binary_flag)
+        return real_open(candidate, flags & ~binary_marker)
 
-    monkeypatch.setattr(local_graph_assurance.os, "O_BINARY", binary_flag, raising=False)
+    monkeypatch.setattr(
+        local_graph_assurance.os,
+        "O_BINARY",
+        platform_binary_flag | binary_marker,
+        raising=False,
+    )
     monkeypatch.setattr(local_graph_assurance.os, "open", require_binary_mode)
 
     assert local_graph_assurance._read_regular_file(root, path, 100) == b"- safe\r\n"

--- a/tests/test_local_graph_assurance.py
+++ b/tests/test_local_graph_assurance.py
@@ -43,7 +43,7 @@ def test_self_test_uses_the_isolated_worker_and_returns_only_safe_aggregates() -
     report = run_local_graph_assurance_self_test()
     encoded = json.dumps(report, sort_keys=True)
 
-    assert report["status"] == "passed"
+    assert report["status"] == "passed", report
     assert set(report) == {"schema_version", "status", "limits", "observed", "findings", "runtime"}
     assert "Alpha" not in encoded
     assert "11111111-1111-1111-1111-111111111111" not in encoded
@@ -361,8 +361,8 @@ def test_assurance_enforces_max_file_bytes_during_traversal(tmp_path: Path) -> N
 
 def test_assurance_enforces_max_total_bytes_during_traversal(tmp_path: Path) -> None:
     root = _vault(tmp_path)
-    (root / "pages" / "One.md").write_text("- one\n", encoding="utf-8")
-    (root / "pages" / "Two.md").write_text("- two\n", encoding="utf-8")
+    (root / "pages" / "One.md").write_bytes(b"- one\n")
+    (root / "pages" / "Two.md").write_bytes(b"- two\n")
 
     report = run_local_graph_assurance(root, AssuranceLimits(max_total_bytes=7, max_file_bytes=6))
 
@@ -573,7 +573,8 @@ def test_runner_handles_no_report_and_invalid_report_with_cleanup(
     assert process.started
     assert process.joined == [AssuranceLimits().timeout_seconds]
     assert context.process_target is local_graph_assurance._worker
-    assert context.process_args is not None and context.process_args[0] == "/vault"
+    assert context.process_args is not None
+    assert context.process_args[0] == str(Path("/vault").expanduser())
     assert result_queue.closed and result_queue.joined
 
 

--- a/tests/test_local_graph_assurance.py
+++ b/tests/test_local_graph_assurance.py
@@ -168,6 +168,26 @@ def test_guarded_read_rejects_unsafe_or_unreadable_files(
     assert local_graph_assurance._read_regular_file(root, path, 100) is None
 
 
+def test_guarded_read_requests_binary_mode_when_the_platform_supports_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _vault(tmp_path)
+    path = root / "pages" / "entry.md"
+    path.write_bytes(b"- safe\r\n")
+    binary_flag = 1 << 29
+    real_open = local_graph_assurance.os.open
+
+    def require_binary_mode(candidate: Path, flags: int) -> int:
+        if not flags & binary_flag:
+            raise OSError("text-mode descriptor rejected")
+        return real_open(candidate, flags & ~binary_flag)
+
+    monkeypatch.setattr(local_graph_assurance.os, "O_BINARY", binary_flag, raising=False)
+    monkeypatch.setattr(local_graph_assurance.os, "open", require_binary_mode)
+
+    assert local_graph_assurance._read_regular_file(root, path, 100) == b"- safe\r\n"
+
+
 def test_guarded_read_rejects_descriptor_identity_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = _vault(tmp_path)
     path = root / "pages" / "entry.md"

--- a/tests/test_quality_gate_contract.py
+++ b/tests/test_quality_gate_contract.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import re
-import subprocess
 import tomllib
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -32,31 +33,132 @@ def test_nltk_lock_uses_a_patched_registry_release() -> None:
     assert tuple(int(part) for part in nltk["version"].split(".")) >= (3, 10, 3)
 
 
-def _dry_run(target: str) -> list[str]:
-    result = subprocess.run(
-        ["make", "--no-print-directory", "--dry-run", target],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
+class MakefileContractError(AssertionError):
+    """Stable diagnostics for the deliberately small supported Makefile syntax."""
+
+
+_TARGET_NAME = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _read_makefile_recipes(target: str, makefile: Path = ROOT / "Makefile") -> list[str]:
+    entries: dict[str, tuple[list[str], list[str]]] = {}
+    continuation_targets: set[str] = set()
+    current: tuple[list[str], list[str]] | None = None
+
+    for line_number, raw_line in enumerate(makefile.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        if raw_line.startswith("\t"):
+            if current is None:
+                raise MakefileContractError(f"orphan-recipe:{line_number}")
+            if raw_line.rstrip().endswith("\\"):
+                continuation_targets.update(
+                    name for name, entry in entries.items() if entry is current
+                )
+                continue
+            recipe = raw_line[1:].strip()
+            if recipe:
+                current[1].append(recipe)
+            continue
+        if ":" not in raw_line:
+            raise MakefileContractError(f"unsupported-syntax:{line_number}")
+
+        name, prerequisite_text = raw_line.split(":", 1)
+        name = name.strip()
+        prerequisites = prerequisite_text.split()
+        if not _TARGET_NAME.fullmatch(name) or any(
+            not _TARGET_NAME.fullmatch(item) for item in prerequisites
+        ):
+            raise MakefileContractError(f"invalid-declaration:{line_number}")
+        if name == ".PHONY":
+            current = None
+            continue
+        if name in entries:
+            raise MakefileContractError(f"duplicate-target:{name}")
+        current = (prerequisites, [])
+        entries[name] = current
+
+    if not _TARGET_NAME.fullmatch(target):
+        raise MakefileContractError("invalid-requested-target")
+    if target not in entries:
+        raise MakefileContractError("unknown-target")
+
+    expanded: set[str] = set()
+    visiting: set[str] = set()
+    commands: list[str] = []
+
+    def visit(name: str) -> None:
+        if name in visiting:
+            raise MakefileContractError("dependency-cycle")
+        if name in expanded:
+            return
+        if name not in entries:
+            raise MakefileContractError("unresolved-prerequisite")
+        if name in continuation_targets:
+            raise MakefileContractError("unsupported-continuation")
+        visiting.add(name)
+        prerequisites, recipes = entries[name]
+        for prerequisite in prerequisites:
+            visit(prerequisite)
+        visiting.remove(name)
+        expanded.add(name)
+        commands.extend(recipes)
+
+    visit(target)
+    if not commands:
+        raise MakefileContractError("empty-closure")
+    return commands
+
+
+def test_structural_reader_preserves_depth_first_recipe_order(tmp_path: Path) -> None:
+    makefile = tmp_path / "Makefile"
+    makefile.write_text(
+        "all: first second\n\tprintf aggregate\n"
+        "first:\n\tprintf first\n"
+        "second:\n\tprintf second\n",
+        encoding="utf-8",
     )
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    assert _read_makefile_recipes("all", makefile) == [
+        "printf first",
+        "printf second",
+        "printf aggregate",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("text", "message"),
+    [
+        ("all: missing\n", "unresolved-prerequisite"),
+        ("all: loop\nloop: all\n", "dependency-cycle"),
+        ("all:\n\tprintf first \\\n\tprintf second\n", "unsupported-continuation"),
+        ("all:\nall:\n\tprintf duplicate\n", "duplicate-target:all"),
+    ],
+)
+def test_structural_reader_fails_closed_on_ambiguous_syntax(
+    tmp_path: Path, text: str, message: str
+) -> None:
+    makefile = tmp_path / "Makefile"
+    makefile.write_text(text, encoding="utf-8")
+
+    with pytest.raises(MakefileContractError, match=re.escape(message)):
+        _read_makefile_recipes("all", makefile)
 
 
 def test_lint_targets_separate_verification_from_rewrites() -> None:
-    assert _dry_run("lint") == ["uv run ruff check ."]
-    assert _dry_run("lint-fix") == ["uv run ruff check . --fix"]
+    assert _read_makefile_recipes("lint") == ["uv run ruff check ."]
+    assert _read_makefile_recipes("lint-fix") == ["uv run ruff check . --fix"]
 
 
 def test_all_uses_only_non_mutating_ruff_targets() -> None:
-    commands = _dry_run("all")
+    commands = _read_makefile_recipes("all")
 
     assert "uv run ruff check ." in commands
     assert "uv run ruff check . --fix" not in commands
 
 
 def test_check_type_checks_compatibility_snapshot_generator() -> None:
-    commands = _dry_run("check")
+    commands = _read_makefile_recipes("check")
 
     mypy_command = next(command for command in commands if command.startswith("uv run mypy "))
     assert "scripts/update_compat_snapshots.py" in mypy_command
@@ -168,3 +270,220 @@ def test_daily_metrics_write_job_is_main_only() -> None:
     assert "git push origin HEAD:main" in workflow
     assert "pull_request" not in workflow
     assert "pull_request_target" not in workflow
+
+
+def test_ci_uses_locked_cross_platform_native_actions_jobs() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    for job in ("quality", "tests", "dependency-audit", "package-contract"):
+        assert f"\n  {job}:\n" in workflow
+    for runner in ("ubuntu-24.04", "macos-15", "windows-2025"):
+        assert runner in workflow
+    assert '["3.12", "3.13"]' in workflow
+    assert workflow.count("uv sync --locked --all-extras") == 4
+    assert workflow.count("pip-audit") == 1
+    assert (
+        'uv run pip-audit --no-deps --disable-pip -r '
+        '"${{ runner.temp }}/requirements-audit.txt"'
+    ) in workflow
+    for flag in ("--all-extras", "--no-dev", "--no-emit-workspace"):
+        assert flag in workflow
+    assert "--no-hashes" not in workflow
+    assert "twine==6.2.0" in workflow
+    assert "mypy==1.20.2 dist-contract/*.whl" in workflow
+    assert workflow.count("persist-credentials: false") == 4
+    assert workflow.count("timeout-minutes:") == 4
+    assert "pull_request_target" not in workflow
+
+
+def test_ci_keeps_quality_checks_out_of_the_runtime_matrix() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    quality = workflow.split("\n  quality:\n", 1)[1].split("\n  tests:\n", 1)[0]
+    tests = workflow.split("\n  tests:\n", 1)[1].split("\n  dependency-audit:\n", 1)[0]
+
+    assert "run: make lint" in quality
+    assert "run: make check" in quality
+    assert "run: make docs-check" in quality
+    assert "run: make vendor-name-check" in quality
+    assert "run: make verify-clean" in quality
+    assert "make " not in tests
+    assert "uv run pytest" in tests
+    assert "--cov-fail-under=80" in tests
+
+
+def test_workflow_analysis_is_path_scoped_read_only_and_blocking() -> None:
+    workflow = (ROOT / ".github/workflows/workflow-analysis.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "pull_request:" in workflow
+    assert "push:" in workflow
+    assert 'branches: ["main"]' in workflow
+    assert workflow.count("paths:") == 2
+    assert "contents: read" in workflow
+    assert "persist-credentials: false" in workflow
+    assert "timeout-minutes: 5" in workflow
+    assert "actionlint_1.7.12_linux_amd64.tar.gz" in workflow
+    assert "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8" in workflow
+    assert 'run: |\n          "$RUNNER_TEMP/actionlint" -color' in workflow
+    assert "zizmor==1.29.0" in workflow
+    assert "--offline" not in workflow
+    assert "--strict-collection" in workflow
+    assert "--format=github" in workflow
+    assert "GH_TOKEN" not in workflow
+    assert "pull_request_target" not in workflow
+
+
+def test_dependency_hygiene_is_periodic_and_not_a_pull_request_gate() -> None:
+    workflow = (ROOT / ".github/workflows/dependency-hygiene.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "pull_request:" not in workflow
+    assert "push:" not in workflow
+    assert "contents: read" in workflow
+    assert "persist-credentials: false" in workflow
+    assert "runs-on: ubuntu-24.04" in workflow
+    assert "timeout-minutes: 5" in workflow
+    assert 'version: "0.11.7"' in workflow
+    assert "uv sync --locked --all-extras" in workflow
+    assert "deptry==0.25.1" in workflow
+    assert "uv run --with deptry==0.25.1 deptry . --github-output" in workflow
+
+
+def test_dependabot_delays_routine_version_updates() -> None:
+    config = (ROOT / ".github/dependabot.yml").read_text(encoding="utf-8")
+
+    assert config.count("cooldown:") == 2
+    assert config.count("default-days: 7") == 2
+
+
+def test_actionlint_pre_commit_hook_is_commit_pinned() -> None:
+    config = (ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+    assert "https://github.com/rhysd/actionlint" in config
+    assert "rev: 914e7df21a07ef503a81201c76d2b11c789d3fca" in config
+    assert "-   id: actionlint" in config
+
+
+def test_deptry_configuration_has_only_measured_scope_rules() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    deptry = pyproject["tool"]["deptry"]
+
+    assert deptry["extend_exclude"] == ["legacy"]
+    assert deptry["per_rule_ignores"] == {"DEP004": ["logseq_matryca_parser"]}
+    assert "ignore" not in deptry
+
+
+def test_zizmor_configuration_has_no_global_rule_disable() -> None:
+    config = (ROOT / "zizmor.yml").read_text(encoding="utf-8")
+
+    assert "disable: true" not in config
+    assert "dangerous-triggers" not in config
+
+
+@pytest.mark.parametrize(
+    "workflow_name",
+    [
+        "dependency-review.yml",
+        "parser-adversarial.yml",
+        "scorecard.yml",
+        "daily-metrics.yml",
+        "pypi_publish.yml",
+    ],
+)
+def test_specialized_workflows_pin_standard_runner_images(workflow_name: str) -> None:
+    workflow = (ROOT / ".github/workflows" / workflow_name).read_text(encoding="utf-8")
+
+    assert "ubuntu-latest" not in workflow
+    assert "runs-on: ubuntu-24.04" in workflow
+
+
+def test_specialized_workflows_bound_every_job() -> None:
+    expected_job_counts = {
+        "dependency-review.yml": 1,
+        "parser-adversarial.yml": 1,
+        "scorecard.yml": 1,
+        "daily-metrics.yml": 1,
+        "pypi_publish.yml": 4,
+    }
+
+    for name, count in expected_job_counts.items():
+        workflow = (ROOT / ".github/workflows" / name).read_text(encoding="utf-8")
+        assert workflow.count("timeout-minutes:") == count
+
+
+def test_specialized_read_only_checkouts_do_not_persist_credentials() -> None:
+    expected = {
+        "dependency-review.yml": 1,
+        "parser-adversarial.yml": 1,
+        "scorecard.yml": 1,
+        "pypi_publish.yml": 2,
+    }
+
+    for name, count in expected.items():
+        workflow = (ROOT / ".github/workflows" / name).read_text(encoding="utf-8")
+        assert workflow.count("persist-credentials: false") == count
+
+    metrics = (ROOT / ".github/workflows/daily-metrics.yml").read_text(encoding="utf-8")
+    assert "persist-credentials: true" in metrics
+
+
+def test_adversarial_workflow_uses_the_locked_environment() -> None:
+    workflow = (ROOT / ".github/workflows/parser-adversarial.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'version: "0.11.7"' in workflow
+    assert "uv sync --locked --all-extras" in workflow
+
+
+def test_release_disables_dependency_caches_and_preserves_order() -> None:
+    workflow = (ROOT / ".github/workflows/pypi_publish.yml").read_text(encoding="utf-8")
+
+    assert "enable-cache: true" not in workflow
+    assert workflow.count("enable-cache: false") == 2
+    assert "needs: pre-flight" in workflow
+    assert "needs: build" in workflow
+    assert "needs: publish" in workflow
+    assert "softprops/action-gh-release" not in workflow
+    assert "gh release create" in workflow
+    assert "--verify-tag" in workflow
+    assert "--notes-file release-bundle/RELEASE_NOTES.md" in workflow
+    assert "--no-hashes" not in workflow
+    assert "uv export --all-extras --no-dev --no-emit-workspace" in workflow
+    assert "pip-audit --no-deps --disable-pip" in workflow
+
+
+def test_ci_assurance_document_is_maintained_and_linked_from_entry_points() -> None:
+    assurance = ROOT / "docs/CI_ASSURANCE.md"
+    assert assurance.is_file()
+
+    text = assurance.read_text(encoding="utf-8")
+    for heading in (
+        "## Pull-request and main checks",
+        "## Scheduled and settings-managed assurance",
+        "## Release assurance",
+        "## Evidence boundaries",
+    ):
+        assert heading in text
+
+    maintained = (ROOT / "docs/maintained.toml").read_text(encoding="utf-8")
+    assert '"docs/CI_ASSURANCE.md"' in maintained
+    for path in ("docs/README.md", "docs/index.md", "CONTRIBUTING.md", "AGENTS.md"):
+        entry_point = (ROOT / path).read_text(encoding="utf-8")
+        expected = "CI_ASSURANCE.md" if path.startswith("docs/") else "docs/CI_ASSURANCE.md"
+        assert expected in entry_point
+
+
+def test_ci_assurance_document_keeps_hosted_claims_evidence_bounded() -> None:
+    text = (ROOT / "docs/CI_ASSURANCE.md").read_text(encoding="utf-8")
+
+    assert "Local PASS" in text
+    assert "Hosted PASS" in text
+    assert "Settings PASS" in text
+    assert "Publication PASS" in text
+    assert "pull_request_target" in text
+    assert "CodeQL default setup" in text

--- a/tests/test_writer_security.py
+++ b/tests/test_writer_security.py
@@ -122,8 +122,10 @@ def test_atomic_replace_preserves_permission_bits(tmp_path: Path) -> None:
     proposal = append_child_to_node(graph, target_uuid, "written")
 
     assert proposal.applied is True
-    assert stat.S_IMODE(page_path.stat().st_mode) == 0o640
-    assert (page_path.stat().st_uid, page_path.stat().st_gid) == original_owner
+    assert page_path.read_text(encoding="utf-8") == "- Parent\n  - written\n"
+    if os.name != "nt":
+        assert stat.S_IMODE(page_path.stat().st_mode) == 0o640
+        assert (page_path.stat().st_uid, page_path.stat().st_gid) == original_owner
 
 
 @pytest.mark.parametrize(

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,3 @@
+# Workflow security findings must be fixed or narrowly justified in review.
+# No rule is globally disabled.
+rules: {}


### PR DESCRIPTION
## Summary

- replace the previous primary CI shape with native, read-only GitHub Actions jobs for quality, tests, dependency auditing, and package contracts
- test Python 3.12 and 3.13 across Ubuntu 24.04, macOS 15, and Windows 2025
- add path-scoped actionlint and zizmor workflow analysis, monthly deptry hygiene, and Dependabot cooldowns
- harden specialized and release workflows with pinned runners, explicit timeouts, locked environments, minimal credentials, and aligned hash-preserving dependency audits
- add a maintained CI assurance guide plus the complete design, execution plan, and evidence boundaries
- fix Windows portability exposed by the new matrix: binary local-assurance reads, native path and permission expectations, newline-stable byte fixtures, and complete folded CLI identifiers

## Type of change

- [x] CI and supply-chain assurance
- [x] Documentation update
- [x] Runtime behavior change
- [ ] Breaking change

## Validation

- [x] `make all` passes on Python 3.12: 787 tests, 91.20% coverage
- [x] complete hosted suites pass on Python 3.12 and 3.13 across Ubuntu 24.04, macOS 15, and Windows 2025
- [x] all 15 PR checks pass, including CodeQL, dependency review, production dependency audit, quality, package contract, and workflow static analysis
- [x] actionlint 1.7.12 passes
- [x] zizmor 1.29.0 reports no findings
- [x] deptry 0.25.1 reports no dependency issues
- [x] pip-audit reports no known vulnerabilities
- [x] wheel contract, Twine 6.2.0, and downstream Mypy 1.20.2 pass
- [x] pre-commit hooks pass

## Evidence boundaries

Local validation and the hosted 15-check matrix are bound to commit `05ee6923155ea63dbee2e027585560c8c45eee5b`. The release-only publication and attestation path remains unexecuted until a maintainer starts a tagged release.

## AI assistance and data handling

- [x] Meaningful AI assistance was used; the maintainer reviewed the complete diff and remains responsible for the change.
- [x] No private vault data, credentials, tokens, or unpublished security details were included.
- [x] The change follows the repository AI-assisted contribution and documentation policies.