### PR TITLE
security: resolve Banks and govern temporary NLTK exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,11 @@ jobs:
           --output-file "${{ runner.temp }}/requirements-audit.txt"
 
       - name: Audit exported dependencies
-        run: uv run pip-audit --no-deps --disable-pip -r "${{ runner.temp }}/requirements-audit.txt"
+        # Temporary exception governed by docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md.
+        run: >-
+          uv run pip-audit --no-deps --disable-pip
+          --ignore-vuln PYSEC-2026-3740
+          -r "${{ runner.temp }}/requirements-audit.txt"
 
   package-contract:
     name: Wheel and source distribution contract

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Audit production dependencies
         run: |
           uv export --all-extras --no-dev --no-emit-workspace -o "${{ runner.temp }}/requirements-audit.txt"
-          uv run pip-audit --no-deps --disable-pip -r "${{ runner.temp }}/requirements-audit.txt"
+          # Temporary exception governed by docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md.
+          uv run pip-audit --no-deps --disable-pip \
+            --ignore-vuln PYSEC-2026-3740 \
+            -r "${{ runner.temp }}/requirements-audit.txt"
 
       - name: Run full quality gate
         run: make all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Time-bounded NLTK advisory exception** — document the exact optional AI
+  dependency exposure, non-reachability evidence, compensating controls,
+  owner, upstream advisory, and 2026-10-05 expiry for `PYSEC-2026-3740` while
+  no patched NLTK registry release exists. CI and release audits ignore only
+  that advisory; all other dependency findings remain fail-closed.
+
 ## [1.8.2] - 2026-08-30
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ entry points.
 | [`reference/CONFORMANCE_SUPPORT_MATRIX.md`](reference/CONFORMANCE_SUPPORT_MATRIX.md) | Integrators, contributors | Supported runtimes, public contract tiers, optional adapters, and deprecation rules |
 | [`reference/DEPENDENCY_LICENSE_POLICY.md`](reference/DEPENDENCY_LICENSE_POLICY.md) | Maintainers, release reviewers | Release SBOM, dependency/license inventory, checksum, override, and attestation contract |
 | [`security/DAILY_METRICS_THREAT_MODEL.md`](security/DAILY_METRICS_THREAT_MODEL.md) | Maintainers, security reviewers | Trust boundaries and fail-closed controls for the self-mutating metrics archive |
+| [`security/DEPENDENCY_ADVISORY_EXCEPTIONS.md`](security/DEPENDENCY_ADVISORY_EXCEPTIONS.md) | Maintainers, security reviewers | Exact, time-bounded dependency advisory exceptions and compensating controls |
 | [`decisions/ADR-0001-PROTOCOL_ADAPTER_BOUNDARY.md`](decisions/ADR-0001-PROTOCOL_ADAPTER_BOUNDARY.md) | Maintainers, integrators | Decision to defer protocol endpoints until explicit safety and compatibility gates are met |
 | [`decisions/ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md`](decisions/ADR-0002-OFFICIAL-OKF-V02-MIGRATION-GATE.md) | Maintainers, documentation reviewers | Decision to preserve the measured official OKF backlog until profile conflicts are resolved |
 | [`decisions/ADR-0003-AAIF-SUBMISSION-GATE.md`](decisions/ADR-0003-AAIF-SUBMISSION-GATE.md) | Maintainers, legal reviewers | Evidence-based NO-GO and reconsideration gate for any AAIF submission |

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ navigation layers only.
 | [Support and compatibility matrix](reference/CONFORMANCE_SUPPORT_MATRIX.md) | Supported runtimes, public API tiers, optional adapters, and explicit limits |
 | [Dependency, license, SBOM, and provenance policy](reference/DEPENDENCY_LICENSE_POLICY.md) | Release evidence, override, checksum, and attestation contract |
 | [Daily metrics threat model](security/DAILY_METRICS_THREAT_MODEL.md) | Security boundary for the self-mutating repository traffic archive |
+| [Dependency advisory exceptions](security/DEPENDENCY_ADVISORY_EXCEPTIONS.md) | Exact, time-bounded security audit exceptions and compensating controls |
 | [Architecture](CLEAN_CODE_ARCHITECTURE.md) | Canonical architecture and public graph API |
 | [Stellar audit baseline](REPOSITORY_STELLAR_ROADMAP_2026-08-06.md) | Dated evidence-backed audit and original improvement sequence |
 | [GitHub and AAIF readiness study](REPOSITORY_GOVERNANCE_AAIF_STUDY_2026-08-19.md) | Governance, supply-chain, agent, and AAIF-readiness study |

