### PR TITLE
docs(architecture): define the Parser-Plumber boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ backlinks, exports, visualizations, and AI chunks are derived views.
 | **SYNAPSE** | Export lineage-aware LangChain documents, LlamaIndex nodes, and enriched chunks | `SynapseAdapter` |
 | **FORGE** | Serialize JSON, clean Markdown, Logseq pages, and Obsidian-compatible output | `ForgeExporter`, `serialize_logseq_page` |
 | **KINETIC** | Run CLI parse, export, scan, visualize, agent-read, and agent-write workflows | `matryca-parse` |
-| **LENS** | Build an interactive graph visualization | `GraphVisualizer` |
+| **LENS** | Build a compatible reference-topology visualization; planned compatible deprecation follows a later Trama UI migration | `GraphVisualizer` |
 | **Agent access** | Read a token-efficient X-Ray outline or perform bounded writes | `agent-read`, `agent-write`, `logseq_agent_write` |
 
 ## Start here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Parser-Plumber boundary** — record Parser as the deterministic Logseq OG
+  parsing library and Plumber as the sole cross-product Logseq gateway to
+  Trama and Brain. Existing Parser APIs and LENS behavior remain compatible;
+  any Trama UI migration requires a later, separately reviewed compatible
+  deprecation plan (#203).
+
 ## [1.8.2] - 2026-08-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ Logseq Matryca Parser is a deterministic **Stack-Machine engine** that acts as t
 The base parser is local-first and has zero telemetry. Optional AI, watcher, and
 visualization dependencies remain lazy. See the [architecture](docs/ARCHITECTURE.md)
 and [API stability reference](docs/reference/API_STABILITY.md) for exact boundaries.
+For cross-product Logseq OG use, Plumber is the gateway to Trama and Brain;
+Parser remains the deterministic parsing stage. LENS stays compatible while a
+future Trama graph-intelligence migration is separately designed and released.
 
 ### Data model — `LogseqNode` task fields
 
@@ -247,7 +250,9 @@ assert result["status"] == "success"
 ---
 
 ## 🗺️ Roadmap
-- [ ] **Desktop GUI:** Standalone app for non-technical users. [(Join the RFC)](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/3)
+- [ ] **Graph-intelligence UI:** A future Matryca Trama surface may succeed the
+  compatible Parser LENS workflow after a separately reviewed migration; Parser
+  does not commit to a standalone GUI. [(Track the historical RFC)](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/3)
 - [x] **Obsidian Adapter:** Native CLI export (`--format obsidian`) with YAML frontmatter and `^` block anchors.
 - [ ] **Ollama Integration:** One-click local RAG setup. [(RFC draft)](docs/rfc/OLLAMA_RAG.md) · [(Track progress #34)](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/34)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,22 @@ Full contributor contract: [`CLEAN_CODE_ARCHITECTURE.md`](CLEAN_CODE_ARCHITECTUR
 
 High-level data flow from sovereign graph files through deterministic parsing to AST-backed exporters and adapters.
 
+## Cross-repository boundary
+
+For Logseq OG integration, Parser is the deterministic parsing stage in this
+data flow:
+
+```text
+Logseq OG -> Parser -> Plumber -> Trama/Brain
+```
+
+Parser owns the typed AST, in-memory graph, and parser-native serialization.
+Plumber owns source selection, host adapters, sessions, and public cross-product
+contracts. The flow does not add Python imports: Parser runtime does not import
+Plumber, Trama, or Brain, while Trama and Brain consume Plumber contracts and
+do not import or know Parser. Details and compatibility consequences are in
+[ADR-0004](decisions/ADR-0004-PARSER-PLUMBER-BOUNDARY.md).
+
 ```mermaid
 flowchart LR
     FS[(Local Logseq\nGraph .md)] --> Logos[LOGOS Engine\nParser]
@@ -307,6 +323,8 @@ The KINETIC **`export --format langchain-enriched`** path serializes these docum
 When LENS receives a loaded **`LogseqGraph`**, wikilinks resolve through `get_page`: canonical pages and aliases are included, unresolved page links are omitted, and tag nodes remain visible independently of page resolution.
 
 Visualization export uses **`pyvis`** with **`force_atlas_2based`** physics, fullscreen canvas, HUD filters, glassmorphism control chrome, and stabilized layout configuration suitable for **large graphs at interactive frame rates** in the browser (product positioning targets fluid exploration of graphs on the order of **10⁴ nodes**).
+
+LENS remains fully compatible as a Parser reference-topology tool. Trama owns future product-intelligence visualization. Any later migration must preserve compatibility through a separately reviewed deprecation plan. No migration, warning, removal, or changed command is part of this repository slice.
 
 ### 3.4 AGENT WRITER — Append-Only Sandboxing & Headless Splicer
 

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -8,8 +8,8 @@ audience: contributors
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-30
-verified: 2026-08-30
+last_verified: 2026-09-05
+verified: 2026-09-05
 stale_after: 2027-02-26
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -27,7 +27,14 @@ This document applies **Robert C. Martin's** *Clean Architecture* (dependency ru
 
 **Adoption model:** **incremental v1**. A full hexagonal package split (`domain/ports.py`, separate driver packages) is **out of scope** for routine PRs. Uncle Bob here is a **quality contract**, not a mandate to rewrite the flat `src/logseq_matryca_parser/` layout in one change.
 
-**Downstream consumer:** [Matryca Plumber](https://github.com/MarcoPorcellato/matryca-plumber) depends on this library as the inner AST ring. Public APIs (`LogseqGraph`, `StackMachineParser`, `SynapseAdapter`, agent write helpers) must stay stable and framework-agnostic.
+**Cross-repository boundary:** Parser owns deterministic OG parsing, typed ASTs,
+the in-memory graph, and parser-native serialization. [Matryca
+Plumber](https://github.com/MarcoPorcellato/matryca-plumber) may depend on it
+as an internal OG parser and is the sole cross-product Logseq gateway to Trama
+and Brain. Parser does not select sources, operate host adapters, or define
+public `plumber.*` contracts. Public APIs (`LogseqGraph`, `StackMachineParser`,
+`SynapseAdapter`, agent write helpers) stay stable and framework-agnostic; see
+[ADR-0004](decisions/ADR-0004-PARSER-PLUMBER-BOUNDARY.md).
 
 ---
 
@@ -53,6 +60,10 @@ This document applies **Robert C. Martin's** *Clean Architecture* (dependency ru
 | **Use cases** | `logos_parser.py`, `graph.py`, `logseq_markdown.py`, `logseq_paths.py` | Parse, index, serialize, path translation — **no** CLI or optional AI/viz imports |
 | **Adapters** | `synapse.py`, `forge.py`, `agent_writer.py`, `agent_press.py`, `lens.py` | Framework projections (LangChain, LlamaIndex, Obsidian, PyVis) |
 | **Drivers** | `kinetic.py`, `kinetic_commands.py`, `kinetic_export.py`, `__main__.py` | Operator CLI — orchestrates use cases and adapters |
+
+Parser runtime modules must not import Plumber, Trama, or Brain. Trama and Brain
+consume Plumber contracts and do not import or know Parser. This is a product
+boundary, not a reason to move existing Parser APIs or LENS behavior in place.
 
 ```mermaid
 flowchart TB
@@ -99,6 +110,7 @@ flowchart TB
 | Adapters must not import `kinetic` | same |
 | Import cycles between `src/` modules | `0` expected — verify via local graph study (`check` cycles) |
 | Adapters use **public** `LogseqGraph` APIs | Code review + audit SOP |
+| Parser runtime does not import Plumber, Trama, or Brain | [`tests/test_layer_boundary.py`](../tests/test_layer_boundary.py) |
 
 ### v1 by design (do not "fix" without an epic)
 
@@ -172,6 +184,10 @@ not stable public API.
 | Format handlers | JSON, markdown, obsidian, langchain | `kinetic_export.py` |
 
 **Rule:** no new parsing logic in KINETIC modules — call `LogseqGraph.load_directory` or `StackMachineParser`.
+
+LENS remains a compatible optional Parser adapter. A later, separately accepted
+Trama migration owns user-facing graph-intelligence UI; no LENS warning,
+removal, command, or API change is authorized by this boundary decision.
 
 ### `synapse.py` + `synapse_embed.py` — SYNAPSE adapters
 

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -204,6 +204,11 @@ visualizer.export_html(output)
 
 `export_html()` writes the HTML file but does not open it automatically.
 
+LENS remains compatible for this reference-topology workflow. A future Trama
+migration may replace it for user-facing graph intelligence, but this recipe,
+command, and API remain unchanged until separately announced with compatibility
+guidance.
+
 ---
 
 ## Recipe 7 — Contributor test patterns

--- a/docs/GOOD_FIRST_ISSUES.md
+++ b/docs/GOOD_FIRST_ISSUES.md
@@ -154,7 +154,7 @@ Run `make vendor-name-check` before docs PRs to ensure Ghost Tooling policy (no 
 ## Out of scope for a first PR
 
 - Changes to Pydantic models in `logos_core.py` (open a design issue first).
-- Desktop GUI ([#3](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/3)) — multi-sprint epic.
+- Trama graph-intelligence UI ([#3](https://github.com/MarcoPorcellato/logseq-matryca-parser/issues/3)) — cross-product work; Parser LENS remains compatible and no Parser GUI work belongs in a first PR.
 - Bulk mldoc parity work in `logos_parser.py` — high regression risk.
 - Obsidian namespace path alignment — cross-tool behavior, needs design.
 

--- a/docs/decisions/ADR-0004-PARSER-PLUMBER-BOUNDARY.md
+++ b/docs/decisions/ADR-0004-PARSER-PLUMBER-BOUNDARY.md
@@ -1,0 +1,81 @@
+---
+type: ArchitectureDecision
+title: ADR-0004 Parser and Plumber boundary
+description: Decision that Parser remains a deterministic OG parsing library while Plumber owns the cross-product Logseq gateway.
+status: stable
+classification: active
+audience: maintainers
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-09-05
+verified: 2026-09-05
+stale_after: 2027-03-04
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# ADR-0004: Parser and Plumber boundary
+
+## Status
+
+Accepted.
+
+## Context
+
+Logseq Matryca Parser already provides deterministic parsing of Logseq OG
+Markdown into a typed AST, an in-memory graph, and parser-native
+serializations. Cross-product integration needs one gateway that can select a
+source, own host adapters and session lifecycle, and publish stable contracts
+to product consumers without making those consumers depend on Parser internals.
+
+## Decision
+
+The supported OG data flow is:
+
+```text
+Logseq OG -> Parser -> Plumber -> Trama/Brain
+```
+
+Parser owns deterministic OG parsing, typed AST construction, its in-memory
+graph, and parser-native serialization. It accepts caller-provided local
+Markdown inputs, but does not choose a cross-product source, operate a Logseq
+host adapter, own sessions, or define public `plumber.*` contracts.
+
+Plumber owns source selection, Logseq host adapters, session lifecycle, and
+versioned public contracts for downstream consumers. The data flow above is not
+a Python dependency direction. The Parser runtime must not import Plumber, Trama, or Brain. Plumber may use Parser internally for an OG source.
+
+Trama and Brain consume Plumber contracts. They must not import or know Parser,
+and must not access Logseq OG files or a Logseq DB through a parallel gateway.
+
+LENS remains compatible in this slice. Its current API, CLI command, optional
+dependency, and behavior are unchanged. A later, separately reviewed migration
+will move user-facing graph-intelligence visualization to Trama and may begin a
+compatible LENS deprecation. This decision adds no warning, removal, command,
+or API change.
+
+Parser remains protocol-neutral under
+[ADR-0001](ADR-0001-PROTOCOL_ADAPTER_BOUNDARY.md). This decision adds no MCP
+server, network endpoint, GUI, release, or compatibility claim.
+
+## Consequences
+
+- Parser remains independently useful to developer consumers that need only
+  deterministic Markdown parsing, an in-memory graph, CLI workflows, or
+  parser-native exports.
+- Plumber is the only cross-product boundary between Logseq sources and Trama
+  or Brain.
+- Existing Parser public APIs and LENS compatibility promises remain unchanged.
+- Any future UI migration, host adapter, protocol, mutation, or release needs
+  its own accepted design and verification evidence.
+
+## Verification and rollback
+
+`tests/test_plumber_boundary_docs.py` keeps this decision and the maintained
+architecture guides explicit. `tests/test_layer_boundary.py` rejects Parser
+runtime imports of Plumber, Trama, and Brain. Rollback requires a superseding
+ADR and a separately reviewed compatibility plan; it does not authorize an
+implicit import or product-surface change.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -15,6 +15,7 @@ introduced incrementally. Do not rewrite historical roadmaps into ADRs.
 | Privacy-safe local graph assurance | [`ADR-002-local-graph-assurance-boundary.md`](ADR-002-local-graph-assurance-boundary.md) | Accepted M5 aggregate-only local CLI boundary; no content retention or network operation |
 | Documentation lifecycle and MKQ | [`DOCUMENTATION_SYSTEM.md`](../DOCUMENTATION_SYSTEM.md) | Source contract recorded; MKQ-4 enforcement and private profile activation pending under issue #109 |
 | Protocol adapter boundary | [`ADR-0001-PROTOCOL_ADAPTER_BOUNDARY.md`](ADR-0001-PROTOCOL_ADAPTER_BOUNDARY.md) | Accepted: keep the core protocol-neutral until explicit schema, safety, permissions, and conformance gates are met |
+| Parser and Plumber boundary | [`ADR-0004-PARSER-PLUMBER-BOUNDARY.md`](ADR-0004-PARSER-PLUMBER-BOUNDARY.md) | Accepted: Parser owns deterministic OG parsing; Plumber is the sole cross-product Logseq gateway to Trama and Brain |
 | Official OKF v0.2 migration | [`ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md`](ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md) | Accepted: defer conformance while the measured 38-finding backlog and nested-index profile conflict remain |
 | AAIF submission | [`ADR-0003-AAIF-SUBMISSION-GATE.md`](ADR-0003-AAIF-SUBMISSION-GATE.md) | Accepted: NO-GO until governance, adoption, legal, live security, and release-evidence gates pass |
 

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -38,6 +38,7 @@ maintained_documents = [
   "docs/decisions/ADR-0001-PROTOCOL_ADAPTER_BOUNDARY.md",
   "docs/decisions/ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md",
   "docs/decisions/ADR-0003-AAIF-SUBMISSION-GATE.md",
+  "docs/decisions/ADR-0004-PARSER-PLUMBER-BOUNDARY.md",
   "docs/decisions/ADR-001-external-oracle-boundary.md",
   "docs/decisions/ADR-002-local-graph-assurance-boundary.md",
   "docs/reference/index.md",

--- a/docs/reference/API_STABILITY.md
+++ b/docs/reference/API_STABILITY.md
@@ -8,8 +8,8 @@ audience: contributors
 owner: logseq-matryca-parser
 authority: source_repository
 execution_mode: reviewed
-last_verified: 2026-08-07
-verified: 2026-08-07
+last_verified: 2026-09-05
+verified: 2026-09-05
 stale_after: 2027-02-03
 okf_profile: matryca_okf_inspired_quality
 okf_spec_version: null
@@ -77,6 +77,12 @@ The following integrations remain public but experimental:
 
 Everything not exported from `logseq_matryca_parser.__all__` is internal unless
 another maintained contract explicitly promotes it.
+
+`GraphVisualizer` remains experimental and compatible in this release line. A
+future migration of user-facing graph intelligence to Trama may introduce a
+compatible deprecation only through a separately reviewed decision, release
+notes, and migration guidance. No deprecation warning or API change is made by
+the Parser-Plumber boundary decision.
 
 ## Version source
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -5,7 +5,7 @@
 | Repository | Relationship |
 |---|---|
 | [Matryca Knowledge](https://github.com/MarcoPorcellato/matryca-knowledge) | Federated knowledge projection and MKQ governance; never the source authority for this repository |
-| [Matryca Plumber](https://github.com/MarcoPorcellato/matryca-plumber) | Downstream consumer of parser, graph and CLI contracts |
+| [Matryca Plumber](https://github.com/MarcoPorcellato/matryca-plumber) | May use Parser internally for deterministic OG parsing; it is the cross-product gateway, while Parser is not a cross-product gateway |
 
 ## Governance baseline
 

--- a/tests/test_layer_boundary.py
+++ b/tests/test_layer_boundary.py
@@ -68,6 +68,12 @@ _FORBIDDEN_USE_CASE_ADAPTER_IMPORTS = (
     "from .agent_press",
 )
 
+_FORBIDDEN_CROSS_REPOSITORY_RUNTIME_IMPORTS = (
+    "matryca_plumber",
+    "matryca_trama",
+    "matryca_brain",
+)
+
 
 def _module_text(name: str) -> str:
     return (_SRC / name).read_text(encoding="utf-8")
@@ -119,4 +125,14 @@ def test_use_cases_do_not_import_kinetic() -> None:
         for needle in _FORBIDDEN_INNER_ADAPTER_IMPORTS:
             if needle in text:
                 offenders.append(f"{name} imports kinetic via {needle!r}")
+    assert offenders == []
+
+
+def test_parser_runtime_does_not_import_cross_repository_products() -> None:
+    offenders: list[str] = []
+    for path in sorted(_SRC.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        for package in _FORBIDDEN_CROSS_REPOSITORY_RUNTIME_IMPORTS:
+            if f"import {package}" in text or f"from {package}" in text:
+                offenders.append(f"{path.name} imports {package}")
     assert offenders == []

--- a/tests/test_plumber_boundary_docs.py
+++ b/tests/test_plumber_boundary_docs.py
@@ -1,0 +1,37 @@
+"""Regression coverage for the Parser-to-Plumber architectural boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR = ROOT / "docs" / "decisions" / "ADR-0004-PARSER-PLUMBER-BOUNDARY.md"
+
+
+def test_parser_plumber_boundary_adr_is_maintained_and_explicit() -> None:
+    text = ADR.read_text(encoding="utf-8")
+    assert "Logseq OG -> Parser -> Plumber -> Trama/Brain" in text
+    assert "The Parser runtime must not import Plumber, Trama, or Brain." in text
+    assert "LENS remains compatible in this slice" in text
+
+    maintained = (ROOT / "docs" / "maintained.toml").read_text(encoding="utf-8")
+    assert '"docs/decisions/ADR-0004-PARSER-PLUMBER-BOUNDARY.md"' in maintained
+
+
+def test_parser_authority_docs_preserve_parser_only_ownership() -> None:
+    clean_architecture = (ROOT / "docs" / "CLEAN_CODE_ARCHITECTURE.md").read_text(
+        encoding="utf-8"
+    )
+    architecture = (ROOT / "docs" / "ARCHITECTURE.md").read_text(encoding="utf-8")
+
+    assert "Parser owns deterministic OG parsing" in clean_architecture
+    assert "Trama owns future product-intelligence visualization" in architecture
+
+
+def test_active_navigation_does_not_assign_a_parser_gui_or_gateway_role() -> None:
+    starter_scope = (ROOT / "docs" / "GOOD_FIRST_ISSUES.md").read_text(encoding="utf-8")
+    references = (ROOT / "docs" / "reference" / "index.md").read_text(encoding="utf-8")
+
+    assert "Desktop GUI ([#3]" not in starter_scope
+    assert "Trama graph-intelligence UI" in starter_scope
+    assert "not a cross-product gateway" in references


### PR DESCRIPTION
## Summary

- Define Parser as the deterministic Logseq OG parsing stage upstream of the Plumber gateway.
- Record the only cross-product flow as Logseq OG -> Parser -> Plumber -> Trama/Brain.
- Prevent runtime imports from Parser to Plumber, Trama, or Brain and document that Trama/Brain never know Parser.
- Keep LENS fully compatible in this slice while making its future Trama migration and deprecation a separate gated change.

## Test plan

- [x] Focused boundary tests: 9 passed
- [x] Ruff
- [x] Mypy: 79 source files
- [x] Documentation checks
- [x] Full pytest: 792 passed, coverage threshold met
- [x] Vendor-name check
- [x] Diff validation

## Boundaries

- Documentation and regression tests only.
- No LENS warning, removal, CLI/API change, GUI, MCP server, runtime adapter, package publication, or release claim.
- Existing public Parser APIs remain compatible.

Fixes #203
References MarcoPorcellato/matryca-plumber#563
References MarcoPorcellato/matryca-trama#19
