### PR TITLE
feat(graph): add in-memory snapshot factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **In-memory snapshot graph factory** — `SnapshotPage` and
+  `LogseqGraph.from_snapshot_pages()` build the existing parser graph indexes from
+  bounded, caller-captured Markdown without source discovery, file reopening, or
+  graph-root filesystem inspection.
+  The stable additive API preserves deterministic ordering, parser identities,
+  aliases, backlinks, diagnostics, and opt-in strict modes while keeping source
+  capture and cross-product projection outside Parser (#209).
+
 ### Security
 
 - **Time-bounded NLTK advisory exception** — document the exact optional AI

--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ graph = LogseqGraph.load_directory("/path/to/logseq/graph")
 page_obj = graph.get_page("My Page")  # case-insensitive
 effective = graph.get_effective_properties(page_obj.root_nodes[0].uuid)
 
+# Build the same in-memory indexes from caller-captured Markdown without filesystem access.
+from logseq_matryca_parser import SnapshotPage
+
+snapshot_graph = LogseqGraph.from_snapshot_pages(
+    "/path/to/logseq/graph",
+    [SnapshotPage("pages/Project.md", "- Captured block\n")],
+)
+
 # Export to LangChain with lineage metadata
 docs = SynapseAdapter.to_langchain_documents(page.root_nodes, source_name=page.title)
 

--- a/RELEASE_HIGHLIGHTS.md
+++ b/RELEASE_HIGHLIGHTS.md
@@ -5,6 +5,12 @@ For the exhaustive change history, see the [changelog](CHANGELOG.md). For
 published artifacts and attestations, see
 [GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
 
+## Unreleased
+
+| Area | Change |
+| :--- | :--- |
+| **Graph API** | `SnapshotPage` and `LogseqGraph.from_snapshot_pages()` build ordinary in-memory graph indexes from bounded caller-captured Markdown. The additive API never discovers, reopens, or inspects logical source paths or its graph-root label; source capture, revisions, and external DTO projection remain outside Parser. |
+
 ## v1.8.2
 
 Patch release — strengthens the hosted assurance boundary, clarifies

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -149,7 +149,7 @@ make check
 
 | Area | Responsibility |
 |------|----------------|
-| Bulk load | `load_directory`, `_enrich_pages_index` |
+| Bulk load | `load_directory`, `from_snapshot_pages`, `_enrich_pages_index` |
 | Incremental | `invalidate_and_reload_page`, watcher |
 | Coherence | Per-graph in-process coordinator shared by readers, writer splices, and watcher reloads |
 | Query | `GraphQuery`, `search_content`, backlinks |
@@ -170,6 +170,15 @@ candidate construction. Watcher debounce shutdown closes later routes, cancels
 pending timers, and waits for admitted routes to finish; callbacks stay FIFO,
 isolated, outside graph coordination, and use a separate bounded dispatcher
 close.
+
+`SnapshotPage` plus `LogseqGraph.from_snapshot_pages()` is the additive
+in-memory bulk-load boundary. It accepts caller-captured Markdown text and safe
+graph-relative logical paths, parses only through `StackMachineParser.parse()`, and
+then reuses the normal graph index builders. The factory neither discovers nor
+reopens or inspects source paths or the graph-root label; those synthetic paths are
+graph metadata only. Capture,
+filesystem authority, revisions, and cross-product DTO projection remain outside
+Parser.
 
 The private inventory and snapshot representations are implementation details,
 not stable public API.

--- a/docs/reference/API_STABILITY.md
+++ b/docs/reference/API_STABILITY.md
@@ -40,7 +40,7 @@ minor release unless a security issue makes that unsafe.
 |---|---|
 | Version | `__version__` |
 | Parser | `StackMachineParser`, `LogosParser`, `LogseqPage`, `LogseqNode`, `LogosNode`, `ASTVisitor` |
-| Graph | `LogseqGraph` |
+| Graph | `LogseqGraph`, `SnapshotPage` |
 | Diagnostics | `Diagnostic`, `DiagnosticCode`, `DiagnosticSeverity`, `collect_graph_diagnostics` |
 | Errors | `LogseqParserError`, `LogseqIndentationError`, `BlockReferenceError`, `PageTitleCollisionError`, `VaultWriteError` |
 | Writer preview | `WriteProposal` |
@@ -56,6 +56,19 @@ updating this table and those tests in the same PR.
 the loader normalizes a textual path with `Path(graph_path).expanduser().resolve()`.
 Both strict modes are opt-in, preserving the
 permissive default.
+
+`SnapshotPage(logical_path, text)` and
+`LogseqGraph.from_snapshot_pages(graph_path, snapshot_pages, *, strict_refs=False,
+strict_title_collisions=False)` are stable additive graph APIs. The factory accepts
+either a mapping of graph-relative POSIX Markdown paths to already-captured text or
+a sequence of `SnapshotPage` values. It normalizes and orders unique `pages/` and
+`journals/` paths deterministically, accepts at most 1,024 pages and 16 MiB of UTF-8
+text, parses with the existing in-memory parser, and reuses the ordinary graph index
+builders and strict modes. It never discovers or reopens logical source paths.
+Synthetic source paths on the resulting models are metadata for graph behavior, not
+filesystem-read authority; capture, source selection, hashing, and revisions remain
+the caller's responsibility. Its graph-root label is normalized lexically without
+expanding, resolving, or inspecting the caller path.
 
 Diagnostic code compatibility, serialization, and path-safety rules are defined
 in the [structured diagnostics contract](DIAGNOSTICS.md).

--- a/src/logseq_matryca_parser/__init__.py
+++ b/src/logseq_matryca_parser/__init__.py
@@ -22,7 +22,7 @@ from .forge import (
     MarkdownForgeVisitor,
     ObsidianForgeVisitor,
 )
-from .graph import LogseqGraph
+from .graph import LogseqGraph, SnapshotPage
 from .logos_core import ASTVisitor, LogosNode, LogseqNode, LogseqPage, SovereignNotePackage
 from .logos_parser import (
     LOGSEQ_PATTERNS,
@@ -87,6 +87,7 @@ __all__ = [
     "PageRegistry",
     "PageTitleCollisionError",
     "SessionAliasRegistry",
+    "SnapshotPage",
     "SovereignNotePackage",
     "StackMachineParser",
     "SynapseAdapter",

--- a/src/logseq_matryca_parser/graph.py
+++ b/src/logseq_matryca_parser/graph.py
@@ -7,11 +7,11 @@ import os
 import re
 import threading
 import uuid
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from queue import Queue
 from typing import Any, Self
 
@@ -27,11 +27,18 @@ from logseq_matryca_parser.exceptions import BlockReferenceError, PageTitleColli
 from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
 from logseq_matryca_parser.logos_parser import StackMachineParser
 from logseq_matryca_parser.logseq_markdown import _normalize_logseq_ref_token
-from logseq_matryca_parser.logseq_paths import discover_graph_files, is_excluded_graph_path
+from logseq_matryca_parser.logseq_paths import (
+    decode_page_title_segment,
+    discover_graph_files,
+    filename_to_page_title,
+    is_excluded_graph_path,
+)
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+_MAX_SNAPSHOT_PAGE_COUNT = 1_024
+_MAX_SNAPSHOT_TOTAL_BYTES = 16 * 1024 * 1024
 _WATCHER_DEBOUNCE_SECONDS = 0.5
 _WATCHER_IGNORE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\.swp$"),
@@ -253,8 +260,19 @@ def _append_backlink(registry: dict[str, list[str]], key: str, source_uuid: str)
     logger.debug("backlink index: %s <- source=%s", key, source_uuid)
 
 
-def iter_canonical_pages_from_dict(pages: dict[str, LogseqPage]) -> Iterator[LogseqPage]:
+def _resolved_source_path_key(source_path: str) -> str:
+    """Return the historical filesystem-resolved ordering key for source pages."""
+    return str(Path(source_path).resolve())
+
+
+def iter_canonical_pages_from_dict(
+    pages: dict[str, LogseqPage],
+    *,
+    source_path_key: Callable[[str], str] | None = None,
+) -> Iterator[LogseqPage]:
     """Yield each physical ``LogseqPage`` once in deterministic source-path order."""
+    if source_path_key is None:
+        source_path_key = _resolved_source_path_key
     seen_page_ids: set[int] = set()
     canonical_pages: list[LogseqPage] = []
     for page in pages.values():
@@ -264,14 +282,17 @@ def iter_canonical_pages_from_dict(pages: dict[str, LogseqPage]) -> Iterator[Log
         seen_page_ids.add(page_id)
         canonical_pages.append(page)
     canonical_pages.sort(
-        key=lambda page: str(Path(page.source_path).resolve())
-        if page.source_path
-        else page.title,
+        key=lambda page: source_path_key(page.source_path) if page.source_path else page.title,
     )
     yield from canonical_pages
 
 
-def _resolve_page_by_title(pages: dict[str, LogseqPage], title: str) -> LogseqPage | None:
+def _resolve_page_by_title(
+    pages: dict[str, LogseqPage],
+    title: str,
+    *,
+    source_path_key: Callable[[str], str] | None = None,
+) -> LogseqPage | None:
     """Resolve a page title with case-insensitive fallback (pre-``lower_title_map``)."""
     stripped = title.strip()
     if not stripped:
@@ -280,13 +301,18 @@ def _resolve_page_by_title(pages: dict[str, LogseqPage], title: str) -> LogseqPa
     if direct is not None:
         return direct
     lower = stripped.lower()
-    for page in iter_canonical_pages_from_dict(pages):
+    for page in iter_canonical_pages_from_dict(pages, source_path_key=source_path_key):
         if page.title.lower() == lower:
             return page
     return None
 
 
-def _wikilink_backlink_keys(pages: dict[str, LogseqPage], link: str) -> list[str]:
+def _wikilink_backlink_keys(
+    pages: dict[str, LogseqPage],
+    link: str,
+    *,
+    source_path_key: Callable[[str], str] | None = None,
+) -> list[str]:
     """Normalized backlink index keys for a wikilink (literal + canonical title + aliases)."""
     keys: list[str] = []
     seen: set[str] = set()
@@ -294,7 +320,7 @@ def _wikilink_backlink_keys(pages: dict[str, LogseqPage], link: str) -> list[str
     if primary:
         keys.append(primary)
         seen.add(primary)
-    page = _resolve_page_by_title(pages, link)
+    page = _resolve_page_by_title(pages, link, source_path_key=source_path_key)
     if page is not None:
         for candidate in (page.title, *_collect_page_alias_tokens(page.properties)):
             key = _normalize_backlink_key(candidate)
@@ -304,10 +330,15 @@ def _wikilink_backlink_keys(pages: dict[str, LogseqPage], link: str) -> list[str
     return keys
 
 
-def _node_backlink_keys(pages: dict[str, LogseqPage], node: LogseqNode) -> Iterator[str]:
+def _node_backlink_keys(
+    pages: dict[str, LogseqPage],
+    node: LogseqNode,
+    *,
+    source_path_key: Callable[[str], str] | None = None,
+) -> Iterator[str]:
     """Yield every backlink index key contributed by one source node."""
     for link in node.wikilinks:
-        yield from _wikilink_backlink_keys(pages, link)
+        yield from _wikilink_backlink_keys(pages, link, source_path_key=source_path_key)
     for tag in node.tags:
         key = _normalize_backlink_key(tag)
         if key:
@@ -318,10 +349,14 @@ def _node_backlink_keys(pages: dict[str, LogseqPage], node: LogseqNode) -> Itera
             yield key
 
 
-def _build_node_registry_from_pages(pages: dict[str, LogseqPage]) -> dict[str, LogseqNode]:
+def _build_node_registry_from_pages(
+    pages: dict[str, LogseqPage],
+    *,
+    source_path_key: Callable[[str], str] | None = None,
+) -> dict[str, LogseqNode]:
     """Build the global node registry from indexed pages only (no title-collision ghosts)."""
     registry: dict[str, LogseqNode] = {}
-    for page in iter_canonical_pages_from_dict(pages):
+    for page in iter_canonical_pages_from_dict(pages, source_path_key=source_path_key):
         for node in _flatten_nodes(page.root_nodes):
             registry[node.uuid] = node
     return registry
@@ -550,12 +585,16 @@ def _build_lower_title_map(pages: dict[str, LogseqPage]) -> dict[str, str]:
     return title_map
 
 
-def _build_backlink_registry(pages: dict[str, LogseqPage]) -> dict[str, list[str]]:
+def _build_backlink_registry(
+    pages: dict[str, LogseqPage],
+    *,
+    source_path_key: Callable[[str], str] | None = None,
+) -> dict[str, list[str]]:
     """Map normalized targets (page title lower or block UUID) to source node UUIDs."""
     registry: dict[str, list[str]] = {}
-    for page in iter_canonical_pages_from_dict(pages):
+    for page in iter_canonical_pages_from_dict(pages, source_path_key=source_path_key):
         for node in _flatten_nodes(page.root_nodes):
-            for key in _node_backlink_keys(pages, node):
+            for key in _node_backlink_keys(pages, node, source_path_key=source_path_key):
                 _append_backlink(registry, key, node.uuid)
     logger.debug("backlink registry built: %s distinct targets", len(registry))
     return registry
@@ -564,6 +603,89 @@ def _build_backlink_registry(pages: dict[str, LogseqPage]) -> dict[str, list[str
 def _parse_page_file_worker(path: Path) -> LogseqPage:
     """Parse a single markdown file in isolation (thread-safe)."""
     return StackMachineParser().parse_page_file(path)
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotPage:
+    """One pre-captured Markdown page supplied to :meth:`LogseqGraph.from_snapshot_pages`.
+
+    ``logical_path`` is a graph-relative POSIX path under ``pages/`` or ``journals/``.
+    ``text`` is the already-captured Markdown source; this value never grants filesystem-read
+    authority to the graph factory.
+    """
+
+    logical_path: str
+    text: str
+
+
+def _normalize_snapshot_logical_path(logical_path: str) -> PurePosixPath:
+    """Return one safe, normalized graph-relative POSIX Markdown path."""
+    if not isinstance(logical_path, str):
+        raise TypeError("snapshot logical path must be a string")
+    if not logical_path or "\\" in logical_path:
+        raise ValueError("snapshot logical path must be a non-empty POSIX path")
+    candidate = PurePosixPath(logical_path)
+    if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
+        raise ValueError("snapshot logical path escapes graph root")
+    parts = tuple(part for part in candidate.parts if part != ".")
+    if (
+        len(parts) < 2
+        or parts[0] not in {"pages", "journals"}
+        or PurePosixPath(*parts).suffix != ".md"
+        or is_excluded_graph_path(Path(*parts))
+    ):
+        raise ValueError("snapshot logical path is not tracked Markdown")
+    return PurePosixPath(*parts)
+
+
+def _derive_snapshot_page_title(logical_path: PurePosixPath) -> str:
+    """Derive a title with the normal path rules without resolving caller metadata."""
+    title_parts = logical_path.with_suffix("").parts[1:]
+    if len(title_parts) == 1:
+        return filename_to_page_title(title_parts[0])
+    return "/".join(decode_page_title_segment(part) for part in title_parts)
+
+
+def _normalize_snapshot_graph_path(graph_path: Path | str) -> Path:
+    """Return an absolute, normalized graph-root label without filesystem inspection."""
+    raw_path = os.fspath(graph_path)
+    if not isinstance(raw_path, str):
+        raise TypeError("snapshot graph path must be a string or Path")
+    return Path(os.path.abspath(raw_path))
+
+
+def _normalize_snapshot_pages(
+    snapshot_pages: Mapping[str, str] | Sequence[SnapshotPage],
+) -> tuple[tuple[PurePosixPath, str], ...]:
+    """Validate, bound, deduplicate, and canonically order caller-owned snapshots."""
+    if len(snapshot_pages) > _MAX_SNAPSHOT_PAGE_COUNT:
+        raise ValueError("snapshot page limit exceeded")
+    raw_pages: Iterator[SnapshotPage]
+    if isinstance(snapshot_pages, Mapping):
+        raw_pages = (
+            SnapshotPage(logical_path=logical_path, text=text)
+            for logical_path, text in snapshot_pages.items()
+        )
+    else:
+        raw_pages = iter(snapshot_pages)
+
+    normalized: dict[PurePosixPath, str] = {}
+    total_bytes = 0
+    for page_count, snapshot in enumerate(raw_pages, start=1):
+        if page_count > _MAX_SNAPSHOT_PAGE_COUNT:
+            raise ValueError("snapshot page limit exceeded")
+        if not isinstance(snapshot, SnapshotPage):
+            raise TypeError("snapshot pages must be SnapshotPage values")
+        if not isinstance(snapshot.text, str):
+            raise TypeError("snapshot text must be a string")
+        logical_path = _normalize_snapshot_logical_path(snapshot.logical_path)
+        if logical_path in normalized:
+            raise ValueError("duplicate snapshot logical path")
+        total_bytes += len(snapshot.text.encode("utf-8"))
+        if total_bytes > _MAX_SNAPSHOT_TOTAL_BYTES:
+            raise ValueError("snapshot aggregate byte limit exceeded")
+        normalized[logical_path] = snapshot.text
+    return tuple(sorted(normalized.items(), key=lambda item: item[0].as_posix()))
 
 
 @dataclass(frozen=True, slots=True)
@@ -832,12 +954,11 @@ class LogseqGraph(BaseModel):
 
         if not files:
             logger.debug("LogseqGraph.load_directory: no markdown files under %s", resolved)
-            return cls(
+            return cls._from_source_pages(
                 graph_path=resolved,
-                pages={},
                 source_pages=source_pages,
-                node_registry={},
-                backlink_registry={},
+                strict_refs=strict_refs,
+                strict_title_collisions=strict_title_collisions,
             )
 
         max_workers = min(_DEFAULT_MAX_WORKERS, len(files))
@@ -859,18 +980,71 @@ class LogseqGraph(BaseModel):
         source_pages = {
             str(path.resolve()): page for path, page in path_page_pairs
         }
-        pages, diagnostics = _build_pages_index_from_source_pages(source_pages, resolved)
-        node_registry = _build_node_registry_from_pages(pages)
-        backlink_registry = _build_backlink_registry(pages)
-        lower_title_map = _build_lower_title_map(pages)
-
-        logger.debug(
-            "LogseqGraph.load_directory: indexed %s pages, %s nodes",
-            len(pages),
-            len(node_registry),
-        )
-        graph = cls(
+        return cls._from_source_pages(
             graph_path=resolved,
+            source_pages=source_pages,
+            strict_refs=strict_refs,
+            strict_title_collisions=strict_title_collisions,
+        )
+
+    @classmethod
+    def from_snapshot_pages(
+        cls,
+        graph_path: Path | str,
+        snapshot_pages: Mapping[str, str] | Sequence[SnapshotPage],
+        *,
+        strict_refs: bool = False,
+        strict_title_collisions: bool = False,
+    ) -> LogseqGraph:
+        """Build a graph from bounded caller-captured Markdown without filesystem discovery or reads."""
+        resolved = _normalize_snapshot_graph_path(graph_path)
+        source_pages: dict[str, LogseqPage] = {}
+        for logical_path, text in _normalize_snapshot_pages(snapshot_pages):
+            source_path = resolved.joinpath(*logical_path.parts)
+            parser = StackMachineParser()
+            page = parser.parse(
+                text,
+                page_title=_derive_snapshot_page_title(logical_path),
+            )
+            source_pages[str(source_path)] = page.model_copy(
+                update={
+                    "source_path": str(source_path),
+                    "graph_root": str(resolved),
+                    "root_nodes": parser._apply_source_path(page.root_nodes, str(source_path)),
+                }
+            )
+        return cls._from_source_pages(
+            graph_path=resolved,
+            source_pages=source_pages,
+            strict_refs=strict_refs,
+            strict_title_collisions=strict_title_collisions,
+            source_paths_are_lexical=True,
+        )
+
+    @classmethod
+    def _from_source_pages(
+        cls,
+        *,
+        graph_path: Path,
+        source_pages: dict[str, LogseqPage],
+        strict_refs: bool,
+        strict_title_collisions: bool,
+        source_paths_are_lexical: bool = False,
+    ) -> LogseqGraph:
+        """Build and validate one complete graph index from already parsed physical pages."""
+        pages, diagnostics = _build_pages_index_from_source_pages(source_pages, graph_path)
+        source_path_key = str if source_paths_are_lexical else None
+        node_registry = _build_node_registry_from_pages(
+            pages,
+            source_path_key=source_path_key,
+        )
+        backlink_registry = _build_backlink_registry(
+            pages,
+            source_path_key=source_path_key,
+        )
+        lower_title_map = _build_lower_title_map(pages)
+        graph = cls(
+            graph_path=graph_path,
             pages=pages,
             source_pages=source_pages,
             node_registry=node_registry,

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -32,6 +32,7 @@ EXPECTED_ROOT_EXPORTS = {
     "PageRegistry",
     "PageTitleCollisionError",
     "SessionAliasRegistry",
+    "SnapshotPage",
     "SovereignNotePackage",
     "StackMachineParser",
     "SynapseAdapter",
@@ -94,3 +95,21 @@ def test_stable_graph_loader_signature() -> None:
     assert get_type_hints(package.LogseqGraph.load_directory).get("graph_path") == (
         Path | str
     )
+
+
+def test_stable_snapshot_graph_factory_signature() -> None:
+    signature = inspect.signature(package.LogseqGraph.from_snapshot_pages)
+
+    assert tuple(signature.parameters) == (
+        "graph_path",
+        "snapshot_pages",
+        "strict_refs",
+        "strict_title_collisions",
+    )
+    assert signature.parameters["strict_refs"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert signature.parameters["strict_refs"].default is False
+    assert (
+        signature.parameters["strict_title_collisions"].kind
+        is inspect.Parameter.KEYWORD_ONLY
+    )
+    assert signature.parameters["strict_title_collisions"].default is False

--- a/tests/test_snapshot_graph.py
+++ b/tests/test_snapshot_graph.py
@@ -1,0 +1,277 @@
+"""Public graph construction from already-captured Markdown snapshots."""
+
+from __future__ import annotations
+
+import builtins
+import os
+from collections.abc import Iterator, Mapping, Sequence
+from pathlib import Path
+from typing import Any, overload
+
+import pytest
+
+import logseq_matryca_parser.graph as graph_module
+from logseq_matryca_parser import (
+    BlockReferenceError,
+    LogseqGraph,
+    PageTitleCollisionError,
+    SnapshotPage,
+)
+
+
+class _OversizedSnapshotMapping(Mapping[str, str]):
+    """Fail if the factory touches entries after seeing an over-limit cardinality."""
+
+    def __getitem__(self, _key: str) -> str:
+        raise AssertionError("oversized mapping entries must not be read")
+
+    def __iter__(self) -> Iterator[str]:
+        raise AssertionError("oversized mapping must not be iterated")
+
+    def __len__(self) -> int:
+        return graph_module._MAX_SNAPSHOT_PAGE_COUNT + 1
+
+
+class _UnderreportedSnapshotSequence(Sequence[SnapshotPage]):
+    """Exercise the iteration-time bound when an untrusted sequence lies about length."""
+
+    @overload
+    def __getitem__(self, index: int) -> SnapshotPage: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[SnapshotPage]: ...
+
+    def __getitem__(self, index: int | slice) -> SnapshotPage | Sequence[SnapshotPage]:
+        snapshots = (
+            SnapshotPage(logical_path="pages/Alpha.md", text="- alpha\n"),
+            SnapshotPage(logical_path="pages/Beta.md", text="- beta\n"),
+        )
+        return snapshots[index]
+
+    def __len__(self) -> int:
+        return 0
+
+
+def test_from_snapshot_pages_mapping_and_sequence_match_disk_graph(tmp_path: Path) -> None:
+    """Snapshot construction reuses Parser graph semantics without source reopening."""
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    block_uuid = "64c752b0-d33b-4448-a261-e4dc2bbe12d3"
+    alpha = f"- Anchor\n  id:: {block_uuid}\n"
+    beta = f"alias:: Bee\n\n- Links [[Alpha]] and (({block_uuid}))\n"
+    (pages / "Alpha.md").write_text(alpha, encoding="utf-8")
+    (pages / "Beta.md").write_text(beta, encoding="utf-8")
+
+    disk_graph = LogseqGraph.load_directory(graph_root, strict_refs=True)
+    snapshot_graph = LogseqGraph.from_snapshot_pages(
+        graph_root,
+        [
+            SnapshotPage(logical_path="pages/Beta.md", text=beta),
+            SnapshotPage(logical_path="pages/Alpha.md", text=alpha),
+        ],
+        strict_refs=True,
+    )
+    mapping_graph = LogseqGraph.from_snapshot_pages(
+        graph_root,
+        {"pages/Alpha.md": alpha, "pages/Beta.md": beta},
+        strict_refs=True,
+    )
+
+    assert set(snapshot_graph.pages) == set(disk_graph.pages) == set(mapping_graph.pages)
+    for title in disk_graph.pages:
+        disk_page = disk_graph.pages[title]
+        snapshot_page = snapshot_graph.pages[title]
+        mapping_page = mapping_graph.pages[title]
+        assert snapshot_page.title == disk_page.title == mapping_page.title
+        assert snapshot_page.root_nodes == disk_page.root_nodes == mapping_page.root_nodes
+        assert snapshot_page.refs == disk_page.refs == mapping_page.refs
+        assert snapshot_page.properties == disk_page.properties == mapping_page.properties
+    assert [page.title for page in snapshot_graph.iter_canonical_pages()] == [
+        page.title for page in disk_graph.iter_canonical_pages()
+    ]
+    assert snapshot_graph.get_backlinks("Alpha") == disk_graph.get_backlinks("Alpha")
+    assert snapshot_graph.get_backlinks(block_uuid) == disk_graph.get_backlinks(block_uuid)
+
+
+def test_from_snapshot_pages_never_discovers_or_reopens_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Logical source paths are metadata, never filesystem-read authority."""
+    graph_root = tmp_path / "unopened-vault"
+
+    def reject_filesystem_access(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("snapshot factory must not access the filesystem")
+
+    monkeypatch.setattr(graph_module, "discover_graph_files", reject_filesystem_access)
+    monkeypatch.setattr(
+        graph_module.StackMachineParser,
+        "parse_page_file",
+        reject_filesystem_access,
+    )
+
+    graph = LogseqGraph.from_snapshot_pages(
+        graph_root,
+        [SnapshotPage(logical_path="pages/Alpha.md", text="- Snapshot only\n")],
+    )
+
+    assert graph.graph_path == graph_root.resolve()
+    assert graph.pages["Alpha"].source_path == str((graph_root / "pages" / "Alpha.md").resolve())
+    assert graph.pages["Alpha"].root_nodes[0].content == "Snapshot only"
+
+
+def test_from_snapshot_pages_uses_lexical_graph_path_without_filesystem_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Snapshot graph roots normalize lexically without resolve, stat, or open calls."""
+    graph_root = Path("snapshot-root/../vault")
+    normalized_root = Path(os.path.abspath(graph_root))
+    original_resolve: Any = graph_module.Path.resolve
+    original_stat: Any = graph_module.Path.stat
+    original_open: Any = graph_module.Path.open
+    original_builtin_open: Any = builtins.open
+
+    def is_snapshot_path(path: Path) -> bool:
+        return (
+            path in (graph_root, normalized_root)
+            or graph_root in path.parents
+            or normalized_root in path.parents
+        )
+
+    def guarded_resolve(path: Path, *args: Any, **kwargs: Any) -> Any:
+        if is_snapshot_path(path):
+            raise AssertionError("snapshot graph path must not resolve")
+        return original_resolve(path, *args, **kwargs)
+
+    def guarded_stat(path: Path, *args: Any, **kwargs: Any) -> Any:
+        if is_snapshot_path(path):
+            raise AssertionError("snapshot graph path must not stat")
+        return original_stat(path, *args, **kwargs)
+
+    def guarded_path_open(path: Path, *args: Any, **kwargs: Any) -> Any:
+        if is_snapshot_path(path):
+            raise AssertionError("snapshot graph path must not open")
+        return original_open(path, *args, **kwargs)
+
+    def guarded_builtin_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(file, (str, os.PathLike)) and is_snapshot_path(Path(file)):
+            raise AssertionError("snapshot graph path must not open")
+        return original_builtin_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(graph_module.Path, "resolve", guarded_resolve)
+    monkeypatch.setattr(graph_module.Path, "stat", guarded_stat)
+    monkeypatch.setattr(graph_module.Path, "open", guarded_path_open)
+    monkeypatch.setattr(builtins, "open", guarded_builtin_open)
+
+    graph = LogseqGraph.from_snapshot_pages(
+        graph_root,
+        {
+            "pages/Alpha.md": "- Snapshot only\n",
+            "pages/Beta.md": "- [[alpha]]\n",
+        },
+    )
+
+    assert graph.graph_path == normalized_root
+    assert graph.pages["Alpha"].source_path == str(normalized_root / "pages" / "Alpha.md")
+    assert [node.content for node in graph.get_backlinks("Alpha")] == ["[[alpha]]"]
+
+
+def test_from_snapshot_pages_does_not_follow_existing_logical_symlinks(tmp_path: Path) -> None:
+    """A logical path stays metadata even when a same-named source symlink exists."""
+    graph_root = tmp_path / "vault"
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    outside = tmp_path / "Outside.md"
+    outside.write_text("- outside\n", encoding="utf-8")
+    logical_source = pages / "Alpha.md"
+    try:
+        logical_source.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlink creation unavailable on this platform")
+
+    graph = LogseqGraph.from_snapshot_pages(
+        graph_root,
+        {"pages/Alpha.md": "- Snapshot only\n"},
+    )
+
+    assert graph.pages["Alpha"].source_path == str(logical_source)
+    assert graph.pages["Alpha"].root_nodes[0].content == "Snapshot only"
+
+
+@pytest.mark.parametrize(
+    "snapshots",
+    [
+        [SnapshotPage(logical_path="../outside.md", text="- unsafe\n")],
+        [SnapshotPage(logical_path="pages/Alpha.txt", text="- malformed\n")],
+        [
+            SnapshotPage(logical_path="pages/Alpha.md", text="- first\n"),
+            SnapshotPage(logical_path="pages/./Alpha.md", text="- second\n"),
+        ],
+    ],
+)
+def test_from_snapshot_pages_rejects_unsafe_or_duplicate_logical_paths(
+    tmp_path: Path, snapshots: list[SnapshotPage]
+) -> None:
+    """Only unique POSIX Markdown paths under pages or journals are admissible."""
+    with pytest.raises(ValueError):
+        LogseqGraph.from_snapshot_pages(tmp_path / "vault", snapshots)
+
+
+def test_from_snapshot_pages_enforces_page_and_aggregate_byte_bounds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bounded callers cannot force unbounded page or text aggregation."""
+    monkeypatch.setattr(graph_module, "_MAX_SNAPSHOT_PAGE_COUNT", 1)
+    with pytest.raises(ValueError, match="page limit"):
+        LogseqGraph.from_snapshot_pages(
+            tmp_path / "vault",
+            {
+                "pages/Alpha.md": "- alpha\n",
+                "pages/Beta.md": "- beta\n",
+            },
+        )
+
+    monkeypatch.setattr(graph_module, "_MAX_SNAPSHOT_TOTAL_BYTES", 4)
+    with pytest.raises(ValueError, match="byte limit"):
+        LogseqGraph.from_snapshot_pages(
+            tmp_path / "vault",
+            {"pages/Alpha.md": "- alpha\n"},
+        )
+
+
+def test_from_snapshot_pages_rejects_oversized_mapping_before_iteration(tmp_path: Path) -> None:
+    """The page ceiling applies before any caller-controlled mapping is materialized."""
+    with pytest.raises(ValueError, match="page limit"):
+        LogseqGraph.from_snapshot_pages(tmp_path / "vault", _OversizedSnapshotMapping())
+
+
+def test_from_snapshot_pages_enforces_bound_while_iterating_untrusted_sequence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A false sequence length cannot bypass the page ceiling during normalization."""
+    monkeypatch.setattr(graph_module, "_MAX_SNAPSHOT_PAGE_COUNT", 1)
+
+    with pytest.raises(ValueError, match="page limit"):
+        LogseqGraph.from_snapshot_pages(tmp_path / "vault", _UnderreportedSnapshotSequence())
+
+
+def test_from_snapshot_pages_preserves_strict_reference_and_collision_modes(tmp_path: Path) -> None:
+    """Snapshot graphs use the same strict validation and diagnostics builders as disk loads."""
+    graph_root = tmp_path / "vault"
+
+    with pytest.raises(BlockReferenceError):
+        LogseqGraph.from_snapshot_pages(
+            graph_root,
+            {"pages/Broken.md": "- missing ((00000000-0000-0000-0000-000000000099))\n"},
+            strict_refs=True,
+        )
+
+    with pytest.raises(PageTitleCollisionError):
+        LogseqGraph.from_snapshot_pages(
+            graph_root,
+            {
+                "pages/A.md": "title:: Shared\n\n- first\n",
+                "pages/B.md": "title:: Shared\n\n- second\n",
+            },
+            strict_title_collisions=True,
+        )

--- a/tests/typing_samples/public_api.py
+++ b/tests/typing_samples/public_api.py
@@ -2,14 +2,20 @@
 
 from pathlib import Path
 
-from logseq_matryca_parser import LogseqGraph, LogseqPage, StackMachineParser
+from logseq_matryca_parser import LogseqGraph, LogseqPage, SnapshotPage, StackMachineParser
 
 parser: StackMachineParser = StackMachineParser()
 page: LogseqPage = parser.parse("- typed block", page_title="Typed")
 graph_path: Path = Path("/tmp/example")
 graph: LogseqGraph = LogseqGraph.load_directory(graph_path, strict_refs=False)
 graph_from_string: LogseqGraph = LogseqGraph.load_directory(str(graph_path), strict_refs=False)
+graph_from_snapshot: LogseqGraph = LogseqGraph.from_snapshot_pages(
+    graph_path,
+    [SnapshotPage(logical_path="pages/Typed.md", text="- typed block\n")],
+    strict_refs=False,
+)
 
 assert page.title == "Typed"
 assert isinstance(graph, LogseqGraph)
 assert isinstance(graph_from_string, LogseqGraph)
+assert isinstance(graph_from_snapshot, LogseqGraph)


### PR DESCRIPTION
## Summary

- add stable `SnapshotPage` and `LogseqGraph.from_snapshot_pages` APIs
- build existing graph indexes from bounded in-memory Markdown snapshots
- preserve parsing, UUID, hierarchy, references, aliases and strict-mode semantics
- guarantee no filesystem discovery or reopen in the snapshot factory

## Verification

- focused exact-head tests: 16 passed
- full `make all`
- independent review: GREEN
- remote tree matches locally reviewed tree

This enables Plumber to own coherent capture and project Parser models into `plumber.*` DTOs. It does not add Plumber, Trama, UI, DB or transport behavior.

Closes #209