### PR TITLE
chore: release 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-08-30
+
 ### Changed
 
 - **Native cross-platform GitHub assurance** — replace the public-repository
   receipt-routing experiment with SHA-pinned GitHub-hosted quality, packaging,
   dependency, CodeQL, Linux, macOS, and Windows checks. Local maintainer
-  guidance now treats hosted Actions as the authoritative public CI path.
+  guidance now treats hosted Actions as the authoritative public CI path (#194).
+- **Cookbook guidance** — add corrected broken-block-reference and LENS
+  visualization recipes, including their CLI outcome and optional dependency
+  boundaries (#195).
 - **Graph loader path-type acceptance** — `LogseqGraph.load_directory` accepts
   `graph_path` as either `Path` or `str`, normalizes with
-  `Path(graph_path).expanduser().resolve()`, and preserves strict-mode defaults.
+  `Path(graph_path).expanduser().resolve()`, and preserves strict-mode defaults
+  (#197).
 
 ### Fixed
 
@@ -23,7 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mode so CRLF files retain their measured byte length, use platform-neutral
   byte and path fixtures, preserve POSIX permission assertions only where the
   operating system provides those semantics, and fold CLI diagnostic
-  identifiers instead of replacing their final characters with an ellipsis.
+  identifiers instead of replacing their final characters with an ellipsis
+  (#194).
+- **Optional AI dependency guidance** — use one consistent message when AI
+  export dependencies are unavailable: `uv sync --extra ai` (#196).
 
 ## [1.8.1] - 2026-08-25
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ User-facing behavior is documented in:
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — LOGOS, SYNAPSE, `LogseqGraph`, agents, and data flow
 - [`docs/internal/LOCAL_CODE_STUDY.md`](docs/internal/LOCAL_CODE_STUDY.md) — maintainer local code audit runbook (not for public issues/CHANGELOG)
 - [`docs/logseq_ast_primer.md`](docs/logseq_ast_primer.md) — Logseq Spatial Markdown domain rules
-- [`CHANGELOG.md`](CHANGELOG.md) — shipped releases (current: **1.8.1**) and **Unreleased** changes (Keep a Changelog)
+- [`CHANGELOG.md`](CHANGELOG.md) — release candidate **1.8.2**, latest published release **1.8.1**, and **Unreleased** changes (Keep a Changelog)
 - [`docs/RELEASE_PROCESS.md`](docs/RELEASE_PROCESS.md) — version bump, tag, and PyPI publish checklist
 - [`docs/CI_ASSURANCE.md`](docs/CI_ASSURANCE.md) — pull-request, scheduled, settings-managed, and release checks
 - [`docs/CODEQL.md`](docs/CODEQL.md) — CodeQL default setup (no custom `codeql.yml`)

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Read the complete [release highlights](RELEASE_HIGHLIGHTS.md), the exhaustive
 [changelog](CHANGELOG.md), or the signed artifacts on
 [GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
 
+- **v1.8.2 (release candidate)** — Adds SHA-pinned hosted assurance, portable Windows local assurance, corrected cookbook recipes, consistent optional-AI guidance, and `Path | str` graph loading.
 - **v1.8.1** — Hardened deep-outline parsing, coherent incremental graph mutations, bounded assurance cleanup, and stable provenance for optional NLTK.
 - **v1.8.0** — Added bounded privacy-safe local graph assurance, source-location contracts, and the first internal parser line-classification phase.
 - **v1.7.1** — Added the runnable offline SYNAPSE RAG example and tightened release-note and optional-dependency security checks.

--- a/RELEASE_HIGHLIGHTS.md
+++ b/RELEASE_HIGHLIGHTS.md
@@ -5,6 +5,21 @@ For the exhaustive change history, see the [changelog](CHANGELOG.md). For
 published artifacts and attestations, see
 [GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
 
+## v1.8.2 (release candidate)
+
+Release candidate — strengthens the hosted assurance boundary, clarifies
+integration guidance, and makes the graph loader easier to call. **No
+intentional breaking changes** to stable package imports or CLI behavior. The
+v1.8.2 tag, PyPI publication, GitHub Release, hashes, and attestations remain
+pending the release workflow.
+
+| Area | Change |
+| :--- | :--- |
+| **Hosted assurance** | Native GitHub-hosted quality, package, dependency, CodeQL, Linux, macOS, and Windows checks use reviewed SHA-pinned actions; Windows local-assurance inputs and fixtures are portable. |
+| **Cookbook and LENS** | Corrected broken-block-reference and graph-visualization recipes show the expected CLI result, `Path` usage, and optional dependency boundary. |
+| **Optional AI guidance** | Missing AI export dependencies now consistently direct users to `uv sync --extra ai`. |
+| **Graph API** | `LogseqGraph.load_directory` accepts either `Path` or `str` while preserving existing strict-mode defaults. |
+
 ## v1.8.1
 
 Patch release — hardens deep-outline parsing, coherent incremental graph

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,12 @@
 
 ## Supported Versions
 
-Security fixes are provided **only for the latest released version** on [PyPI](https://pypi.org/project/logseq-matryca-parser/).
+Security fixes are provided **only for the latest released version** on [PyPI](https://pypi.org/project/logseq-matryca-parser/). Until the v1.8.2 tag workflow completes, that version remains v1.8.1.
 
 | Version | Supported |
 | ------- | --------- |
-| **1.8.1** (latest) | Yes |
+| 1.8.2 (release candidate; not published) | Pending publication |
+| **1.8.1** (latest released) | Yes |
 | 1.8.0 and older | No |
 
 We recommend always running the current release and upgrading promptly when a security advisory is published.

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -8,9 +8,9 @@ audience: contributors
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-24
-verified: 2026-08-24
-stale_after: 2027-02-17
+last_verified: 2026-08-30
+verified: 2026-08-30
+stale_after: 2027-02-26
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
 supersedes: null
@@ -19,7 +19,7 @@ superseded_by: null
 
 # Clean Code & Clean Architecture — Logseq Matryca Parser
 
-**Version:** documents **v1.8.1** maintainer contracts (v1 structural backlog complete; parser, graph-coherence, and local-assurance slices merged)
+**Version:** documents **v1.8.2** maintainer contracts (v1 structural backlog complete; parser, graph-coherence, and local-assurance slices merged)
 **Audience:** contributors and Cursor agents patching `src/logseq_matryca_parser/`  
 **Companion:** [`ARCHITECTURE.md`](ARCHITECTURE.md) (LOGOS domain contract) · [`BUG_HUNT_REPORT.md`](BUG_HUNT_REPORT.md) (audit evidence) · [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -19,6 +19,17 @@ superseded_by: null
 
 # Documentation evolution log
 
+## 2026-08-30 — v1.8.2 release candidate
+
+- Prepared the v1.8.2 release candidate from
+  `main@e836f82b09784baf909bc3ec233bed06fa055fc7`, incorporating #194
+  (`347ee7a5e9b4a667a39c16699fa4fe868a8adfa2`), #195
+  (`7329c182f3df16fcba98328a33a4de7aadaad861`), #196
+  (`3e3c9f0cf9cee29c46a94343ff7f4c66a2623d5b`), and #197
+  (`e836f82b09784baf909bc3ec233bed06fa055fc7`).
+- Reconciled the version source, changelog, release history, reader highlights, security support status, contributor guidance, and maintained Clean Architecture metadata without rewriting historical release records.
+- The v1.8.2 tag, PyPI publication, GitHub Release, public hashes, and attestations are pending the ordered tag workflow. A post-publication entry must record the exact public evidence after that workflow succeeds.
+
 ## 2026-08-30
 
 - Added the maintained

--- a/src/logseq_matryca_parser/_version.py
+++ b/src/logseq_matryca_parser/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the distribution version."""
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"

--- a/tests/test_check_wheel_contract.py
+++ b/tests/test_check_wheel_contract.py
@@ -32,7 +32,7 @@ def _wheel(
 
 
 def test_source_version_reads_lightweight_version_module() -> None:
-    assert source_version() == "1.8.1"
+    assert source_version() == "1.8.2"
 
 
 def test_valid_wheel_contract(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- prepare version 1.8.2 from the verified #194–#197 changes
- harmonize the changelog, release highlights, security support table, contributor guidance, architecture metadata, and documentation log
- update the release-version contract fixture

## Local qualification

- `make all`: 788 tests passed, 91% statement coverage
- `make vendor-name-check`: passed
- release contract and release-note extraction: passed
- fresh wheel and sdist build: passed
- wheel contract and Twine 6.2.0: passed
- CycloneDX SBOM and dependency-license inventory: passed
- SHA-256 generation and verification: passed
- independent review: Spec PASS / Quality APPROVED

## Publication boundary

This pull request prepares the release candidate only. The v1.8.2 tag, PyPI publication, GitHub Release, public checksums, and attestations remain pending the release workflow after merge.
