### PR TITLE
docs: record v1.8.2 publication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ User-facing behavior is documented in:
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — LOGOS, SYNAPSE, `LogseqGraph`, agents, and data flow
 - [`docs/internal/LOCAL_CODE_STUDY.md`](docs/internal/LOCAL_CODE_STUDY.md) — maintainer local code audit runbook (not for public issues/CHANGELOG)
 - [`docs/logseq_ast_primer.md`](docs/logseq_ast_primer.md) — Logseq Spatial Markdown domain rules
-- [`CHANGELOG.md`](CHANGELOG.md) — release candidate **1.8.2**, latest published release **1.8.1**, and **Unreleased** changes (Keep a Changelog)
+- [`CHANGELOG.md`](CHANGELOG.md) — latest release **1.8.2** and **Unreleased** changes (Keep a Changelog)
 - [`docs/RELEASE_PROCESS.md`](docs/RELEASE_PROCESS.md) — version bump, tag, and PyPI publish checklist
 - [`docs/CI_ASSURANCE.md`](docs/CI_ASSURANCE.md) — pull-request, scheduled, settings-managed, and release checks
 - [`docs/CODEQL.md`](docs/CODEQL.md) — CodeQL default setup (no custom `codeql.yml`)

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Read the complete [release highlights](RELEASE_HIGHLIGHTS.md), the exhaustive
 [changelog](CHANGELOG.md), or the signed artifacts on
 [GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
 
-- **v1.8.2 (release candidate)** — Adds SHA-pinned hosted assurance, portable Windows local assurance, corrected cookbook recipes, consistent optional-AI guidance, and `Path | str` graph loading.
+- **v1.8.2** — Adds SHA-pinned hosted assurance, portable Windows local assurance, corrected cookbook recipes, consistent optional-AI guidance, and `Path | str` graph loading.
 - **v1.8.1** — Hardened deep-outline parsing, coherent incremental graph mutations, bounded assurance cleanup, and stable provenance for optional NLTK.
 - **v1.8.0** — Added bounded privacy-safe local graph assurance, source-location contracts, and the first internal parser line-classification phase.
 - **v1.7.1** — Added the runnable offline SYNAPSE RAG example and tightened release-note and optional-dependency security checks.

--- a/RELEASE_HIGHLIGHTS.md
+++ b/RELEASE_HIGHLIGHTS.md
@@ -5,13 +5,11 @@ For the exhaustive change history, see the [changelog](CHANGELOG.md). For
 published artifacts and attestations, see
 [GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
 
-## v1.8.2 (release candidate)
+## v1.8.2
 
-Release candidate — strengthens the hosted assurance boundary, clarifies
+Patch release — strengthens the hosted assurance boundary, clarifies
 integration guidance, and makes the graph loader easier to call. **No
-intentional breaking changes** to stable package imports or CLI behavior. The
-v1.8.2 tag, PyPI publication, GitHub Release, hashes, and attestations remain
-pending the release workflow.
+intentional breaking changes** to stable package imports or CLI behavior.
 
 | Area | Change |
 | :--- | :--- |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,12 @@
 
 ## Supported Versions
 
-Security fixes are provided **only for the latest released version** on [PyPI](https://pypi.org/project/logseq-matryca-parser/). Until the v1.8.2 tag workflow completes, that version remains v1.8.1.
+Security fixes are provided **only for the latest released version** on [PyPI](https://pypi.org/project/logseq-matryca-parser/). The latest supported release is v1.8.2.
 
 | Version | Supported |
 | ------- | --------- |
-| 1.8.2 (release candidate; not published) | Pending publication |
-| **1.8.1** (latest released) | Yes |
-| 1.8.0 and older | No |
+| **1.8.2** (latest released) | Yes |
+| 1.8.1 and older | No |
 
 We recommend always running the current release and upgrading promptly when a security advisory is published.
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -19,6 +19,21 @@ superseded_by: null
 
 # Documentation evolution log
 
+## 2026-08-30 — v1.8.2 publication
+
+- Published v1.8.2 from PR #198 merge SHA
+  `976d5413df27330226d9b3a65b005d129de236b0` at tag `v1.8.2`.
+- Release workflow run [#33295184723](https://github.com/MarcoPorcellato/logseq-matryca-parser/actions/runs/33295184723) completed successfully, creating the [GitHub Release](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases/tag/v1.8.2) and [PyPI 1.8.2](https://pypi.org/project/logseq-matryca-parser/1.8.2/) publication.
+- Downloaded release assets matched `SHA256SUMS`, and GitHub attestation
+  verification passed for every listed artifact against this repository:
+
+  | Artifact | SHA-256 | Attestation |
+  | --- | --- | --- |
+  | `logseq_matryca_parser-1.8.2-py3-none-any.whl` | `1b3deb43466c63c46ca3b11cd35a2b4436b0ba3528a5f82bcc52fd0a10cd4820` | Verified |
+  | `logseq_matryca_parser-1.8.2.tar.gz` | `aa9a15ab43c1197724550fde121023da52d4ade49f9886eaa0c48df04c37be08` | Verified |
+  | `SBOM.cdx.json` | `67802e45427a76f0de1bd9ce544eb5199ac48aa00611fca807b5d5fd01c131e0` | Verified |
+  | `DEPENDENCY_LICENSES.json` | `fb75132dd4562d8b25dd8dda45ef41ff0fe64a7966d6967cd859071802f20834` | Verified |
+
 ## 2026-08-30 — v1.8.2 release candidate
 
 - Prepared the v1.8.2 release candidate from


### PR DESCRIPTION
## Summary

- mark v1.8.2 as the current released and supported version
- remove release-candidate wording from current reader-facing documentation
- record the exact release workflow, GitHub Release, PyPI publication, public checksums, and attestation verification

## Verification

- documentation lifecycle gate: passed
- vendor-name check: passed
- pre-commit actionlint, Ruff, and Mypy hooks: passed
- `git diff --check`: passed
- independent review: Spec PASS / Quality APPROVED

The historical release-candidate record remains unchanged as evidence of the pre-publication state.
