### PR TITLE
docs(cookbook): integrate corrected broken-ref and LENS recipes

### DIFF
--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -140,6 +140,21 @@ if broken:
 
 **CLI tip:** `matryca-parse scan /path/to/graph --broken-refs` prints a Rich table of unresolved refs and exits `1` for CI (since v1.5.0). For programmatic checks, use `graph.get_broken_references()` as above.
 
+Expected failure output has a `Broken Block References` table; its vault-specific
+rows vary, but its exit status is `1`:
+
+```console
+$ matryca-parse scan /path/to/graph --broken-refs
+                         Broken Block References
+┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Page   ┃ Block UUID               ┃ Missing Block Ref        ┃
+┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ ...    │ ...                      │ ((...))                  │
+└────────┴──────────────────────────┴──────────────────────────┘
+$ echo $?
+1
+```
+
 For stable machine-readable findings, use `collect_graph_diagnostics(graph)` or
 `matryca-parse scan /path/to/graph --diagnostics-json`. The JSON command emits
 only the diagnostic array, uses vault-relative paths, and exits `1` when an
@@ -166,7 +181,32 @@ permission and ownership metadata. See the
 
 ---
 
-## Recipe 6 — Contributor test patterns
+## Recipe 6 — Interactive graph visualization (LENS)
+
+Generate an interactive HTML visualization from the in-memory graph. This
+requires the optional `[viz]` extra (`uv sync --extra viz`); `[ai]` is not
+required.
+
+```python
+from pathlib import Path
+
+from logseq_matryca_parser.graph import LogseqGraph
+from logseq_matryca_parser.lens import GraphVisualizer
+
+vault = Path("/path/to/logseq/graph")
+output = Path("/path/to/visualization.html")
+
+graph = LogseqGraph.load_directory(vault)
+visualizer = GraphVisualizer(pages=list(graph.iter_canonical_pages()), graph=graph)
+visualizer.build_network()
+visualizer.export_html(output)
+```
+
+`export_html()` writes the HTML file but does not open it automatically.
+
+---
+
+## Recipe 7 — Contributor test patterns
 
 Pick a scoped task from [`GOOD_FIRST_ISSUES.md`](GOOD_FIRST_ISSUES.md) (wave 2: [#43](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/43)–[#52](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/52)), then mirror nearby tests:
 


### PR DESCRIPTION
## Description

Fixes #93.

This current-main replay integrates the useful work from #99 while addressing the maintainer review. The original contributor, Dodothereal, remains the commit author.

- documents the expected broken-reference table and exit status 1;
- adds one Path-based LENS visualization recipe;
- states that the viz extra is required and the ai extra is not;
- removes unsupported browser-opening and large-graph performance claims;
- preserves the current contributor recipe and current-suite wording.

## Type of change

- [x] Documentation update

## Validation

- Maintained documentation checker: pass
- Executable temporary-graph LENS smoke: pass
- Actual broken-reference CLI smoke: expected exit 1
- make all: 787 passed, 91.20% coverage
- diff check and pre-commit: pass

## AI assistance and data handling

- [x] AI assistance was used and the complete diff was reviewed by the maintainer.
- [x] No private vault data, credentials, or unpublished security details were used.
- [x] The change follows the repository AI-assisted contribution policy.

## Contract impact

- [x] Documentation now matches the implemented CLI and LENS behavior.
- [x] No runtime, API, GitHub setting, release provenance, or protocol-support claim is changed.
