### PR TITLE
test(packaging): cover wheel CLI failures

### DIFF
--- a/tests/test_check_wheel_contract.py
+++ b/tests/test_check_wheel_contract.py
@@ -5,7 +5,7 @@ import io
 import zipfile
 from pathlib import Path
 
-from scripts.check_wheel_contract import MARKER, check_wheel, source_version
+from scripts.check_wheel_contract import MARKER, check_wheel, main, source_version
 
 
 def _wheel(
@@ -56,3 +56,29 @@ def test_wheel_contract_reports_version_mismatch(tmp_path: Path) -> None:
     assert check_wheel(wheel, "1.7.0") == [
         "wheel version '1.5.0' does not match source version '1.7.0'"
     ]
+
+
+def test_main_accepts_valid_wheel(tmp_path: Path, capsys) -> None:
+    wheel = _wheel(tmp_path / "package.whl", version=source_version())
+
+    assert main([str(wheel)]) == 0
+    assert capsys.readouterr().out == (
+        f"wheel-contract: OK ({wheel.name}, version {source_version()})\n"
+    )
+
+
+def test_main_reports_missing_wheel_without_raising(tmp_path: Path, capsys) -> None:
+    missing_wheel = tmp_path / "missing.whl"
+
+    assert main([str(missing_wheel)]) == 2
+    diagnostic = capsys.readouterr().out
+    assert diagnostic.startswith("wheel-contract: ")
+    assert str(missing_wheel) in diagnostic
+
+
+def test_main_reports_malformed_wheel_without_raising(tmp_path: Path, capsys) -> None:
+    malformed_wheel = tmp_path / "malformed.whl"
+    malformed_wheel.write_text("not a wheel archive", encoding="utf-8")
+
+    assert main([str(malformed_wheel)]) == 2
+    assert capsys.readouterr().out == "wheel-contract: File is not a zip file\n"


### PR DESCRIPTION
Fixes #152.

Adds direct `main()` coverage for valid wheels, missing paths, and malformed archives. The failure cases assert exit code 2 and stable `wheel-contract:` diagnostics without exceptions escaping.

Validation:
- `uv run pytest tests/test_check_wheel_contract.py -q`
- `make all` (813 tests, 91.20% coverage)
- `make vendor-name-check`

AI assistance was used to draft the tests; I reviewed the complete diff and verified it with the repository's deterministic checks.
