### PR TITLE
chore(release): prepare v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-09-06
+
 ### Added
 
 - **In-memory snapshot graph factory** — `SnapshotPage` and
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   owner, upstream advisory, and 2026-10-05 expiry for `PYSEC-2026-3740` while
   no patched NLTK registry release exists. CI and release audits ignore only
   that advisory; all other dependency findings remain fail-closed.
+
 ### Changed
 
 - **Parser-Plumber boundary** — record Parser as the deterministic Logseq OG

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Read the complete [release highlights](RELEASE_HIGHLIGHTS.md), the exhaustive
 [changelog](CHANGELOG.md), or the signed artifacts on
 [GitHub Releases](https://github.com/MarcoPorcellato/logseq-matryca-parser/releases).
 
+- **v1.9.0** — Adds the stable in-memory snapshot graph factory, clarifies the Parser-Plumber boundary, and governs the temporary optional-NLTK advisory exception.
 - **v1.8.2** — Adds SHA-pinned hosted assurance, portable Windows local assurance, corrected cookbook recipes, consistent optional-AI guidance, and `Path | str` graph loading.
 - **v1.8.1** — Hardened deep-outline parsing, coherent incremental graph mutations, bounded assurance cleanup, and stable provenance for optional NLTK.
 - **v1.8.0** — Added bounded privacy-safe local graph assurance, source-location contracts, and the first internal parser line-classification phase.

--- a/RELEASE_HIGHLIGHTS.md
+++ b/RELEASE_HIGHLIGHTS.md
@@ -7,9 +7,17 @@ published artifacts and attestations, see
 
 ## Unreleased
 
+## v1.9.0
+
+Minor release — adds a stable in-memory graph factory and clarifies the
+cross-product integration boundary. **No intentional breaking changes** to
+stable package imports or CLI behavior.
+
 | Area | Change |
 | :--- | :--- |
 | **Graph API** | `SnapshotPage` and `LogseqGraph.from_snapshot_pages()` build ordinary in-memory graph indexes from bounded caller-captured Markdown. The additive API never discovers, reopens, or inspects logical source paths or its graph-root label; source capture, revisions, and external DTO projection remain outside Parser. |
+| **Architecture** | Parser remains the deterministic Logseq OG library. Plumber is the sole cross-product gateway to Trama and Brain; existing Parser APIs and LENS behavior remain compatible. |
+| **Dependency security** | A time-bounded, evidence-backed exception governs `PYSEC-2026-3740` for optional AI dependency NLTK until a patched registry release exists; all other dependency findings remain fail-closed. |
 
 ## v1.8.2
 

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -19,7 +19,7 @@ superseded_by: null
 
 # Clean Code & Clean Architecture — Logseq Matryca Parser
 
-**Version:** documents **v1.8.2** maintainer contracts (v1 structural backlog complete; parser, graph-coherence, and local-assurance slices merged)
+**Version:** documents **v1.9.0** maintainer contracts (v1 structural backlog complete; parser, graph-coherence, local-assurance, and stable snapshot-graph slices merged)
 **Audience:** contributors and Cursor agents patching `src/logseq_matryca_parser/`  
 **Companion:** [`ARCHITECTURE.md`](ARCHITECTURE.md) (LOGOS domain contract) · [`BUG_HUNT_REPORT.md`](BUG_HUNT_REPORT.md) (audit evidence) · [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 

--- a/src/logseq_matryca_parser/_version.py
+++ b/src/logseq_matryca_parser/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the distribution version."""
 
-__version__ = "1.8.2"
+__version__ = "1.9.0"

--- a/tests/test_check_wheel_contract.py
+++ b/tests/test_check_wheel_contract.py
@@ -32,7 +32,7 @@ def _wheel(
 
 
 def test_source_version_reads_lightweight_version_module() -> None:
-    assert source_version() == "1.8.2"
+    assert source_version() == "1.9.0"
 
 
 def test_valid_wheel_contract(tmp_path: Path) -> None:


### PR DESCRIPTION
Prepare the exact v1.9.0 source candidate for the stable in-memory snapshot graph API. Release-state documents continue to identify v1.8.2 as latest published until tag/PyPI verification.

Verified: release contract, focused tests, docs gate, full `make all`, independent GREEN review. No tag or publication.

Closes #211