### PR TITLE
security: govern temporary NLTK advisory exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,11 @@ jobs:
           --output-file "${{ runner.temp }}/requirements-audit.txt"
 
       - name: Audit exported dependencies
-        run: uv run pip-audit --no-deps --disable-pip -r "${{ runner.temp }}/requirements-audit.txt"
+        # Temporary exception governed by docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md.
+        run: >-
+          uv run pip-audit --no-deps --disable-pip
+          --ignore-vuln PYSEC-2026-3740
+          -r "${{ runner.temp }}/requirements-audit.txt"
 
   package-contract:
     name: Wheel and source distribution contract

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Audit production dependencies
         run: |
           uv export --all-extras --no-dev --no-emit-workspace -o "${{ runner.temp }}/requirements-audit.txt"
-          uv run pip-audit --no-deps --disable-pip -r "${{ runner.temp }}/requirements-audit.txt"
+          # Temporary exception governed by docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md.
+          uv run pip-audit --no-deps --disable-pip \
+            --ignore-vuln PYSEC-2026-3740 \
+            -r "${{ runner.temp }}/requirements-audit.txt"
 
       - name: Run full quality gate
         run: make all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Time-bounded NLTK advisory exception** — document the exact optional AI
+  dependency exposure, non-reachability evidence, compensating controls,
+  owner, upstream advisory, and 2026-10-05 expiry for `PYSEC-2026-3740` while
+  no patched NLTK registry release exists. CI and release audits ignore only
+  that advisory; all other dependency findings remain fail-closed.
+
 ## [1.8.2] - 2026-08-30
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ entry points.
 | [`reference/CONFORMANCE_SUPPORT_MATRIX.md`](reference/CONFORMANCE_SUPPORT_MATRIX.md) | Integrators, contributors | Supported runtimes, public contract tiers, optional adapters, and deprecation rules |
 | [`reference/DEPENDENCY_LICENSE_POLICY.md`](reference/DEPENDENCY_LICENSE_POLICY.md) | Maintainers, release reviewers | Release SBOM, dependency/license inventory, checksum, override, and attestation contract |
 | [`security/DAILY_METRICS_THREAT_MODEL.md`](security/DAILY_METRICS_THREAT_MODEL.md) | Maintainers, security reviewers | Trust boundaries and fail-closed controls for the self-mutating metrics archive |
+| [`security/DEPENDENCY_ADVISORY_EXCEPTIONS.md`](security/DEPENDENCY_ADVISORY_EXCEPTIONS.md) | Maintainers, security reviewers | Exact, time-bounded dependency advisory exceptions and compensating controls |
 | [`decisions/ADR-0001-PROTOCOL_ADAPTER_BOUNDARY.md`](decisions/ADR-0001-PROTOCOL_ADAPTER_BOUNDARY.md) | Maintainers, integrators | Decision to defer protocol endpoints until explicit safety and compatibility gates are met |
 | [`decisions/ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md`](decisions/ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md) | Maintainers, documentation reviewers | Decision to preserve the measured official OKF backlog until profile conflicts are resolved |
 | [`decisions/ADR-0003-AAIF-SUBMISSION-GATE.md`](decisions/ADR-0003-AAIF-SUBMISSION-GATE.md) | Maintainers, legal reviewers | Evidence-based NO-GO and reconsideration gate for any AAIF submission |

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ navigation layers only.
 | [Support and compatibility matrix](reference/CONFORMANCE_SUPPORT_MATRIX.md) | Supported runtimes, public API tiers, optional adapters, and explicit limits |
 | [Dependency, license, SBOM, and provenance policy](reference/DEPENDENCY_LICENSE_POLICY.md) | Release evidence, override, checksum, and attestation contract |
 | [Daily metrics threat model](security/DAILY_METRICS_THREAT_MODEL.md) | Security boundary for the self-mutating repository traffic archive |
