### PR TITLE
test: add CLI failure path tests for check_wheel_contract (#152)

### DIFF
--- a/tests/test_check_wheel_contract.py
+++ b/tests/test_check_wheel_contract.py
@@ -5,7 +5,9 @@ import io
 import zipfile
 from pathlib import Path
 
-from scripts.check_wheel_contract import MARKER, check_wheel, source_version
+import pytest
+
+from scripts.check_wheel_contract import MARKER, check_wheel, main, source_version
 
 
 def _wheel(
@@ -56,3 +58,35 @@ def test_wheel_contract_reports_version_mismatch(tmp_path: Path) -> None:
     assert check_wheel(wheel, "1.7.0") == [
         "wheel version '1.5.0' does not match source version '1.7.0'"
     ]
+
+
+def test_cli_reports_missing_wheel_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = tmp_path / "absent.whl"
+
+    code = main([str(missing)])
+
+    assert code == 2
+    assert capsys.readouterr().out.startswith("wheel-contract:")
+
+
+def test_cli_reports_malformed_archive_without_raising(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    not_a_wheel = tmp_path / "package.whl"
+    not_a_wheel.write_text("this is not a zip archive", encoding="utf-8")
+
+    code = main([str(not_a_wheel)])
+
+    assert code == 2
+    assert capsys.readouterr().out.startswith("wheel-contract:")
+
+
+def test_cli_accepts_valid_wheel(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    wheel = _wheel(tmp_path / "package.whl", version=source_version())
+
+    code = main([str(wheel)])
+
+    assert code == 0
+    assert "wheel-contract: OK" in capsys.readouterr().out


### PR DESCRIPTION
## Description
Fixes #152

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🛡️ Sovereign Developer Checklist
- [x] I picked task #152 from the good first issues list
- [x] I have added tests for my changes
- [ ] I have executed `make all` locally (uv/make not available in my environment; ran `python -m pytest tests/test_check_wheel_contract.py -q` directly → 7 passed)
- [ ] I updated CHANGELOG.md (test-only change, no user-visible behavior change)

## 🤖 AI assistance and data handling
- [x] I used AI assistance (Claude Code) to help write the tests; I reviewed the complete diff and take responsibility for the submitted work
- [x] I did not upload private vault data, credentials, tokens, or unpublished security details
- [x] I reviewed the complete diff

## 🧭 Contract impact
- [x] This PR does not affect any documented contract — test-only change, no production code touched

## Screenshots / CLI Output
python -m pytest tests/test_check_wheel_contract.py -q
7 passed (4 pre-existing + 3 new)

3 new tests added:
- test_cli_reports_missing_wheel_path
- test_cli_reports_malformed_archive_without_raising  
- test_cli_accepts_valid_wheel