--- a/docs/maintained.toml
+++ b/docs/maintained.toml
@@ -48,6 +48,7 @@ maintained_documents = [
   "docs/reference/DIAGNOSTICS.md",
   "docs/reference/FILESYSTEM_SAFETY.md",
    "docs/security/DAILY_METRICS_THREAT_MODEL.md",
+   "docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md",
    "docs/reference/LOCAL_GRAPH_ASSURANCE.md",
    "docs/reference/PERFORMANCE_EVIDENCE.md",
    "docs/rfc/SOURCE_LOCATION_RFC.md",

--- a/docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md
+++ b/docs/security/DEPENDENCY_ADVISORY_EXCEPTIONS.md
@@ -1,0 +1,76 @@
+---
+type: SecurityPolicy
+title: Dependency advisory exceptions
+description: Time-bounded, fail-closed exceptions for known dependency advisories without an available patched release.
+status: stable
+classification: canonical
+audience: maintainers
+owner: logseq-matryca-parser
+authority: source_repository
+execution_mode: reviewed
+last_verified: 2026-09-05
+verified: 2026-09-05
+stale_after: 2026-10-05
+okf_profile: matryca_okf_inspired_quality
+okf_spec_version: null
+supersedes: null
+superseded_by: null
+---
+
+# Dependency advisory exceptions
+
+This register implements the exception requirements in the
+[dependency policy](../reference/DEPENDENCY_LICENSE_POLICY.md). Each exception
+is exact, reviewable, temporary, and enforced by repository tests. A package
+with a patched release must be upgraded; it must not be added here merely to
+make an audit pass.
+
+## Active exception: NLTK path traversal
+
+| Field | Decision |
+|---|---|
+| Advisory | `PYSEC-2026-3740` / `GHSA-8mgp-746c-j5xp` |
+| Package | `nltk 3.10.3` |
+| Scope | Transitive runtime dependency of the optional AI extra through `llama-index-core`; absent from the base parser installation |
+| Owner | `@MarcoPorcellato` |
+| Review date | 2026-09-05 |
+| Expiry date | 2026-10-05 |
+| Upstream tracking | [NLTK security advisory](https://github.com/nltk/nltk/security/advisories/GHSA-8mgp-746c-j5xp) |
+
+### Exploitability analysis
+
+The advisory affects path handling in model import and export operations. The
+Parser does not import NLTK and does not call `TransitionParser`,
+`AveragedPerceptron`, `PerceptronTagger`, or `save_maxent_params`. Its optional
+AI adapter imports only schema types from `llama_index.core.schema`; it does
+not accept an NLTK model path or expose an NLTK training, loading, or saving
+operation. The vulnerable operations are therefore not reachable through the
+Parser's public API or CLI at this revision.
+
+This conclusion is limited to this repository. It does not declare NLTK safe
+for direct use by another application sharing the environment.
+
+### Compensating controls
+
+- A deterministic test rejects direct NLTK imports or references to the named
+  vulnerable APIs anywhere under `src/`.
+- CI and release audits ignore only `PYSEC-2026-3740`; every other advisory
+  remains fail-closed.
+- The base installation does not include the optional AI dependency graph.
+- Any proposal to expose NLTK model import, export, training, loading, or
+  saving must first remove this exception or complete a new security review.
+
+### Removal criteria
+
+Remove both workflow flags and this active entry as soon as the first of these
+conditions occurs:
+
+1. a patched NLTK registry release is available and qualified in the locked
+   optional AI dependency graph;
+2. the optional dependency chain no longer resolves to an affected NLTK
+   version;
+3. repository code reaches an affected API; or
+4. 2026-10-05 is reached without a fresh reviewed decision.
+
+Expiry is fail-closed: an expired entry is not permission to keep ignoring the
+advisory.

--- a/tests/test_dependency_advisory_exception.py
+++ b/tests/test_dependency_advisory_exception.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ADVISORY_ID = "PYSEC-2026-3740"
+GHSA_ID = "GHSA-8mgp-746c-j5xp"
+PROHIBITED_APIS = (
+    "TransitionParser",
+    "AveragedPerceptron",
+    "PerceptronTagger",
+    "save_maxent_params",
+)
+
+
+def test_nltk_advisory_exception_is_exact_and_release_consistent() -> None:
+    ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    release = (ROOT / ".github" / "workflows" / "pypi_publish.yml").read_text(
+        encoding="utf-8"
+    )
+
+    exact_exception = f"--ignore-vuln {ADVISORY_ID}"
+    assert ci.count(exact_exception) == 1
+    assert release.count(exact_exception) == 1
+    assert "--ignore-vuln CVE-2026-71492" not in ci + release
+    assert (ci + release).count("--ignore-vuln") == 2
+
+
+def test_nltk_advisory_exception_records_required_governance() -> None:
+    policy = (
+        ROOT / "docs" / "security" / "DEPENDENCY_ADVISORY_EXCEPTIONS.md"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        ADVISORY_ID,
+        GHSA_ID,
+        "nltk 3.10.3",
+        "optional AI",
+        "@MarcoPorcellato",
+        "2026-10-05",
+        "https://github.com/nltk/nltk/security/advisories/GHSA-8mgp-746c-j5xp",
+    ):
+        assert required in policy
+
+
+def test_parser_does_not_reach_the_waived_nltk_apis() -> None:
+    production_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted((ROOT / "src").rglob("*.py"))
+    )
+
+    assert "nltk" not in production_text.casefold()
+    for api_name in PROHIBITED_APIS:
+        assert api_name not in production_text

--- a/tests/test_quality_gate_contract.py
+++ b/tests/test_quality_gate_contract.py
@@ -282,10 +282,9 @@ def test_ci_uses_locked_cross_platform_native_actions_jobs() -> None:
     assert '["3.12", "3.13"]' in workflow
     assert workflow.count("uv sync --locked --all-extras") == 4
     assert workflow.count("pip-audit") == 1
-    assert (
-        'uv run pip-audit --no-deps --disable-pip -r '
-        '"${{ runner.temp }}/requirements-audit.txt"'
-    ) in workflow
+    assert "uv run pip-audit --no-deps --disable-pip" in workflow
+    assert "--ignore-vuln PYSEC-2026-3740" in workflow
+    assert '-r "${{ runner.temp }}/requirements-audit.txt"' in workflow
     for flag in ("--all-extras", "--no-dev", "--no-emit-workspace"):
         assert flag in workflow
     assert "--no-hashes" not in workflow

--- a/uv.lock
+++ b/uv.lock
@@ -195,7 +195,7 @@ wheels = [
 
 [[package]]
 name = "banks"
-version = "2.4.2"
+version = "2.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -205,9 +205,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/51/08fb68d23f4b0f6256fe85dc86e9576941550f890b079352fba719e07b39/banks-2.4.2.tar.gz", hash = "sha256:cda6013bd377ea7b701933578bfb9370fc21ad70bc13cedfc3f5cb2c034ca3dc", size = 188633, upload-time = "2026-04-27T12:15:22.021Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b5/4784ee9518b97f9f69c714a4303f9a6186a7e4ff2349f89e24767e9754d9/banks-2.4.5.tar.gz", hash = "sha256:ff575732fc67d5493a73c21e0d7268bc49e86fff02b0b8735e8efb9fcb9af3a4", size = 190822, upload-time = "2026-07-07T08:14:12.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/b6/8dc5477681b782e2f99de703e7a99828883364b9e03a60d3e2c47053d56a/banks-2.4.2-py3-none-any.whl", hash = "sha256:5fe407cc48c101f3e13d1cf732b83b8246003337612f13c0705d2e81f6faffb7", size = 35050, upload-time = "2026-04-27T12:15:20.785Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b0/4d34cb2fe538aeb6d4b0723b3339cb932120db084a5c9a3c6966a26bbe1b/banks-2.4.5-py3-none-any.whl", hash = "sha256:ac2e0091b4c79379d4773c9d04a138a0d937ee27c5803bf0142acc6d6769eea1", size = 36145, upload-time = "2026-07-07T08:14:10.974Z" },
 ]
 
 [[package]]
