### PR TITLE
fix(graph): accept string vault paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   receipt-routing experiment with SHA-pinned GitHub-hosted quality, packaging,
   dependency, CodeQL, Linux, macOS, and Windows checks. Local maintainer
   guidance now treats hosted Actions as the authoritative public CI path.
+- **Graph loader path-type acceptance** — `LogseqGraph.load_directory` accepts
+  `graph_path` as either `Path` or `str`, normalizes with
+  `Path(graph_path).expanduser().resolve()`, and preserves strict-mode defaults.
 
 ### Fixed
 

--- a/docs/reference/API_STABILITY.md
+++ b/docs/reference/API_STABILITY.md
@@ -52,7 +52,9 @@ graph entry points are regression-tested. Adding a new stable symbol requires
 updating this table and those tests in the same PR.
 
 `LogseqGraph.load_directory` accepts keyword-only `strict_refs=False` and
-`strict_title_collisions=False`. Both strict modes are opt-in, preserving the
+`strict_title_collisions=False`. It also accepts `graph_path` as `Path` or `str`;
+the loader normalizes a textual path with `Path(graph_path).expanduser().resolve()`.
+Both strict modes are opt-in, preserving the
 permissive default.
 
 Diagnostic code compatibility, serialization, and path-safety rules are defined

--- a/src/logseq_matryca_parser/graph.py
+++ b/src/logseq_matryca_parser/graph.py
@@ -814,7 +814,7 @@ class LogseqGraph(BaseModel):
     @classmethod
     def load_directory(
         cls,
-        graph_path: Path,
+        graph_path: Path | str,
         *,
         strict_refs: bool = False,
         strict_title_collisions: bool = False,
@@ -826,7 +826,7 @@ class LogseqGraph(BaseModel):
         When ``strict_title_collisions`` is True, raise :class:`PageTitleCollisionError` instead
         of accepting the historical deterministic winner for an ambiguous title or alias.
         """
-        resolved = graph_path.expanduser().resolve()
+        resolved = Path(graph_path).expanduser().resolve()
         files = discover_graph_files(resolved)
         source_pages: dict[str, LogseqPage] = {}
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -31,6 +31,23 @@ def test_load_directory_empty_graph(tmp_path: Path) -> None:
     assert graph.get_node_by_uuid("nonexistent") is None
 
 
+def test_load_directory_accepts_string_graph_path(tmp_path: Path) -> None:
+    """A textual graph path is accepted and normalized to the same resolved graph."""
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    graph_root.mkdir()
+    pages.mkdir()
+    (pages / "Alpha.md").write_text("- Root alpha\n", encoding="utf-8")
+
+    graph_from_path = LogseqGraph.load_directory(graph_root)
+    graph_from_string = LogseqGraph.load_directory(str(graph_root))
+
+    assert graph_from_string.graph_path == graph_root.resolve()
+    assert graph_from_string.pages == graph_from_path.pages
+    assert graph_from_string.get_nodes_by_tag("shared") == []
+    assert graph_from_string.get_nodes_by_tag("project-x") == []
+
+
 def test_load_directory_bulk_parse_and_uuid_lookup(tmp_path: Path) -> None:
     """Multiple pages are indexed and nodes are reachable by synthetic UUID."""
     graph_root = tmp_path / "vault"

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import inspect
 from importlib.resources import files
+from pathlib import Path
+from typing import get_type_hints
 
 import logseq_matryca_parser as package
 
@@ -88,3 +90,7 @@ def test_stable_graph_loader_signature() -> None:
         is inspect.Parameter.KEYWORD_ONLY
     )
     assert signature.parameters["strict_title_collisions"].default is False
+    assert signature.parameters["graph_path"].annotation == "Path | str"
+    assert get_type_hints(package.LogseqGraph.load_directory).get("graph_path") == (
+        Path | str
+    )

--- a/tests/typing_samples/public_api.py
+++ b/tests/typing_samples/public_api.py
@@ -6,7 +6,10 @@ from logseq_matryca_parser import LogseqGraph, LogseqPage, StackMachineParser
 
 parser: StackMachineParser = StackMachineParser()
 page: LogseqPage = parser.parse("- typed block", page_title="Typed")
-graph: LogseqGraph = LogseqGraph.load_directory(Path("/tmp/example"), strict_refs=False)
+graph_path: Path = Path("/tmp/example")
+graph: LogseqGraph = LogseqGraph.load_directory(graph_path, strict_refs=False)
+graph_from_string: LogseqGraph = LogseqGraph.load_directory(str(graph_path), strict_refs=False)
 
 assert page.title == "Typed"
 assert isinstance(graph, LogseqGraph)
+assert isinstance(graph_from_string, LogseqGraph)


### PR DESCRIPTION
## Summary

- replace stale and conflicting #193 with a focused current-main change
- accept both `Path` and `str` at `LogseqGraph.load_directory`
- normalize once at the public boundary and preserve all downstream `Path` behavior
- add runtime equivalence, stable-signature, and built-wheel typing coverage
- update the stable API contract and unreleased changelog

## Scope boundary

This replacement deliberately excludes the CCP configuration, static-analysis
bootstrap/workflows, broad quality changes, unrelated parser changes, and
restart artifacts present in #193.

Supersedes #193 after this replacement is merged.

## Verification

- impact analysis: explicitly approved CRITICAL hub; 10 direct callers, 12 affected symbols, 8 flows
- post-change import cycles: 0
- focused graph/API tests: 51 passed
- typing sample: passed
- Ruff, pre-commit, documentation, vendor-name check: passed
- `make all`: 788 passed, 91.20% coverage
- independent review: Spec PASS, Quality APPROVED
