### PR TITLE
docs(lens): freeze transitional visualization scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **LENS Stage 0 transition** — mark the compatible `GraphVisualizer`,
+  `visualize`, and `demo` surfaces as transitional and feature-frozen, with
+  Matryca Trama as future user-facing graph-intelligence destination. This
+  release makes no API removal or deprecation-warning change (#213).
+
 ## [1.9.0] - 2026-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ selected by the caller.
 - **Parse and query:** load one page or a complete vault as a typed AST and graph.
 - **Build RAG context:** export LangChain documents, LlamaIndex nodes, or enriched chunks.
 - **Move knowledge:** generate JSON, clean Markdown, or an Obsidian vault.
-- **Visualize:** render an interactive graph with LENS.
+- **Visualize:** render an interactive reference-topology graph with the transitional,
+  feature-frozen LENS adapter.
 - **Use an AI agent:** start from [`AGENTS.md`](AGENTS.md) or the concise [`llms.txt`](llms.txt) index.
 
 ---
@@ -150,6 +151,10 @@ and [API stability reference](docs/reference/API_STABILITY.md) for exact boundar
 For cross-product Logseq OG use, Plumber is the gateway to Trama and Brain;
 Parser remains the deterministic parsing stage. LENS stays compatible while a
 future Trama graph-intelligence migration is separately designed and released.
+Stage 0 marks LENS as transitional and feature-frozen: `GraphVisualizer`,
+`matryca-parse visualize`, and `matryca-parse demo` remain available without a
+deprecation warning. Matryca Trama is the destination for future user-facing
+graph intelligence.
 
 ### Data model — `LogseqNode` task fields
 
@@ -181,7 +186,7 @@ uv sync --all-extras
 ```
 
 ```bash
-# 1. Visualize your local graph (LENS)
+# 1. Visualize your local graph (LENS: transitional, feature-frozen)
 matryca-parse visualize /path/to/logseq/graph my-map.html
 
 # 2. Export for AI / RAG (SYNAPSE)

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -194,9 +194,11 @@ not stable public API.
 
 **Rule:** no new parsing logic in KINETIC modules — call `LogseqGraph.load_directory` or `StackMachineParser`.
 
-LENS remains a compatible optional Parser adapter. A later, separately accepted
-Trama migration owns user-facing graph-intelligence UI; no LENS warning,
-removal, command, or API change is authorized by this boundary decision.
+LENS remains a compatible optional Parser adapter. Stage 0 marks it
+transitional and feature-frozen while preserving its commands and API without a
+deprecation warning. A later, separately accepted Matryca Trama migration owns
+user-facing graph-intelligence UI; removal or behavior change requires its own
+compatibility decision.
 
 ### `synapse.py` + `synapse_embed.py` — SYNAPSE adapters
 

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -204,10 +204,12 @@ visualizer.export_html(output)
 
 `export_html()` writes the HTML file but does not open it automatically.
 
-LENS remains compatible for this reference-topology workflow. A future Trama
-migration may replace it for user-facing graph intelligence, but this recipe,
-command, and API remain unchanged until separately announced with compatibility
-guidance.
+LENS is transitional and feature-frozen for this reference-topology workflow.
+`GraphVisualizer`, this recipe, `matryca-parse visualize`, and
+`matryca-parse demo` remain compatible and emit no deprecation warning in Stage
+0. Matryca Trama is the destination for future user-facing graph intelligence;
+a separately reviewed migration must provide compatibility guidance before any
+behavior change.
 
 ---
 

--- a/docs/reference/API_STABILITY.md
+++ b/docs/reference/API_STABILITY.md
@@ -91,11 +91,11 @@ The following integrations remain public but experimental:
 Everything not exported from `logseq_matryca_parser.__all__` is internal unless
 another maintained contract explicitly promotes it.
 
-`GraphVisualizer` remains experimental and compatible in this release line. A
-future migration of user-facing graph intelligence to Trama may introduce a
-compatible deprecation only through a separately reviewed decision, release
-notes, and migration guidance. No deprecation warning or API change is made by
-the Parser-Plumber boundary decision.
+`GraphVisualizer` remains experimental, compatible, transitional, and
+feature-frozen in this release line. Stage 0 changes no API and emits no
+deprecation warning. Future user-facing graph intelligence belongs in Matryca
+Trama; a compatible deprecation may begin only through a separately reviewed
+decision, release notes, and migration guidance.
 
 ## Version source
 

--- a/src/logseq_matryca_parser/kinetic_commands.py
+++ b/src/logseq_matryca_parser/kinetic_commands.py
@@ -236,7 +236,7 @@ def visualize(
     ),
     output_html: Path = typer.Argument(..., help="Output HTML path for network visualization."),
 ) -> None:
-    """Parse a graph, compute deep topology stats, and export an interactive HTML network."""
+    """LENS transitional, feature-frozen command; compatible reference topology for Matryca Trama migration."""
     resolved = _resolve_graph_path(ctx, graph_path)
 
     from logseq_matryca_parser.graph import LogseqGraph
@@ -278,7 +278,7 @@ def demo(
         help="Path for the standalone showcase HTML (default: showcase.html in cwd).",
     ),
 ) -> None:
-    """Build a sample graph from the official Logseq demo topology and write showcase HTML (no graph files read)."""
+    """LENS transitional, feature-frozen demo; compatible reference topology for Matryca Trama migration."""
     _ = ctx
     pages = _build_official_logseq_demo_pages()
     try:

--- a/tests/test_kinetic.py
+++ b/tests/test_kinetic.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -74,6 +76,38 @@ def test_per_command_help_renders_without_error(command: str) -> None:
     result = runner.invoke(app, [command, "--help"])
     assert result.exit_code == 0
     assert result.output.strip()
+
+
+@pytest.mark.parametrize("command", ["visualize", "demo"])
+def test_lens_command_help_marks_stage_zero_transition(command: str) -> None:
+    """LENS Stage 0 keeps commands while making their product boundary explicit."""
+    result = runner.invoke(app, [command, "--help"])
+
+    assert result.exit_code == 0
+    assert "transitional" in result.output.lower()
+    assert "feature-frozen" in result.output.lower()
+    assert "Matryca Trama" in result.output
+
+
+def test_package_import_is_silent_without_deprecation_warning(tmp_path: Path) -> None:
+    """Stage 0 adds no import-time output or deprecation warning."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::DeprecationWarning",
+            "-c",
+            "import logseq_matryca_parser",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
 
 
 def test_verbose_flag_enables_debug_logging(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
Stage 0 of #213: mark LENS transitional and feature-frozen while preserving `GraphVisualizer`, `[viz]`, `visualize`, `demo`, ordinary imports and runtime behavior. New graph UI/intelligence belongs to Trama after Plumber qualification.

Verified: focused 44 pass, full `make all`, independent GREEN review. No warning, removal, code transplant or copyright claim.

Refs #213