### PR TITLE
docs: correct v1.8.2 backlog counts

### DIFF
--- a/docs/superpowers/receipts/2026-08-30-v1.8.2-backlog-reconciliation.md
+++ b/docs/superpowers/receipts/2026-08-30-v1.8.2-backlog-reconciliation.md
@@ -13,11 +13,16 @@ PASS. The backlog was reconciled without bulk closure.
 
 ## Evidence
 
-- Open issues before reconciliation: 36.
-- Open issues after closing completed
-  [#124](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/124):
-  35.
-- Good-first-issue count remains 22.
+- Baseline before delivery: 36 open issues, including 22 carrying
+  `good first issue`.
+- [PR #195](https://github.com/MarcoPorcellato/logseq-matryca-parser/pull/195)
+  closed completed [#93](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/93),
+  leaving 35 open issues and 21 carrying `good first issue` before the final
+  issue edit.
+- Closing completed
+  [#124](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/124)
+  produced the verified final count: 34 open issues, including 21 carrying
+  `good first issue`.
 - [#104](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/104)
   remains In Progress in milestone 3, with a source-safe Windows timeout
   diagnostic follow-up.


### PR DESCRIPTION
## Summary

- correct the final v1.8.2 backlog arithmetic to include #93, which PR #195 closed before the final #124 reconciliation
- preserve the immutable baseline count while recording the verified final count of 34 open issues and 21 good-first-issues

## Verification

- documentation lifecycle gate: passed
- vendor-name check: passed
- pre-commit actionlint, Ruff, and Mypy hooks: passed
- `git diff --check`: passed
- independent review: Spec PASS / Quality APPROVED