@@ -1725,11 +1725,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/96/e6f8e9d9d7b9cc4457092712a7e919c3186aa2c2fa9ffed2c5d29cc947e8/pip-26.2.tar.gz", hash = "sha256:2d8542afcc84cdd8e846c2b36b2861fad1da376dd98f8e7113e9108a3c331690", size = 1848845, upload-time = "2026-07-29T21:57:56.407Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/62/36/a3aed958d60531cb442b7ab4596cda7b3621cfb916f8ae1d6769795c7dc1/pip-26.2-py3-none-any.whl", hash = "sha256:931c303696af6fa3417112103b1cad26890e5a07eccb5b99783700e33f2b8aad", size = 1816475, upload-time = "2026-07-29T21:57:54.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- retain Dependabot's signed update of Banks 2.4.2 to 2.4.5 and pip 26.1.2 to 26.2
- document the exact `PYSEC-2026-3740` / `GHSA-8mgp-746c-j5xp` exposure in the optional AI graph
- add a time-bounded NLTK exception with owner, upstream tracking, compensating controls, and a fail-closed 2026-10-05 expiry
- keep every other dependency advisory blocking in CI and release workflows
- reject any NLTK reference in Parser production source while the exception is active

## Provenance and safety

The lockfile is byte-identical to signed Dependabot commit `bed0d0cf9c60ab349a6371b966b208f23054cb46`; no manual lockfile edit was made. Parser does not import NLTK or expose the affected model-path operations. The exception does not declare NLTK safe for direct downstream use.

## Verification

- `uv sync --locked --all-extras`
- `make all`
- exact production export plus `pip-audit`: no known vulnerabilities found, one exact NLTK advisory ignored
- no lockfile delta after the Dependabot parent
- documentation expiry probe fails closed after 2026-10-05
- independent security review: GREEN