### PR TITLE
fix(synapse): unify missing AI dependency guidance

### DIFF
--- a/src/logseq_matryca_parser/synapse.py
+++ b/src/logseq_matryca_parser/synapse.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 _PATH_JOIN = " > "
 _REFS_JOIN = ", "
+_MISSING_AI_EXPORT_DEPS_MSG = "Missing AI export dependencies. Install with: uv sync --extra ai"
 
 
 class SynapseMetadata(TypedDict, total=False):
@@ -289,7 +290,7 @@ class SynapseAdapter:
     def to_langchain_documents(nodes: list[LogseqNode], source_name: str) -> list[Any]:
         """Convert AST nodes to LangChain documents using `LangChainVisitor`."""
         if Document is None:
-            raise ImportError("LangChain was not detected. Install 'langchain-core' to use Synapse.")
+            raise ImportError(_MISSING_AI_EXPORT_DEPS_MSG)
         visitor = LangChainVisitor(source_name=source_name, document_cls=Document)
         for node in nodes:
             node.accept(visitor)
@@ -304,7 +305,7 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Convert AST nodes to LlamaIndex nodes preserving topology links."""
         if TextNode is None or NodeRelationship is None or RelatedNodeInfo is None:
-            raise ImportError("LlamaIndex was not detected. Install 'llama-index' to use Synapse.")
+            raise ImportError(_MISSING_AI_EXPORT_DEPS_MSG)
         flat = _flatten_nodes_for_export(nodes)
         unique_paths = {node.source_path for node in flat if node.source_path}
         use_per_node_source = len(unique_paths) > 1
@@ -341,7 +342,7 @@ class SynapseAdapter:
     ) -> list[Any]:
         """Flatten ``nodes`` and emit LangChain ``Document``s with breadcrumb-enriched ``page_content``."""
         if Document is None:
-            raise ImportError("LangChain was not detected. Install 'langchain-core' to use Synapse.")
+            raise ImportError(_MISSING_AI_EXPORT_DEPS_MSG)
         documents: list[Any] = []
         flat = _flatten_nodes_for_export(nodes)
         for node in flat:

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from re import escape
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -69,8 +70,9 @@ def build_ast() -> list[LogseqNode]:
 
 
 def test_to_langchain_documents_raises_when_dependency_missing() -> None:
+    expected = escape("Missing AI export dependencies. Install with: uv sync --extra ai")
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match="LangChain"):
+        with pytest.raises(ImportError, match=expected):
             SynapseAdapter.to_langchain_documents(build_ast(), source_name="test.md")
 
 
@@ -101,12 +103,13 @@ def test_to_langchain_documents_uses_visitor_and_graph_metadata() -> None:
 
 
 def test_to_llamaindex_nodes_raises_when_dependency_missing() -> None:
+    expected = escape("Missing AI export dependencies. Install with: uv sync --extra ai")
     with (
         patch("logseq_matryca_parser.synapse.TextNode", None),
         patch("logseq_matryca_parser.synapse.NodeRelationship", None),
         patch("logseq_matryca_parser.synapse.RelatedNodeInfo", None),
     ):
-        with pytest.raises(ImportError, match="LlamaIndex"):
+        with pytest.raises(ImportError, match=expected):
             SynapseAdapter.to_llamaindex_nodes(build_ast())
 
 
@@ -220,8 +223,9 @@ def test_to_llamaindex_nodes_wires_sibling_next_and_previous() -> None:
 
 
 def test_to_context_enriched_chunks_raises_when_dependency_missing(tmp_path: Path) -> None:
+    expected = escape("Missing AI export dependencies. Install with: uv sync --extra ai")
     with patch("logseq_matryca_parser.synapse.Document", None):
-        with pytest.raises(ImportError, match="LangChain"):
+        with pytest.raises(ImportError, match=expected):
             graph = LogseqGraph(graph_path=tmp_path, pages={})
             SynapseAdapter.to_context_enriched_chunks([], graph)
 


### PR DESCRIPTION
## Summary

- replay the useful intent of #84 on current `main`
- use one clear missing-AI-dependencies message in all three SYNAPSE export paths
- test the public error text independently with an exact escaped literal
- exclude the duplicate demo files and unrelated formatting churn from the original branch

## Attribution

This focused replacement preserves the original contribution by
@IshanikaAurelia1106 as the commit author.

Supersedes #84 after this replacement is merged.

## Verification

- RED before implementation: the three focused tests failed against the old messages
- focused SYNAPSE tests: 3 passed
- Ruff on modified files: passed
- pre-commit (`ruff`, `mypy`): passed
- `make all`: 787 passed, 91.20% coverage
- independent review: Spec PASS, Quality APPROVED