+| [Dependency advisory exceptions](security/DEPENDENCY_ADVISORY_EXCEPTIONS.md) | Exact, time-bounded security audit exceptions and compensating controls |
 | [Architecture](CLEAN_CODE_ARCHITECTURE.md) | Canonical architecture and public graph API |
 | [Stellar audit baseline](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Dated evidence-backed audit and original improvement sequence |
 | [GitHub and AAIF readiness study](REPOSITORY_GOVERNANCE_AAIF_STUDY_2026-08-19.md) | Governance, supply-chain, agent, and AAIF-readiness study |

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -48,6 +48,7 @@ maintained_documents = [
   "docs/reference/DIAGNOSTICS.md",
   "docs/reference/FILESYSTEM_SAFETY.md",
    "docs/security/DAILY_METRICS_THREAT_MODEL.md",
+   "docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md",
    "docs/reference/LOCAL_GRAPH_ASSURANCE.md",
    "docs/reference/PERFORMANCE_EVIDENCE.md",
    "docs/rfc/SOURCE_LOCATION_RFC.md",

--- a/docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md
+++ b/docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md
@@ -1,0 +1,76 @@
+---
+type: SecurityPolicy
+title: Dependency advisory exceptions
+description: Time-bounded, fail-closed exceptions for known dependency advisories without an available patched release.
+status: stable
+classification: canonical
+audience: maintainers
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-09-05
+verified: 2026-09-05
+stale_after: 2026-10-05
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# Dependency advisory exceptions
+
+This register implements the exception requirements in the
+[dependency policy](../reference/DEPENDENCY_LICENSE_POLICY.md). Each exception
+is exact, reviewable, temporary, and enforced by repository tests. A package
+with a patched release must be upgraded; it must not be added here merely to
+make an audit pass.
+
+## Active exception: NLTK path traversal
+
+| Field | Decision |
+|---|---|
+| Advisory | `PYSEC-2026-3740` / `GHSA-8mgp-746c-j5xp` |
+| Package | `nltk 3.10.3` |
+| Scope | Transitive runtime dependency of the optional AI extra through `llama-index-core`; absent from the base parser installation |
+| Owner | `@MarcoPorcellato` |
+| Review date | 2026-09-05 |
+| Expiry date | 2026-10-05 |
+| Upstream tracking | [NLTK security advisory](https://github.com/nltk/nltk/security/advisories/GHSA-8mgp-746c-j5xp) |
+
+### Exploitability analysis
+
+The advisory affects path handling in model import and export operations. The
+Parser does not import NLTK and does not call `TransitionParser`,
+`AveragedPerceptron`, `PerceptronTagger`, or `save_maxent_params`. Its optional
+AI adapter imports only schema types from `llama_index.core.schema`; it does
+not accept an NLTK model path or expose an NLTK training, loading, or saving
+operation. The vulnerable operations are therefore not reachable through the
+Parser's public API or CLI at this revision.
+
+This conclusion is limited to this repository. It does not declare NLTK safe
+for direct use by another application sharing the environment.
+
+### Compensating controls
+
+- A deterministic test rejects direct NLTK imports or references to the named
+  vulnerable APIs anywhere under `src/`.
+- CI and release audits ignore only `PYSEC-2026-3740`; every other advisory
+  remains fail-closed.
+- The base installation does not include the optional AI dependency graph.
+- Any proposal to expose NLTK model import, export, training, loading, or
+  saving must first remove this exception or complete a new security review.
+
+### Removal criteria
+
+Remove both workflow flags and this active entry as soon as the first of these
+conditions occurs:
+
+1. a patched NLTK registry release is available and qualified in the locked
+   optional AI dependency graph;
+2. the optional dependency chain no longer resolves to an affected NLTK
+   version;
+3. repository code reaches an affected API; or
+4. 2026-10-05 is reached without a fresh reviewed decision.
+
+Expiry is fail-closed: an expired entry is not permission to keep ignoring the
+advisory.

--- a/tests/test_dependency_advisory_exception.py
+++ b/tests/test_dependency_advisory_exception.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ADVISORY_ID = "PYSEC-2026-3740"
+GHSA_ID = "GHSA-8mgp-746c-j5xp"
+PROHIBITED_APIS = (
+    "TransitionParser",
+    "AveragedPerceptron",
+    "PerceptronTagger",
+    "save_maxent_params",
+)
+
+
+def test_nltk_advisory_exception_is_exact_and_release_consistent() -> None:
+    ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    release = (ROOT / ".github" / "workflows" / "pypi_publish.yml").read_text(
+        encoding="utf-8"
+    )
+
+    exact_exception = f"--ignore-vuln {ADVISORY_ID}"
+    assert ci.count(exact_exception) == 1
+    assert release.count(exact_exception) == 1
+    assert "--ignore-vuln CVE-2026-71492" not in ci + release
+    assert (ci + release).count("--ignore-vuln") == 2
+
+
+def test_nltk_advisory_exception_records_required_governance() -> None:
+    policy = (
+        ROOT / "docs" / "security" / "DEPENDENCY_ADVISORY_EXCEPTIONS.md"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        ADVISORY_ID,
+        GHSA_ID,
+        "nltk 3.10.3",
+        "optional AI",
+        "@MarcoPorcellato",
+        "2026-10-05",
+        "https://github.com/nltk/nltk/security/advisories/GHSA-8mgp-746c-j5xp",
+    ):
+        assert required in policy
+
+
+def test_parser_does_not_reach_the_waived_nltk_apis() -> None:
+    production_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted((ROOT / "src").rglob("*.py"))
+    )
+
+    assert "nltk" not in production_text.casefold()
+    for api_name in PROHIBITED_APIS:
+        assert api_name not in production_text

--- a/tests/test_quality_gate_contract.py
+++ b/tests/test_quality_gate_contract.py
@@ -282,10 +282,9 @@ def test_ci_uses_locked_cross_platform_native_actions_jobs() -> None:
     assert '["3.12", "3.13"]' in workflow
     assert workflow.count("uv sync --locked --all-extras") == 4
     assert workflow.count("pip-audit") == 1
-    assert (
-        'uv run pip-audit --no-deps --disable-pip -r '
-        '"${{ runner.temp }}/requirements-audit.txt"'
-    ) in workflow
+    assert "uv run pip-audit --no-deps --disable-pip" in workflow
+    assert "--ignore-vuln PYSEC-2026-3740" in workflow
+    assert '-r "${{ runner.temp }}/requirements-audit.txt"' in workflow
     for flag in ("--all-extras", "--no-dev", "--no-emit-workspace"):
         assert flag in workflow
     assert "--no-hashes" not in workflow


### PR DESCRIPTION
## Summary

- record the exact `PYSEC-2026-3740` / `GHSA-8mgp-746c-j5xp` exposure in the optional AI dependency graph
- add a time-bounded exception with owner, upstream tracking, compensating controls, and a fail-closed 2026-10-05 expiry
- keep every other advisory blocking in CI and release workflows
- reject any NLTK reference in Parser production source while the exception is active

## Security boundary

Parser does not import NLTK or expose the affected model path operations. This exception does not declare NLTK safe for direct downstream use. `CVE-2026-71492` for Banks is intentionally not ignored and remains a separate merge blocker until Dependabot updates it to 2.4.5 or later.

## Verification

- `make all`
- `make vendor-name-check`
- focused exception and workflow contract tests: 42 passed
- documentation expiry probe: the entry becomes stale and fails the docs gate after 2026-10-05
- independent security review: GREEN