### PR TITLE
chore: finalize v1.9.0 documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **LENS Stage 0 transition** — mark the compatible `GraphVisualizer`,
-  `visualize`, and `demo` surfaces as transitional and feature-frozen, with
-  Matryca Trama as future user-facing graph-intelligence destination. This
-  release makes no API removal or deprecation-warning change (#213).
-
 ## [1.9.0] - 2026-09-06
 
 ### Added
@@ -36,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **LENS Stage 0 transition** — mark the compatible `GraphVisualizer`,
+  `visualize`, and `demo` surfaces as transitional and feature-frozen, with
+  Matryca Trama as future user-facing graph-intelligence destination. This
+  release makes no API removal or deprecation-warning change (#213).
 - **Parser-Plumber boundary** — record Parser as the deterministic Logseq OG
   parsing library and Plumber as the sole cross-product Logseq gateway to
   Trama and Brain. Existing Parser APIs and LENS behavior remain compatible;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ User-facing behavior is documented in:
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — LOGOS, SYNAPSE, `LogseqGraph`, agents, and data flow
 - [`docs/internal/LOCAL_CODE_STUDY.md`](docs/internal/LOCAL_CODE_STUDY.md) — maintainer local code audit runbook (not for public issues/CHANGELOG)
 - [`docs/logseq_ast_primer.md`](docs/logseq_ast_primer.md) — Logseq Spatial Markdown domain rules
-- [`CHANGELOG.md`](CHANGELOG.md) — latest release **1.8.2** and **Unreleased** changes (Keep a Changelog)
+- [`CHANGELOG.md`](CHANGELOG.md) — latest release **1.9.0** and **Unreleased** changes (Keep a Changelog)
 - [`docs/RELEASE_PROCESS.md`](docs/RELEASE_PROCESS.md) — version bump, tag, and PyPI publish checklist
 - [`docs/CI_ASSURANCE.md`](docs/CI_ASSURANCE.md) — pull-request, scheduled, settings-managed, and release checks
 - [`docs/CODEQL.md`](docs/CODEQL.md) — CodeQL default setup (no custom `codeql.yml`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## Supported Versions
 
-Security fixes are provided **only for the latest released version** on [PyPI](https://pypi.org/project/logseq-matryca-parser/). The latest supported release is v1.8.2.
+Security fixes are provided **only for the latest released version** on [PyPI](https://pypi.org/project/logseq-matryca-parser/). The latest supported release is v1.9.0.
 
 | Version | Supported |
 | ------- | --------- |
-| **1.8.2** (latest released) | Yes |
-| 1.8.1 and older | No |
+| **1.9.0** (latest released) | Yes |
+| 1.8.2 and older | No |
 
 We recommend always running the current release and upgrading promptly when a security advisory is published.
 


### PR DESCRIPTION
## Summary

- move LENS Stage 0 from Unreleased into the v1.9.0 changelog section
- update official supported/current-version references to v1.9.0
- leave Unreleased empty as required by the release contract

## Verification

- release-contract RED before correction: non-empty Unreleased
- `make all`: PASS (810 tests plus lint, typing, docs)
- vendor-name check: PASS
- `check_release_contract.py --tag v1.9.0`: PASS
- extracted v1.9.0 notes reviewed
- commit signature valid; signed tree exactly matches reviewed local tree (`b2657d97689ecb8cf3e68b047e3b67d1a7141bb4`)

Release publication remains gated on this PR merging and exact-main verification.